### PR TITLE
feat(migrate): report progress while a migration run is happening

### DIFF
--- a/crates/rustango/src/migrate/mod.rs
+++ b/crates/rustango/src/migrate/mod.rs
@@ -34,6 +34,9 @@ pub mod make;
 // queries PG-specific `information_schema` and stays
 // `#[cfg(feature = "postgres")]`-gated inside `manage::run_with_writer`.
 pub mod manage;
+/// Watching a migration run while it happens — the observer the
+/// progress-reporting entry points take.
+pub mod progress;
 mod runner;
 pub mod scaffold;
 pub mod snapshot;
@@ -52,9 +55,12 @@ pub use make::{
 };
 #[cfg(feature = "postgres")]
 pub use manage::{append_data_op, make_data_migration};
+pub use progress::{MigrationEvent, MigrationObserver, Outcome};
 pub use runner::ensure_ledger_pool_with_ledger;
 pub use runner::migrate_pool_with_ledger;
 pub use runner::migrate_pool_with_ledger_fake_initial;
+pub use runner::migrate_pool_with_ledger_fake_initial_with_progress;
+pub use runner::migrate_pool_with_progress;
 // Always-on: tri-dialect entry points (work on PG / MySQL / SQLite via
 // the `Pool` enum), plus the inventory + builder surface.
 pub use runner::{
@@ -67,6 +73,6 @@ pub use runner::{
 #[cfg(feature = "postgres")]
 pub use runner::{
     applied_set, apply_all, downgrade, drop_all, ensure_ledger, migrate, migrate_dry_run,
-    migrate_embedded, migrate_to, unapply, unapply_force,
+    migrate_embedded, migrate_to, migrate_with_progress, unapply, unapply_force,
 };
 pub use snapshot::{FieldSnapshot, IndexSnapshot, RelationSnapshot, SchemaSnapshot, TableSnapshot};

--- a/crates/rustango/src/migrate/progress.rs
+++ b/crates/rustango/src/migrate/progress.rs
@@ -1,0 +1,160 @@
+//! Watching a migration run while it happens.
+//!
+//! The runner used to be silent: it took the migrate lock, applied every
+//! pending file, and returned a `Vec<Migration>` when it was done. On a
+//! fresh tenant that is twenty-plus migrations of nothing, and a failure
+//! reported only which *tenant* died, never which migration or how many
+//! had already landed.
+//!
+//! An observer fixes that without changing what the runner does. Pass one
+//! to [`migrate_pool_with_progress`](super::migrate_pool_with_progress)
+//! and it is called as each migration starts and finishes; pass nothing
+//! and the behaviour is exactly what it was.
+//!
+//! ## Observers must not block
+//!
+//! Events are emitted from **inside the migrate lock** — a PG advisory
+//! lock, a MySQL `GET_LOCK`, held for the whole run. Every other process
+//! trying to migrate is waiting behind it. An observer that blocks, does
+//! synchronous I/O, or sends on a full unbuffered channel extends that
+//! hold for everyone.
+//!
+//! Send on a bounded channel that drops when full, or push onto a queue a
+//! separate task drains. Losing a progress event is a cosmetic problem;
+//! stalling every migrating pod is not.
+//!
+//! ```ignore
+//! use rustango::migrate::{migrate_pool_with_progress, MigrationEvent};
+//!
+//! migrate_pool_with_progress(&pool, dir, &|event: MigrationEvent| {
+//!     if let MigrationEvent::Finished { name, index, total, .. } = &event {
+//!         println!("[{index}/{total}] {name}");
+//!     }
+//! })
+//! .await?;
+//! ```
+
+use std::time::Duration;
+
+/// Something that happened during a migration run.
+///
+/// Owned rather than borrowed on purpose: an observer's whole job is
+/// usually to hand the event to somewhere else — a channel, a broadcast
+/// bus, a run log — and a borrow would tie it to the runner's stack. One
+/// allocation per migration is not measurable against the DDL it
+/// describes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationEvent {
+    /// The pending set has been computed. Emitted once, before any
+    /// migration runs, so a watcher can size a progress bar — including
+    /// when `total` is 0 and nothing else will follow.
+    Planned {
+        /// How many migrations will be attempted.
+        total: usize,
+    },
+
+    /// About to apply this migration.
+    Started {
+        /// File stem, e.g. `0002_add_bio_to_author`.
+        name: String,
+        /// 1-based position in the pending set.
+        index: usize,
+        total: usize,
+    },
+
+    /// This migration is done, and the run continues.
+    Finished {
+        name: String,
+        index: usize,
+        total: usize,
+        /// What the runner actually did — see [`Outcome`]. Not every
+        /// "finished" migration ran any SQL.
+        outcome: Outcome,
+        /// Wall time for this migration alone. The reason to emit
+        /// per-migration timings rather than a total: a forty-migration
+        /// chain where one takes ninety seconds is exactly the thing
+        /// this is meant to make visible.
+        elapsed: Duration,
+    },
+
+    /// This migration failed. The runner stops here — a migration chain
+    /// is ordered, so there is no useful sense in which the rest could
+    /// be attempted — and no further events follow.
+    Failed {
+        name: String,
+        index: usize,
+        total: usize,
+        /// Rendered rather than the live error: the error is returned to
+        /// the caller by the runner, and an observer usually wants to
+        /// display or store this rather than match on it.
+        error: String,
+    },
+}
+
+/// What the runner did with a migration it reports as finished.
+///
+/// Three genuinely different things wear the word "applied", and
+/// collapsing them is how a watcher comes to believe DDL ran that never
+/// did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Ran its `forward` operations, then recorded it.
+    Ran,
+
+    /// Ran, but skipped the operations for tables that already existed —
+    /// the cross-ledger reconciliation path. The listed tables were left
+    /// exactly as they were.
+    RanPartial {
+        /// Tables whose operations were skipped because they were
+        /// already present.
+        skipped: Vec<String>,
+    },
+
+    /// Recorded in the ledger **without running any DDL**: the end state
+    /// was already present (a squash over history the database already
+    /// has, or the guarded fake-initial path for a subsystem whose
+    /// tables predate its migrations).
+    ///
+    /// Distinct from [`Ran`](Outcome::Ran) because an operator reading
+    /// "applied 0003" and an operator reading "faked 0003" should reach
+    /// different conclusions about what is in their database.
+    Faked,
+}
+
+/// Receives [`MigrationEvent`]s as a run progresses.
+///
+/// Implemented for any `Fn(MigrationEvent)`, so the common case is a
+/// closure:
+///
+/// ```ignore
+/// migrate_pool_with_progress(&pool, dir, &|e| tx.try_send(e).ok()).await?;
+/// ```
+///
+/// **Implementations must not block** — see the [module
+/// docs](self#observers-must-not-block). Events arrive while the
+/// migrate lock is held.
+pub trait MigrationObserver: Send + Sync {
+    /// Handle one event. Must return promptly and must not panic — a
+    /// panic here unwinds through the runner with the migrate lock held.
+    fn on_event(&self, event: MigrationEvent);
+}
+
+impl<F> MigrationObserver for F
+where
+    F: Fn(MigrationEvent) + Send + Sync,
+{
+    fn on_event(&self, event: MigrationEvent) {
+        self(event);
+    }
+}
+
+/// Emit to an optional observer. `None` is the silent path every
+/// pre-existing entry point takes, and compiles to nothing.
+pub(super) fn emit(
+    observer: Option<&dyn MigrationObserver>,
+    event: impl FnOnce() -> MigrationEvent,
+) {
+    if let Some(observer) = observer {
+        observer.on_event(event());
+    }
+}

--- a/crates/rustango/src/migrate/runner.rs
+++ b/crates/rustango/src/migrate/runner.rs
@@ -26,6 +26,7 @@ use crate::sql::sqlx::PgPool;
 use super::diff::render_changes_split;
 use super::file::{self, Migration, Operation};
 use super::invert::invert;
+use super::progress::{emit, MigrationEvent, MigrationObserver, Outcome};
 use super::snapshot::SchemaSnapshot;
 use super::{ddl, MigrateError};
 
@@ -108,7 +109,7 @@ impl Builder {
     /// As [`migrate`].
     #[cfg(feature = "postgres")]
     pub async fn migrate(&self, pool: &PgPool, dir: &Path) -> Result<Vec<Migration>, MigrateError> {
-        migrate_with_ledger(pool, dir, self.ledger).await
+        migrate_with_ledger(pool, dir, self.ledger, None).await
     }
 
     /// As [`migrate_to`], with this builder's ledger.
@@ -442,11 +443,34 @@ pub async fn migrate(pool: &PgPool, dir: &Path) -> Result<Vec<Migration>, Migrat
     Builder::default().migrate(pool, dir).await
 }
 
+/// [`migrate`], reporting each migration to `observer` as it starts and
+/// finishes.
+///
+/// The PG-typed sibling of [`migrate_pool_with_progress`]. Kept separate
+/// rather than routed through it because this path is not the same code:
+/// it fires the `pre_migrate` / `post_migrate` signals and uses the
+/// PG-typed ledger helpers.
+///
+/// **The observer is called with the migrate lock held**, so it must not
+/// block; see [the module docs](super::progress#observers-must-not-block).
+///
+/// # Errors
+/// As [`migrate`].
+#[cfg(feature = "postgres")]
+pub async fn migrate_with_progress(
+    pool: &PgPool,
+    dir: &Path,
+    observer: &dyn MigrationObserver,
+) -> Result<Vec<Migration>, MigrateError> {
+    migrate_with_ledger(pool, dir, LEDGER_TABLE, Some(observer)).await
+}
+
 #[cfg(feature = "postgres")]
 async fn migrate_with_ledger(
     pool: &PgPool,
     dir: &Path,
     ledger: &str,
+    observer: Option<&dyn MigrationObserver>,
 ) -> Result<Vec<Migration>, MigrateError> {
     #[cfg(feature = "signals")]
     use crate::signals::migrate::{
@@ -460,22 +484,62 @@ async fn migrate_with_ledger(
         let applied = applied_set_for(pool, ledger).await?;
         let pending = pending_migrations(all, &applied);
 
-        let mut newly = Vec::with_capacity(pending.len());
+        let total = pending.len();
+        emit(observer, || MigrationEvent::Planned { total });
+
+        let mut newly = Vec::with_capacity(total);
         // Squash reconciliation applies on this legacy PgPool entry point
         // too — route through the same dialect-agnostic decision used by
         // `migrate_pool` so both runners agree. `fake_initial` stays off
         // here: table-existence faking is opted into only by the
         // framework's system-migration path.
         let enum_pool = crate::sql::Pool::Postgres(pool.clone());
-        for mig in pending {
-            match reconcile(&enum_pool, &mig, &applied, false).await? {
-                ReconcileAction::Fake => fake_apply_pool(&enum_pool, &mig, ledger).await?,
-                // `fake_initial` is off on this path, so `RunPartial` is
-                // unreachable here; treat it as a plain run for totality.
-                ReconcileAction::Run | ReconcileAction::RunPartial(_) => {
-                    apply_one(pool, &mig, ledger).await?
-                }
+        for (i, mig) in pending.into_iter().enumerate() {
+            let index = i + 1;
+            emit(observer, || MigrationEvent::Started {
+                name: mig.name.clone(),
+                index,
+                total,
+            });
+            let began = std::time::Instant::now();
+
+            let step = async {
+                Ok::<_, MigrateError>(match reconcile(&enum_pool, &mig, &applied, false).await? {
+                    ReconcileAction::Fake => {
+                        fake_apply_pool(&enum_pool, &mig, ledger).await?;
+                        Outcome::Faked
+                    }
+                    // `fake_initial` is off on this path, so
+                    // `RunPartial` is unreachable here; treat it as a
+                    // plain run for totality.
+                    ReconcileAction::Run | ReconcileAction::RunPartial(_) => {
+                        apply_one(pool, &mig, ledger).await?;
+                        Outcome::Ran
+                    }
+                })
             }
+            .await;
+
+            let outcome = match step {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    emit(observer, || MigrationEvent::Failed {
+                        name: mig.name.clone(),
+                        index,
+                        total,
+                        error: e.to_string(),
+                    });
+                    return Err(e);
+                }
+            };
+
+            emit(observer, || MigrationEvent::Finished {
+                name: mig.name.clone(),
+                index,
+                total,
+                outcome,
+                elapsed: began.elapsed(),
+            });
             newly.push(mig);
         }
         Ok(newly)
@@ -1431,6 +1495,44 @@ pub async fn migrate_pool(
     migrate_pool_with_ledger(pool, dir, LEDGER_TABLE).await
 }
 
+/// [`migrate_pool`], reporting each migration to `observer` as it starts
+/// and finishes.
+///
+/// The observer sees the pending count up front, then a
+/// [`Started`](MigrationEvent::Started) and a
+/// [`Finished`](MigrationEvent::Finished) per migration — carrying which
+/// of the three apply paths it took and how long it took — or a
+/// [`Failed`](MigrationEvent::Failed) naming the migration that died.
+///
+/// **The observer is called with the migrate lock held**, so it must not
+/// block; see [the module docs](super::progress#observers-must-not-block).
+///
+/// # Errors
+/// As [`migrate_pool`]. The observer never changes the outcome: a run
+/// with an observer applies exactly what the same run without one would.
+pub async fn migrate_pool_with_progress(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    observer: &dyn MigrationObserver,
+) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, LEDGER_TABLE, false, Some(observer)).await
+}
+
+/// [`migrate_pool_with_ledger_fake_initial`] with progress reporting —
+/// the framework's own system-migration path, which is where
+/// [`Outcome::Faked`] actually shows up.
+///
+/// # Errors
+/// As [`migrate_pool_with_ledger_fake_initial`].
+pub async fn migrate_pool_with_ledger_fake_initial_with_progress(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    ledger: &str,
+    observer: &dyn MigrationObserver,
+) -> Result<Vec<Migration>, MigrateError> {
+    migrate_pool_with_ledger_opts(pool, dir, ledger, true, Some(observer)).await
+}
+
 /// Apply every pending migration in `dir` against a custom-named
 /// ledger table. Sibling of [`migrate_pool`] with operator-supplied
 /// ledger name (issue #146). Use for multi-tenant / multi-app
@@ -1445,7 +1547,7 @@ pub async fn migrate_pool_with_ledger(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
-    migrate_pool_with_ledger_opts(pool, dir, ledger, false).await
+    migrate_pool_with_ledger_opts(pool, dir, ledger, false, None).await
 }
 
 /// Like [`migrate_pool_with_ledger`], but with **guarded fake-initial**
@@ -1477,7 +1579,7 @@ pub async fn migrate_pool_with_ledger_fake_initial(
     dir: &Path,
     ledger: &str,
 ) -> Result<Vec<Migration>, MigrateError> {
-    migrate_pool_with_ledger_opts(pool, dir, ledger, true).await
+    migrate_pool_with_ledger_opts(pool, dir, ledger, true, None).await
 }
 
 async fn migrate_pool_with_ledger_opts(
@@ -1485,6 +1587,7 @@ async fn migrate_pool_with_ledger_opts(
     dir: &Path,
     ledger: &str,
     fake_initial: bool,
+    observer: Option<&dyn MigrationObserver>,
 ) -> Result<Vec<Migration>, MigrateError> {
     ensure_ledger_pool_with_ledger(pool, ledger).await?;
     with_migrate_lock_pool(pool, async {
@@ -1492,29 +1595,85 @@ async fn migrate_pool_with_ledger_opts(
         let applied = applied_set_pool_with_ledger(pool, ledger).await?;
         let pending = pending_migrations(all, &applied);
 
-        let mut newly = Vec::with_capacity(pending.len());
-        for mig in pending {
-            match reconcile(pool, &mig, &applied, fake_initial).await? {
-                ReconcileAction::Fake => fake_apply_pool(pool, &mig, ledger).await?,
-                other => {
-                    let effective = match other {
-                        ReconcileAction::RunPartial(existing) => {
-                            std::borrow::Cow::Owned(without_tables(&mig, &existing))
-                        }
-                        _ => std::borrow::Cow::Borrowed(&mig),
-                    };
-                    if effective.atomic {
-                        apply_atomic_pool(pool, &effective, ledger).await?;
-                    } else {
-                        apply_nonatomic_pool(pool, &effective, ledger).await?;
-                    }
+        let total = pending.len();
+        emit(observer, || MigrationEvent::Planned { total });
+
+        let mut newly = Vec::with_capacity(total);
+        for (i, mig) in pending.into_iter().enumerate() {
+            let index = i + 1;
+            emit(observer, || MigrationEvent::Started {
+                name: mig.name.clone(),
+                index,
+                total,
+            });
+            let began = std::time::Instant::now();
+
+            // The whole apply is wrapped so a failure can be reported to
+            // the observer before it propagates. `?` on its own would
+            // leave a watcher looking at a migration stuck on "started"
+            // forever, which is the state this exists to prevent.
+            let outcome = reconcile_and_apply(pool, &mig, &applied, ledger, fake_initial).await;
+            let outcome = match outcome {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    emit(observer, || MigrationEvent::Failed {
+                        name: mig.name.clone(),
+                        index,
+                        total,
+                        error: e.to_string(),
+                    });
+                    return Err(e);
                 }
-            }
+            };
+
+            emit(observer, || MigrationEvent::Finished {
+                name: mig.name.clone(),
+                index,
+                total,
+                outcome,
+                elapsed: began.elapsed(),
+            });
             newly.push(mig);
         }
         Ok(newly)
     })
     .await
+}
+
+/// Reconcile and apply a single pending migration, reporting which of
+/// the three paths it took.
+///
+/// Split out of the loop so the caller can time it and report a failure
+/// with the migration's name attached — the runner's `?` alone loses
+/// which file died.
+async fn reconcile_and_apply(
+    pool: &crate::sql::Pool,
+    mig: &Migration,
+    applied: &HashSet<String>,
+    ledger: &str,
+    fake_initial: bool,
+) -> Result<Outcome, MigrateError> {
+    match reconcile(pool, mig, applied, fake_initial).await? {
+        ReconcileAction::Fake => {
+            fake_apply_pool(pool, mig, ledger).await?;
+            Ok(Outcome::Faked)
+        }
+        other => {
+            let (effective, outcome) = match other {
+                ReconcileAction::RunPartial(existing) => (
+                    std::borrow::Cow::Owned(without_tables(mig, &existing)),
+                    Outcome::RanPartial { skipped: existing },
+                ),
+                _ => (std::borrow::Cow::Borrowed(mig), Outcome::Ran),
+            };
+            if effective.atomic {
+                apply_atomic_pool(pool, &effective, ledger).await?;
+            } else {
+                apply_nonatomic_pool(pool, &effective, ledger).await?;
+            }
+            Ok(outcome)
+        }
+    }
 }
 
 // ------------------------------------------------------- reconciliation

--- a/crates/rustango/src/tenancy/manage/migrations.rs
+++ b/crates/rustango/src/tenancy/manage/migrations.rs
@@ -21,6 +21,11 @@ pub(super) async fn migrate_tenants_cmd<W: Write + Send, DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
+    // Progress goes to the same writer the report does, so `manage
+    // migrate-tenants` shows each migration as it lands instead of
+    // sitting silent for the length of the run.
+    let progress = CliProgress::new(w);
+
     // v0.38 — on PG the legacy `migrate_tenants` handles both schema-
     // mode and database-mode tenants; on non-PG we route through the
     // generic `migrate_tenants_db` which is database-mode-only by
@@ -30,14 +35,118 @@ where
         if let Some(pg_pools) =
             (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
         {
-            tenant_migrate::migrate_tenants(pg_pools, dir, registry_url).await?
+            tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, &progress)
+                .await?
         } else {
-            tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?
+            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
+                .await?
         }
     };
     #[cfg(not(feature = "postgres"))]
-    let report = tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?;
+    let report =
+        tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
+            .await?;
+    let w = progress.into_inner();
     write_tenant_report(w, &report)
+}
+
+/// Prints tenant-migration progress to the verb's own writer.
+///
+/// ## Why the `Mutex`
+///
+/// An observer is `&self` and `Sync` — it has to be, because the runner
+/// hands events out from inside an async body — while a verb writes
+/// through `&mut W`. The mutex is what bridges those, and it is
+/// uncontended: the runner emits from one task at a time.
+///
+/// ## On blocking
+///
+/// [`crate::migrate::progress`] says observers must not block, because
+/// events are emitted with the migrate lock held. Writing a line to a
+/// terminal is microseconds, and this is a CLI: one process, one
+/// operator, and if it does stall on a full pipe (`manage migrate |
+/// head -1`) the only migration it delays is the operator's own. That
+/// reasoning does **not** transfer to a server-side observer.
+struct CliProgress<'w, W> {
+    out: std::sync::Mutex<&'w mut W>,
+}
+
+impl<'w, W: Write + Send> CliProgress<'w, W> {
+    fn new(out: &'w mut W) -> Self {
+        Self {
+            out: std::sync::Mutex::new(out),
+        }
+    }
+
+    /// Hand the writer back so the caller can print the final report.
+    fn into_inner(self) -> &'w mut W {
+        // A poisoned lock means an observer call panicked. The docs say
+        // not to panic in one; if it happened anyway, recover the writer
+        // rather than taking the whole verb down over progress output.
+        self.out.into_inner().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<W: Write + Send> tenant_migrate::TenantMigrationObserver for CliProgress<'_, W> {
+    fn on_event(&self, event: tenant_migrate::TenantMigrationEvent) {
+        use crate::migrate::{MigrationEvent, Outcome};
+        use tenant_migrate::{Chain, TenantMigrationEvent as E};
+
+        let Ok(mut out) = self.out.lock() else {
+            return;
+        };
+        // Progress is cosmetic — a broken pipe or a full disk must not
+        // turn a successful migration into a failed verb, so every write
+        // here is deliberately unchecked.
+        let _ = match event {
+            E::Planned { tenants } if tenants > 0 => {
+                writeln!(out, "migrating {tenants} tenant(s)…")
+            }
+            // Nothing to print for either: a plan of zero tenants, and
+            // the per-tenant summary `write_tenant_report` already
+            // prints once the run is over.
+            E::Planned { .. } | E::TenantFinished { .. } => Ok(()),
+            E::TenantStarted { slug, index, total } => {
+                writeln!(out, "[{index}/{total}] {slug}")
+            }
+            E::Migration { chain, event, .. } => {
+                // The two chains number independently, so `0001_initial`
+                // shows up in both. Tag which one, or it reads as a
+                // migration that ran twice.
+                let tag = match chain {
+                    Chain::System => "system",
+                    Chain::Project => "app",
+                };
+                match event {
+                    MigrationEvent::Finished {
+                        name,
+                        outcome,
+                        elapsed,
+                        ..
+                    } => {
+                        let verb = match outcome {
+                            Outcome::Ran => "applied",
+                            Outcome::RanPartial { .. } => "applied (partial)",
+                            Outcome::Faked => "faked",
+                        };
+                        writeln!(
+                            out,
+                            "        {verb} {tag}/{name} ({:.1}s)",
+                            elapsed.as_secs_f64()
+                        )
+                    }
+                    MigrationEvent::Failed { name, error, .. } => {
+                        writeln!(out, "        ✗ {tag}/{name}: {error}")
+                    }
+                    // `Started` and `Planned` are deliberately quiet:
+                    // one line per migration, printed when it lands and
+                    // carrying its duration, beats two.
+                    _ => Ok(()),
+                }
+            }
+        };
+        let _ = out.flush();
+    }
 }
 
 fn write_tenant_report<W: Write>(
@@ -227,18 +336,24 @@ where
     // `migrate_tenants` (handles schema-mode + database-mode);
     // sqlite/mysql route through `migrate_tenants_db` (database-mode
     // only — schema-mode is PG-only by language).
+    let progress = CliProgress::new(w);
     #[cfg(feature = "postgres")]
     let report = {
         if let Some(pg_pools) =
             (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
         {
-            tenant_migrate::migrate_tenants(pg_pools, dir, registry_url).await?
+            tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, &progress)
+                .await?
         } else {
-            tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?
+            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
+                .await?
         }
     };
     #[cfg(not(feature = "postgres"))]
-    let report = tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?;
+    let report =
+        tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
+            .await?;
+    let w = progress.into_inner();
     write_tenant_report(w, &report)?;
     Ok(())
 }

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -86,6 +86,97 @@ impl TenantMigrationReport {
     }
 }
 
+/// Which of a tenant's two migration chains an event came from.
+///
+/// A tenant migrates twice: the framework's own `system/migrations/`
+/// chain (its tables — users, roles, permissions, api_keys, audit_log,
+/// content_types) into the `__rustango_system_migrations__` ledger, then
+/// the project's own chain into `__rustango_migrations__`. They are
+/// numbered independently, so **`0001_initial` legitimately appears
+/// twice in one tenant's run**. Without this a watcher sees the same
+/// name land twice and concludes something re-ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Chain {
+    /// The framework's own tables, applied first — the project's
+    /// migrations may FK into them (#1171).
+    System,
+    /// The project's own migrations.
+    Project,
+}
+
+/// Something that happened while migrating a set of tenants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TenantMigrationEvent {
+    /// The active-tenant set has been read. Emitted once, up front.
+    Planned {
+        /// How many tenants will be migrated.
+        tenants: usize,
+    },
+    /// Starting this tenant.
+    TenantStarted {
+        slug: String,
+        /// 1-based.
+        index: usize,
+        total: usize,
+    },
+    /// A migration-level event from inside one tenant's run.
+    Migration {
+        slug: String,
+        chain: Chain,
+        event: crate::migrate::MigrationEvent,
+    },
+    /// This tenant is done. Unlike the migration runner, a failure here
+    /// is **not** terminal: `migrate_tenants_db` deliberately continues
+    /// with the remaining tenants, so more events follow.
+    TenantFinished {
+        slug: String,
+        index: usize,
+        total: usize,
+        /// Migrations applied across both chains.
+        applied: usize,
+        /// `Some` if this tenant failed; the batch continues regardless.
+        error: Option<String>,
+    },
+}
+
+/// Receives [`TenantMigrationEvent`]s as a tenant batch progresses.
+///
+/// Implemented for any `Fn(TenantMigrationEvent)`, so a closure works
+/// directly. **Must not block** — the inner migration events are emitted
+/// with that tenant's migrate lock held; see
+/// [`crate::migrate::progress`].
+pub trait TenantMigrationObserver: Send + Sync {
+    /// Handle one event. Must return promptly and must not panic.
+    fn on_event(&self, event: TenantMigrationEvent);
+}
+
+impl<F> TenantMigrationObserver for F
+where
+    F: Fn(TenantMigrationEvent) + Send + Sync,
+{
+    fn on_event(&self, event: TenantMigrationEvent) {
+        self(event);
+    }
+}
+
+/// Adapt a tenant observer into a migration observer for one tenant's
+/// one chain, tagging every event with the slug and chain it came from.
+fn chain_observer<'a>(
+    observer: Option<&'a dyn TenantMigrationObserver>,
+    slug: &'a str,
+    chain: Chain,
+) -> Option<impl crate::migrate::MigrationObserver + 'a> {
+    observer.map(move |observer| {
+        move |event: crate::migrate::MigrationEvent| {
+            observer.on_event(TenantMigrationEvent::Migration {
+                slug: slug.to_owned(),
+                chain,
+                event,
+            });
+        }
+    })
+}
+
 /// Per-tenant migration outcome.
 #[derive(Debug)]
 pub struct TenantMigrationOutcome {
@@ -117,6 +208,15 @@ async fn apply_system_migrations(
     dir: &Path,
     scope: crate::core::ModelScope,
 ) -> Result<Vec<Migration>, TenancyError> {
+    apply_system_migrations_opts(pool, dir, scope, None).await
+}
+
+async fn apply_system_migrations_opts(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    scope: crate::core::ModelScope,
+    observer: Option<&dyn crate::migrate::MigrationObserver>,
+) -> Result<Vec<Migration>, TenancyError> {
     // `system/migrations/` is a sibling of the project's `migrations/`
     // dir. When `dir` is literally `<root>/migrations`, the project root
     // is its parent; otherwise (e.g. a bare test dir) keep `system/`
@@ -147,21 +247,37 @@ async fn apply_system_migrations(
     // the plain runner.
     let applied = match scoped_subset(&system_dir, migration_scope).await? {
         ScopedDir::Owned(temp) => {
-            let r = crate::migrate::migrate_pool_with_ledger_fake_initial(
-                pool,
-                temp.path(),
-                SYSTEM_LEDGER,
-            )
-            .await?;
+            let r = apply_system_dir(pool, temp.path(), observer).await?;
             drop(temp);
             r
         }
-        ScopedDir::Original => {
-            crate::migrate::migrate_pool_with_ledger_fake_initial(pool, &system_dir, SYSTEM_LEDGER)
-                .await?
-        }
+        ScopedDir::Original => apply_system_dir(pool, &system_dir, observer).await?,
     };
     Ok(applied)
+}
+
+/// Run the framework's own chain against `dir`, with or without an
+/// observer. Split out only so the two `ScopedDir` arms don't each carry
+/// the observer branch.
+async fn apply_system_dir(
+    pool: &crate::sql::Pool,
+    dir: &Path,
+    observer: Option<&dyn crate::migrate::MigrationObserver>,
+) -> Result<Vec<Migration>, TenancyError> {
+    Ok(match observer {
+        Some(observer) => {
+            crate::migrate::migrate_pool_with_ledger_fake_initial_with_progress(
+                pool,
+                dir,
+                SYSTEM_LEDGER,
+                observer,
+            )
+            .await?
+        }
+        None => {
+            crate::migrate::migrate_pool_with_ledger_fake_initial(pool, dir, SYSTEM_LEDGER).await?
+        }
+    })
 }
 
 /// Apply registry-scoped pending migrations to the registry DB.
@@ -259,6 +375,36 @@ pub async fn migrate_tenants(
     dir: &Path,
     registry_url: &str,
 ) -> Result<TenantMigrationReport, TenancyError> {
+    migrate_tenants_opts(pools, dir, registry_url, None).await
+}
+
+/// [`migrate_tenants`], reporting progress to `observer` as it goes.
+///
+/// The Postgres sibling of [`migrate_tenants_db_with_progress`], and the
+/// one the CLI actually reaches on a PG registry — it handles
+/// schema-mode tenants as well as database-mode.
+///
+/// **The observer must not block**; see [`crate::migrate::progress`].
+///
+/// # Errors
+/// As [`migrate_tenants`].
+#[cfg(feature = "postgres")]
+pub async fn migrate_tenants_with_progress(
+    pools: &TenantPools,
+    dir: &Path,
+    registry_url: &str,
+    observer: &dyn TenantMigrationObserver,
+) -> Result<TenantMigrationReport, TenancyError> {
+    migrate_tenants_opts(pools, dir, registry_url, Some(observer)).await
+}
+
+#[cfg(feature = "postgres")]
+async fn migrate_tenants_opts(
+    pools: &TenantPools,
+    dir: &Path,
+    registry_url: &str,
+    observer: Option<&dyn TenantMigrationObserver>,
+) -> Result<TenantMigrationReport, TenancyError> {
     let scoped = scoped_subset(dir, MigrationScope::Tenant).await?;
     let scoped_path = match &scoped {
         ScopedDir::Owned(temp) => temp.path().to_path_buf(),
@@ -294,9 +440,31 @@ pub async fn migrate_tenants(
         );
     }
 
+    let total = orgs.len();
+    if let Some(observer) = observer {
+        observer.on_event(TenantMigrationEvent::Planned { tenants: total });
+    }
+
     let mut report = TenantMigrationReport::default();
-    for org in &orgs {
-        let outcome = run_for_one_tenant(pools, org, &scoped_path, registry_url).await;
+    for (i, org) in orgs.iter().enumerate() {
+        let index = i + 1;
+        if let Some(observer) = observer {
+            observer.on_event(TenantMigrationEvent::TenantStarted {
+                slug: org.slug.clone(),
+                index,
+                total,
+            });
+        }
+        let outcome = run_for_one_tenant(pools, org, &scoped_path, registry_url, observer).await;
+        if let Some(observer) = observer {
+            observer.on_event(TenantMigrationEvent::TenantFinished {
+                slug: org.slug.clone(),
+                index,
+                total,
+                applied: outcome.as_ref().map_or(0, Vec::len),
+                error: outcome.as_ref().err().map(ToString::to_string),
+            });
+        }
         match &outcome {
             Ok(applied) => info!(
                 target: "rustango::tenancy",
@@ -344,7 +512,45 @@ pub async fn migrate_tenants(
 pub async fn migrate_tenants_db<DB: Database>(
     pools: &TenantPools<DB>,
     dir: &Path,
+    registry_url: &str,
+) -> Result<TenantMigrationReport, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    migrate_tenants_db_opts(pools, dir, registry_url, None).await
+}
+
+/// [`migrate_tenants_db`], reporting progress to `observer` as it goes.
+///
+/// The observer sees the tenant count up front, then per tenant a
+/// start, every migration event from both of that tenant's chains (see
+/// [`Chain`]), and a finish carrying that tenant's error if it had one.
+/// A tenant failure does not end the stream — the batch continues, and
+/// so do the events.
+///
+/// **The observer must not block**: migration events are emitted with
+/// the tenant's migrate lock held. See [`crate::migrate::progress`].
+///
+/// # Errors
+/// As [`migrate_tenants_db`]. Per-tenant failures are reported in the
+/// returned [`TenantMigrationReport`], not as an error.
+pub async fn migrate_tenants_db_with_progress<DB: Database>(
+    pools: &TenantPools<DB>,
+    dir: &Path,
+    registry_url: &str,
+    observer: &dyn TenantMigrationObserver,
+) -> Result<TenantMigrationReport, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    migrate_tenants_db_opts(pools, dir, registry_url, Some(observer)).await
+}
+
+async fn migrate_tenants_db_opts<DB: Database>(
+    pools: &TenantPools<DB>,
+    dir: &Path,
     _registry_url: &str,
+    observer: Option<&dyn TenantMigrationObserver>,
 ) -> Result<TenantMigrationReport, TenancyError>
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
@@ -369,9 +575,31 @@ where
         "applying tenant-scoped migrations (db-mode only)"
     );
 
+    let total = orgs.len();
+    if let Some(observer) = observer {
+        observer.on_event(TenantMigrationEvent::Planned { tenants: total });
+    }
+
     let mut report = TenantMigrationReport::default();
-    for org in &orgs {
-        let outcome = run_for_one_tenant_db(pools, org, &scoped_path).await;
+    for (i, org) in orgs.iter().enumerate() {
+        let index = i + 1;
+        if let Some(observer) = observer {
+            observer.on_event(TenantMigrationEvent::TenantStarted {
+                slug: org.slug.clone(),
+                index,
+                total,
+            });
+        }
+        let outcome = run_for_one_tenant_db(pools, org, &scoped_path, observer).await;
+        if let Some(observer) = observer {
+            observer.on_event(TenantMigrationEvent::TenantFinished {
+                slug: org.slug.clone(),
+                index,
+                total,
+                applied: outcome.as_ref().map_or(0, Vec::len),
+                error: outcome.as_ref().err().map(ToString::to_string),
+            });
+        }
         match &outcome {
             Ok(applied) => info!(
                 target: "rustango::tenancy",
@@ -406,6 +634,7 @@ async fn run_for_one_tenant_db<DB: Database>(
     pools: &TenantPools<DB>,
     org: &Org,
     dir: &Path,
+    observer: Option<&dyn TenantMigrationObserver>,
 ) -> Result<Vec<Migration>, TenancyError>
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
@@ -440,9 +669,20 @@ where
     // audit_log, content_types) come from the makemigrations-generated
     // system-app migrations and MUST be applied BEFORE the tenant's user
     // migrations, which may FK into them (issue #1171).
-    let mut applied =
-        apply_system_migrations(&inner_pool, dir, crate::core::ModelScope::Tenant).await?;
-    applied.extend(migrate::migrate_pool(&inner_pool, dir).await?);
+    let system_progress = chain_observer(observer, &org.slug, Chain::System);
+    let mut applied = apply_system_migrations_opts(
+        &inner_pool,
+        dir,
+        crate::core::ModelScope::Tenant,
+        system_progress
+            .as_ref()
+            .map(|o| o as &dyn crate::migrate::MigrationObserver),
+    )
+    .await?;
+    applied.extend(match chain_observer(observer, &org.slug, Chain::Project) {
+        Some(o) => migrate::migrate_pool_with_progress(&inner_pool, dir, &o).await?,
+        None => migrate::migrate_pool(&inner_pool, dir).await?,
+    });
     // Data seeders (rows, not DDL — kept): the CRUD permission codenames
     // for every registered model (#61) + the content-type catalog (#89).
     if let Err(e) = super::permissions::auto_create_permissions_pool(&inner_pool).await {
@@ -486,7 +726,13 @@ async fn run_for_one_tenant(
     org: &Org,
     dir: &Path,
     registry_url: &str,
+    observer: Option<&dyn TenantMigrationObserver>,
 ) -> Result<Vec<Migration>, TenancyError> {
+    let system_progress = chain_observer(observer, &org.slug, Chain::System);
+    let system_progress = system_progress
+        .as_ref()
+        .map(|o| o as &dyn crate::migrate::MigrationObserver);
+    let project_progress = chain_observer(observer, &org.slug, Chain::Project);
     let mode = StorageMode::parse(&org.storage_mode).map_err(|got| {
         TenancyError::Validation(format!(
             "org `{}` has unknown storage_mode `{got}`",
@@ -503,9 +749,17 @@ async fn run_for_one_tenant(
             // (issue #1171). Applying user migrations first breaks a fresh
             // tenant whose model references e.g. rustango_users.
             let dbpool: crate::sql::Pool = pool.clone().into();
-            let mut applied =
-                apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
-            applied.extend(migrate::migrate(&pool, dir).await?);
+            let mut applied = apply_system_migrations_opts(
+                &dbpool,
+                dir,
+                crate::core::ModelScope::Tenant,
+                system_progress,
+            )
+            .await?;
+            applied.extend(match &project_progress {
+                Some(o) => migrate::migrate_with_progress(&pool, dir, o).await?,
+                None => migrate::migrate(&pool, dir).await?,
+            });
             // Data seeders (rows, not DDL — kept): CRUD permission
             // codenames for every registered model (#61) + the
             // content-type catalog (#89). Idempotent.
@@ -522,9 +776,17 @@ async fn run_for_one_tenant(
             let tenant_pool = pools.pool_for_org(org).await?;
             // System-app migrations before user migrations (issue #1171).
             let dbpool: crate::sql::Pool = tenant_pool.pool().clone().into();
-            let mut applied =
-                apply_system_migrations(&dbpool, dir, crate::core::ModelScope::Tenant).await?;
-            applied.extend(migrate::migrate(tenant_pool.pool(), dir).await?);
+            let mut applied = apply_system_migrations_opts(
+                &dbpool,
+                dir,
+                crate::core::ModelScope::Tenant,
+                system_progress,
+            )
+            .await?;
+            applied.extend(match &project_progress {
+                Some(o) => migrate::migrate_with_progress(tenant_pool.pool(), dir, o).await?,
+                None => migrate::migrate(tenant_pool.pool(), dir).await?,
+            });
             // Data seeders (rows, not DDL — kept): #61 + #89.
             if let Err(e) = super::permissions::auto_create_permissions(tenant_pool.pool()).await {
                 tracing::warn!(target: "rustango::tenancy", slug = %org.slug, error = %e, "auto_create_permissions failed for database-mode tenant");

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -161,12 +161,13 @@ pub use database_pools::{DatabaseConn, DatabasePool, DatabasePools};
 pub use error::TenancyError;
 #[cfg(all(feature = "tenancy", feature = "sso"))]
 pub use member_auth::{member_sso_router, CurrentMember, MemberAuthConfig, MEMBER_COOKIE};
-#[cfg(feature = "postgres")]
-pub use migrate::migrate_tenants;
 pub use migrate::{
-    migrate_registry, migrate_registry_pool, migrate_tenants_db, migrate_tenants_dyn,
+    migrate_registry, migrate_registry_pool, migrate_tenants_db, migrate_tenants_db_with_progress,
+    migrate_tenants_dyn, Chain, TenantMigrationEvent, TenantMigrationObserver,
     TenantMigrationOutcome, TenantMigrationReport,
 };
+#[cfg(feature = "postgres")]
+pub use migrate::{migrate_tenants, migrate_tenants_with_progress};
 /// Fingerprint of `rustango_orgs`, used by the base-host cache to notice
 /// writes made by another process. Public so a deployment can poll it
 /// itself (e.g. to drive a custom cache) and so tests can assert on it.

--- a/crates/rustango/tests/manage_live.rs
+++ b/crates/rustango/tests/manage_live.rs
@@ -400,6 +400,14 @@ async fn migrate_tenants_runs_against_active_only() {
     res.unwrap();
     assert!(out.contains(&slug), "{out}");
     assert!(out.contains("migration"), "{out}");
+    // #1320 — the verb reports each migration as it lands, not just a
+    // summary once the whole run is over. `app/` distinguishes the
+    // project's chain from the framework's `system/` one, which numbers
+    // independently and would otherwise look like a repeat.
+    assert!(
+        out.contains(&format!("applied app/{mig_name}")),
+        "expected per-migration progress for {mig_name}: {out}"
+    );
 
     let exists: bool = sqlx::query_as::<_, (bool,)>(
         "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = 'thing')",

--- a/crates/rustango/tests/migrate_progress_live.rs
+++ b/crates/rustango/tests/migrate_progress_live.rs
@@ -1,0 +1,581 @@
+// `Pool` is single-variant on a one-backend build and three-variant
+// under `--all-features`, so each module's `let Pool::X(..) = .. else`
+// is refutable in one configuration and not the other.
+#![allow(irrefutable_let_patterns)]
+//! Migration progress reporting (#1320) — execution-based, all three
+//! dialects.
+//!
+//! The runner used to be silent for the length of a run. These assert
+//! the event stream an observer now sees: the pending count up front,
+//! one `Started` / `Finished` pair per migration in apply order, a
+//! `Failed` naming the migration that died, and — the distinction that
+//! matters most — `Faked` never masquerading as `Ran`.
+//!
+//! The apply loop lives on `crate::sql::Pool`, so it is one code path
+//! for Postgres, MySQL and SQLite. That is exactly why it is worth
+//! running the same scenarios against all three rather than trusting
+//! SQLite: the migrate lock is a different mechanism on each
+//! (`pg_advisory_lock`, `GET_LOCK`, none), and the events are emitted
+//! from inside it.
+//!
+//! Each scenario body is shared; the cfg-gated modules at the bottom own
+//! pool construction and call into `scenarios::check_*`. PG reads
+//! `DATABASE_URL`, MySQL reads `MYSQL_TEST_URL`; both skip when unset.
+
+#[cfg(any(feature = "postgres", feature = "sqlite", feature = "mysql"))]
+mod scenarios {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Mutex;
+
+    use rustango::migrate::{
+        self, file, Migration, MigrationEvent, Operation, Outcome, SchemaChange, SchemaSnapshot,
+        TableSnapshot,
+    };
+    use rustango::sql::Pool;
+
+    pub const SYSTEM_LEDGER: &str = "__rustango_system_migrations__";
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn snapshot_with_tables(tables: &[&str]) -> SchemaSnapshot {
+        let ts: Vec<TableSnapshot> = tables
+            .iter()
+            .map(|table| {
+                serde_json::from_value(serde_json::json!({
+                    "name": table,
+                    "model": "T",
+                    "fields": [
+                        {"name": "id", "column": "id", "ty": "i64",
+                         "nullable": false, "primary_key": true}
+                    ]
+                }))
+                .unwrap()
+            })
+            .collect();
+        SchemaSnapshot {
+            tables: ts,
+            ..Default::default()
+        }
+    }
+
+    /// A migration that creates `table`, carrying the cumulative
+    /// snapshot so a chain of them stays internally consistent.
+    fn create_table_mig(name: &str, table: &str, all_tables: &[&str]) -> Migration {
+        Migration {
+            name: name.to_owned(),
+            created_at: "2026-09-10T00:00:00Z".into(),
+            prev: None,
+            atomic: true,
+            scope: migrate::MigrationScope::default(),
+            replaces: Vec::new(),
+            snapshot: snapshot_with_tables(all_tables),
+            forward: vec![Operation::Schema(SchemaChange::CreateTable(table.into()))],
+        }
+    }
+
+    fn write_dir(migs: &[Migration]) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("rustango_progress_dir_{}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        for m in migs {
+            file::write(&dir.join(format!("{}.json", m.name)), m).unwrap();
+        }
+        dir
+    }
+
+    /// Collects events so a test can assert on the whole sequence.
+    #[derive(Default)]
+    pub struct Recorder(Mutex<Vec<MigrationEvent>>);
+
+    impl Recorder {
+        fn observer(&self) -> impl migrate::MigrationObserver + '_ {
+            move |event: MigrationEvent| self.0.lock().unwrap().push(event)
+        }
+
+        fn events(&self) -> Vec<MigrationEvent> {
+            self.0.lock().unwrap().clone()
+        }
+
+        /// A compact rendering, so a failure message shows the sequence
+        /// rather than a wall of struct debug.
+        fn trace(&self) -> Vec<String> {
+            self.events()
+                .iter()
+                .map(|e| match e {
+                    MigrationEvent::Planned { total } => format!("planned:{total}"),
+                    MigrationEvent::Started { name, index, total } => {
+                        format!("start:{name}:{index}/{total}")
+                    }
+                    MigrationEvent::Finished {
+                        name,
+                        index,
+                        total,
+                        outcome,
+                        ..
+                    } => {
+                        let o = match outcome {
+                            Outcome::Ran => "ran",
+                            Outcome::RanPartial { .. } => "partial",
+                            Outcome::Faked => "faked",
+                        };
+                        format!("done:{name}:{index}/{total}:{o}")
+                    }
+                    MigrationEvent::Failed {
+                        name, index, total, ..
+                    } => format!("fail:{name}:{index}/{total}"),
+                })
+                .collect()
+        }
+    }
+
+    /// The happy path: the pending count up front, then a start/finish
+    /// pair per migration, numbered and in apply order.
+    pub async fn check_reports_every_migration_in_order(pool: &Pool, p: &str) {
+        let dir = write_dir(&[
+            create_table_mig("0001_a", &format!("{p}_a"), &[&format!("{p}_a")]),
+            create_table_mig(
+                "0002_b",
+                &format!("{p}_b"),
+                &[&format!("{p}_a"), &format!("{p}_b")],
+            ),
+            create_table_mig(
+                "0003_c",
+                &format!("{p}_c"),
+                &[&format!("{p}_a"), &format!("{p}_b"), &format!("{p}_c")],
+            ),
+        ]);
+
+        let rec = Recorder::default();
+        let applied = migrate::migrate_pool_with_progress(pool, &dir, &rec.observer())
+            .await
+            .expect("migrate");
+
+        assert_eq!(applied.len(), 3);
+        assert_eq!(
+            rec.trace(),
+            vec![
+                "planned:3",
+                "start:0001_a:1/3",
+                "done:0001_a:1/3:ran",
+                "start:0002_b:2/3",
+                "done:0002_b:2/3:ran",
+                "start:0003_c:3/3",
+                "done:0003_c:3/3:ran",
+            ],
+            "{:?}",
+            rec.trace()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `Planned` is emitted even when there is nothing to do, so a
+    /// watcher can render "up to date" instead of waiting for events
+    /// that will never come.
+    pub async fn check_up_to_date_run_still_plans(pool: &Pool, p: &str) {
+        let table = format!("{p}_none");
+        let dir = write_dir(&[create_table_mig("0001_a", &table, &[&table])]);
+
+        migrate::migrate_pool(pool, &dir).await.expect("first");
+
+        let rec = Recorder::default();
+        let applied = migrate::migrate_pool_with_progress(pool, &dir, &rec.observer())
+            .await
+            .expect("second");
+
+        assert!(applied.is_empty(), "nothing should be pending");
+        assert_eq!(rec.trace(), vec!["planned:0"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A failure names the migration that died and stops there — the
+    /// whole point, since the old behaviour reported only that
+    /// *something* failed.
+    pub async fn check_failure_names_the_migration(pool: &Pool, p: &str) {
+        // 0002 recreates the table 0001 just made: the second CREATE
+        // TABLE collides, and this is a plain (non-fake-initial) run.
+        let table = format!("{p}_dup");
+        let dir = write_dir(&[
+            create_table_mig("0001_ok", &table, &[&table]),
+            create_table_mig("0002_boom", &table, &[&table]),
+        ]);
+
+        let rec = Recorder::default();
+        let err = migrate::migrate_pool_with_progress(pool, &dir, &rec.observer())
+            .await
+            .expect_err("second migration must collide");
+
+        let trace = rec.trace();
+        assert_eq!(
+            trace,
+            vec![
+                "planned:2",
+                "start:0001_ok:1/2",
+                "done:0001_ok:1/2:ran",
+                "start:0002_boom:2/2",
+                "fail:0002_boom:2/2",
+            ],
+            "{trace:?}"
+        );
+
+        // The event carries the same failure the caller gets, so a
+        // watcher does not have to correlate two sources.
+        let Some(MigrationEvent::Failed { error, .. }) = rec.events().pop() else {
+            panic!("last event should be Failed: {trace:?}");
+        };
+        assert_eq!(error, err.to_string());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The table [`check_faked_is_distinguishable`] migrates. The
+    /// caller creates it first, because raw `CREATE TABLE` is the one
+    /// thing that cannot be shared across dialects.
+    pub fn faked_table(p: &str) -> String {
+        format!("{p}_pre")
+    }
+
+    /// A faked migration must not report as `Ran`. An operator reading
+    /// "applied 0003" and one reading "faked 0003" should reach
+    /// different conclusions about what is in their database.
+    ///
+    /// Precondition: the caller has already created [`faked_table`],
+    /// standing in for the pre-migration era where the table was built
+    /// by the retired lazy `ensure_table` DDL.
+    pub async fn check_faked_is_distinguishable(pool: &Pool, p: &str) {
+        let table = faked_table(p);
+        let dir = write_dir(&[create_table_mig("0001_create", &table, &[&table])]);
+
+        let rec = Recorder::default();
+        migrate::migrate_pool_with_ledger_fake_initial_with_progress(
+            pool,
+            &dir,
+            SYSTEM_LEDGER,
+            &rec.observer(),
+        )
+        .await
+        .expect("fake-initial migrate");
+
+        assert_eq!(
+            rec.trace(),
+            vec![
+                "planned:1",
+                "start:0001_create:1/1",
+                "done:0001_create:1/1:faked",
+            ],
+            "a migration recorded without running its DDL must not report as `ran`: {:?}",
+            rec.trace()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The silent path is the one every pre-existing caller takes, and
+    /// it must apply exactly what the observed path applies.
+    ///
+    /// SQLite-only, hence the `allow`: this needs two *independent*
+    /// databases, which two temp files give for free. On PG and MySQL
+    /// one server means one shared `__rustango_migrations__`, so the
+    /// second run would find nothing pending and prove nothing.
+    #[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
+    pub async fn check_observing_changes_nothing(silent: &Pool, watched: &Pool, p: &str) {
+        let dir = write_dir(&[
+            create_table_mig("0001_a", &format!("{p}_s1"), &[&format!("{p}_s1")]),
+            create_table_mig(
+                "0002_b",
+                &format!("{p}_s2"),
+                &[&format!("{p}_s1"), &format!("{p}_s2")],
+            ),
+        ]);
+
+        let quiet = migrate::migrate_pool(silent, &dir).await.expect("silent");
+        let rec = Recorder::default();
+        let loud = migrate::migrate_pool_with_progress(watched, &dir, &rec.observer())
+            .await
+            .expect("watched");
+
+        let names = |ms: &[Migration]| ms.iter().map(|m| m.name.clone()).collect::<Vec<_>>();
+        assert_eq!(names(&quiet), names(&loud));
+        assert_eq!(names(&loud), vec!["0001_a", "0002_b"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(feature = "sqlite")]
+mod sqlite_live {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use rustango::sql::{sqlx, Pool};
+
+    use super::scenarios;
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// A temp *file*, not `:memory:` — every pool connection has to see
+    /// the same database, and the migrate path takes more than one.
+    async fn fresh_pool() -> (Pool, PathBuf) {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let mut path = std::env::temp_dir();
+        path.push(format!("rustango_progress_{}_{n}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let url = format!("sqlite:{}?mode=rwc", path.display());
+        let sq = sqlx::SqlitePool::connect(&url).await.expect("sqlite pool");
+        (Pool::Sqlite(sq), path)
+    }
+
+    fn cleanup(pool: Pool, path: &PathBuf) {
+        drop(pool);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn reports_every_migration_in_order() {
+        let (pool, path) = fresh_pool().await;
+        scenarios::check_reports_every_migration_in_order(&pool, "sqp1").await;
+        cleanup(pool, &path);
+    }
+
+    #[tokio::test]
+    async fn up_to_date_run_still_plans() {
+        let (pool, path) = fresh_pool().await;
+        scenarios::check_up_to_date_run_still_plans(&pool, "sqp2").await;
+        cleanup(pool, &path);
+    }
+
+    #[tokio::test]
+    async fn failure_names_the_migration() {
+        let (pool, path) = fresh_pool().await;
+        scenarios::check_failure_names_the_migration(&pool, "sqp3").await;
+        cleanup(pool, &path);
+    }
+
+    #[tokio::test]
+    async fn faked_is_distinguishable_from_ran() {
+        let (pool, path) = fresh_pool().await;
+        let table = scenarios::faked_table("sqp4");
+        let Pool::Sqlite(sq) = &pool else {
+            unreachable!("fresh_pool builds a sqlite pool")
+        };
+        sqlx::query(&format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY)"))
+            .execute(sq)
+            .await
+            .expect("pre-create");
+        scenarios::check_faked_is_distinguishable(&pool, "sqp4").await;
+        cleanup(pool, &path);
+    }
+
+    #[tokio::test]
+    async fn observing_changes_nothing() {
+        let (silent, p1) = fresh_pool().await;
+        let (watched, p2) = fresh_pool().await;
+        scenarios::check_observing_changes_nothing(&silent, &watched, "sqp5").await;
+        cleanup(silent, &p1);
+        cleanup(watched, &p2);
+    }
+}
+
+#[cfg(feature = "postgres")]
+mod pg_live {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// The migrate path takes a session-scoped `pg_advisory_lock` on a
+    /// fixed key, so two of these running at once would serialise on it
+    /// anyway — and the ledger is shared. Run them one at a time.
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    /// `None` when `DATABASE_URL` is unset — the suite skips rather
+    /// than fails, matching every other `*_pg_live` test here.
+    async fn fresh_pool(prefix: &str) -> Option<Pool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pg = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&url)
+            .await
+            .ok()?;
+        // Each scenario gets its own ledger-free slate: drop anything a
+        // previous run left, including the ledger, so `pending` is the
+        // whole chain again.
+        for t in ["a", "b", "c", "none", "dup", "pre", "s1", "s2"] {
+            let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {prefix}_{t} CASCADE"))
+                .execute(&pg)
+                .await;
+        }
+        for ledger in ["__rustango_migrations__", scenarios::SYSTEM_LEDGER] {
+            let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {ledger} CASCADE"))
+                .execute(&pg)
+                .await;
+        }
+        Some(Pool::Postgres(pg))
+    }
+
+    fn prefix(n: u32) -> String {
+        format!("pgp{n}_{}", COUNTER.fetch_add(1, Ordering::SeqCst))
+    }
+
+    #[tokio::test]
+    async fn reports_every_migration_in_order() {
+        let _g = live_lock().lock().await;
+        let p = prefix(1);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        scenarios::check_reports_every_migration_in_order(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn up_to_date_run_still_plans() {
+        let _g = live_lock().lock().await;
+        let p = prefix(2);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        scenarios::check_up_to_date_run_still_plans(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn failure_names_the_migration() {
+        let _g = live_lock().lock().await;
+        let p = prefix(3);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        scenarios::check_failure_names_the_migration(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn faked_is_distinguishable_from_ran() {
+        let _g = live_lock().lock().await;
+        let p = prefix(4);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let table = scenarios::faked_table(&p);
+        let Pool::Postgres(pg) = &pool else {
+            unreachable!("fresh_pool builds a postgres pool")
+        };
+        sqlx::query(&format!("CREATE TABLE {table} (id BIGSERIAL PRIMARY KEY)"))
+            .execute(pg)
+            .await
+            .expect("pre-create");
+        scenarios::check_faked_is_distinguishable(&pool, &p).await;
+    }
+}
+
+#[cfg(feature = "mysql")]
+mod mysql_live {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::OnceLock;
+
+    use rustango::sql::{sqlx, Pool};
+    use tokio::sync::Mutex;
+
+    use super::scenarios;
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// MySQL's migrate lock is a named `GET_LOCK`, so concurrent runs
+    /// would serialise on it; the ledger is shared besides.
+    fn live_lock() -> &'static Mutex<()> {
+        static M: OnceLock<Mutex<()>> = OnceLock::new();
+        M.get_or_init(|| Mutex::new(()))
+    }
+
+    /// `None` when `MYSQL_TEST_URL` is unset — skip, don't fail.
+    async fn fresh_pool(prefix: &str) -> Option<Pool> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let my = sqlx::mysql::MySqlPoolOptions::new()
+            .max_connections(5)
+            .connect(&url)
+            .await
+            .ok()?;
+        for t in ["a", "b", "c", "none", "dup", "pre", "s1", "s2"] {
+            let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{prefix}_{t}`"))
+                .execute(&my)
+                .await;
+        }
+        for ledger in ["__rustango_migrations__", scenarios::SYSTEM_LEDGER] {
+            let _ = sqlx::query(&format!("DROP TABLE IF EXISTS `{ledger}`"))
+                .execute(&my)
+                .await;
+        }
+        Some(Pool::Mysql(my))
+    }
+
+    fn prefix(n: u32) -> String {
+        format!("myp{n}_{}", COUNTER.fetch_add(1, Ordering::SeqCst))
+    }
+
+    #[tokio::test]
+    async fn reports_every_migration_in_order() {
+        let _g = live_lock().lock().await;
+        let p = prefix(1);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        scenarios::check_reports_every_migration_in_order(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn up_to_date_run_still_plans() {
+        let _g = live_lock().lock().await;
+        let p = prefix(2);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        scenarios::check_up_to_date_run_still_plans(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn failure_names_the_migration() {
+        let _g = live_lock().lock().await;
+        let p = prefix(3);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        scenarios::check_failure_names_the_migration(&pool, &p).await;
+    }
+
+    #[tokio::test]
+    async fn faked_is_distinguishable_from_ran() {
+        let _g = live_lock().lock().await;
+        let p = prefix(4);
+        let Some(pool) = fresh_pool(&p).await else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let table = scenarios::faked_table(&p);
+        let Pool::Mysql(my) = &pool else {
+            unreachable!("fresh_pool builds a mysql pool")
+        };
+        sqlx::query(&format!(
+            "CREATE TABLE `{table}` (id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY)"
+        ))
+        .execute(my)
+        .await
+        .expect("pre-create");
+        scenarios::check_faked_is_distinguishable(&pool, &p).await;
+    }
+}


### PR DESCRIPTION
Closes #1320. Slice 3 of #1317 — the one with no dependencies, and the one that pays off on its own.

## Before

Applying migrations was silent. The runner took the migrate lock, applied every pending file, and returned a `Vec<Migration>` when it was done — not one `writeln!`, callback or per-migration span in it. `migrate_tenants_db` logged one line *per tenant, after that tenant finished*.

So: a fresh tenant is twenty-plus migrations of dead air, and a failure tells you which **tenant** died but never which migration, or how many had already landed.

## After

```
migrating 2 tenant(s)…
[1/2] acme
        applied system/0001_rustango_tenant_initial (0.1s)
        applied app/0001_initial (0.0s)
        applied app/0002_add_bio (0.0s)
[2/2] globex
        faked system/0001_rustango_tenant_initial (0.0s)
        ✗ app/0002_add_bio: relation "bio" already exists
ran tenant migrations against 2 tenant(s); 1 failure(s)
  ✓ acme: 3 migration(s)
  ✗ globex: …
```

`migrate::progress` adds an observer — pending count up front, `Started` / `Finished` per migration with its duration, or `Failed` naming the one that died. Every pre-existing entry point passes no observer and behaves exactly as before.

## Three things worth review attention

**`Faked` is not `Ran`.** The runner has three apply paths: run the DDL, run it skipping tables that already exist (`RunPartial`), or record it in the ledger *without running anything* (`--fake-initial` reconciliation, #1167/#1174). Collapsing those into "applied" is how an operator comes to believe DDL ran that never did, so `Outcome` keeps them apart and the CLI prints `faked`.

**Both of a tenant's chains report, tagged.** A tenant migrates the framework's `system/migrations/` chain and then the project's own, into separate ledgers, numbered independently — so **`0001_initial` legitimately lands twice in one tenant's run**. `Chain` says which, rendered `system/…` vs `app/…`. Without it the second one reads as a migration that ran twice.

**Observers must not block, and the docs say why.** Events are emitted from inside the migrate lock (`pg_advisory_lock` / `GET_LOCK`), so a slow observer stalls every other pod trying to migrate. The CLI's own observer writes to the verb's writer, which is the one legitimate exception — one process, one operator, and a stall delays only their own migration. That reasoning is written down where it applies rather than left implicit.

## Tri-dialect, not Postgres-shaped

Both apply loops are instrumented: the tri-dialect `migrate_pool_with_ledger_opts` (on `crate::sql::Pool`) and the PG-typed `migrate_with_ledger` — the latter separately, because it fires the `pre_migrate` / `post_migrate` signals and uses the PG-typed ledger helpers, so it cannot simply be routed through the other. Both tenant fan-outs (`migrate_tenants_db`, and PG's `migrate_tenants` which also handles schema-mode) report too.

Nothing new is gated on `postgres` except the two shims that take a `&PgPool` by signature (`migrate_with_progress`, `migrate_tenants_with_progress`) — mirroring the existing `migrate` / `migrate_tenants` gating.

## API

Additive only; no existing signature changed.

| new | notes |
|---|---|
| `migrate::progress` (`MigrationEvent`, `Outcome`, `MigrationObserver`) | ungated; `MigrationObserver` is blanket-impl'd for `Fn(MigrationEvent)` so a closure works |
| `migrate_pool_with_progress` | ungated, tri-dialect |
| `migrate_pool_with_ledger_fake_initial_with_progress` | ungated; the path where `Faked` actually appears |
| `migrate_with_progress` | `#[cfg(postgres)]` — takes `&PgPool` |
| `tenancy::{Chain, TenantMigrationEvent, TenantMigrationObserver}` | ungated |
| `migrate_tenants_db_with_progress` | ungated, tri-dialect |
| `migrate_tenants_with_progress` | `#[cfg(postgres)]` |

## Verification

- **13 new tests against live Postgres 16, MySQL 8 and SQLite** — one file, shared scenario bodies, three cfg-gated backend modules (the `django6_*` pattern). PG reads `DATABASE_URL`, MySQL `MYSQL_TEST_URL`, both skip when unset.
- `manage_live` 13/13 against PG, including a **new assertion that the verb really emits per-migration lines** — the acceptance criterion, not just the plumbing.
- The five pre-existing migration suites (19 tests) pass **untouched** — that is the proof the silent path is unchanged. One test asserts it directly: same migration dir, two fresh databases, silent vs observed, identical result.
- 3629 lib tests.
- Zero new warnings on `sqlite` / `postgres` / `mysql` / each `+tenancy` / `+signals` / `+testkit` / `--all-features --tests`, plus `--workspace --all-features --no-run` and `cargo fmt --check`.

## What this unblocks

#1321 (persist provisioning runs) and #1322 (the streamed operator console) both need something to stream; this is it. #1223 wants the same per-tenant observability.