### PR TITLE
refactor(tenancy): extract a provisioning engine from the create-tenant verb

### DIFF
--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -8,32 +8,26 @@ use std::path::Path;
 use sqlx::Database;
 
 use crate::core::Column as _;
-use crate::sql::{Auto, FetcherPool, UpdaterPool};
+use crate::sql::{FetcherPool, UpdaterPool};
 
 use crate::tenancy::error::TenancyError;
 #[cfg(feature = "postgres")]
 use crate::tenancy::manage::args::quote_ident;
 use crate::tenancy::manage::args::{next_value, reject_leading_flag};
 use crate::tenancy::manage_interactive;
-use crate::tenancy::migrate as tenant_migrate;
 use crate::tenancy::org::{BackendKind, Org, StorageMode};
 use crate::tenancy::pools::TenantPools;
+use crate::tenancy::provision;
 
 // ---------- create-tenant ----------
 
-struct CreateTenantArgs {
-    slug: String,
-    mode: StorageMode,
-    backend: BackendKind,
-    display_name: Option<String>,
-    database_url: Option<String>,
-    schema_name: Option<String>,
-    host_pattern: Option<String>,
-    port: Option<i32>,
-    path_prefix: Option<String>,
-    no_migrate: bool,
-}
-
+/// The verb: turn `argv` into a [`ProvisionRequest`], run the engine,
+/// print what happens.
+///
+/// Everything that is not about a command line lives in
+/// [`crate::tenancy::provision`] — so an HTTP handler, a webhook or a
+/// job can stand up a tenant without faking an `argv` and handing it a
+/// `Vec<u8>` to write into.
 pub(super) async fn create_tenant<W: Write + Send, DB: Database>(
     pools: &TenantPools<DB>,
     registry_url: &str,
@@ -44,152 +38,92 @@ pub(super) async fn create_tenant<W: Write + Send, DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
-    let parsed = parse_create_tenant_args(args)?;
+    let request = parse_create_tenant_args(args)?;
 
-    // Reject duplicate slug up front — saves a partial-state mess
-    // when CREATE SCHEMA succeeds and the INSERT then fails.
-    let registry = pools.registry_pool();
-    let existing: Vec<Org> = Org::objects()
-        .where_(Org::slug.eq(parsed.slug.clone()))
-        .fetch(&registry)
-        .await?;
-    if !existing.is_empty() {
-        return Err(TenancyError::Validation(format!(
-            "tenant slug `{}` already exists",
-            parsed.slug
-        )));
-    }
-
-    // Compute defaults that depend on the slug + apex env var.
-    let host_pattern = parsed.host_pattern.clone().or_else(|| {
-        std::env::var("RUSTANGO_APEX_DOMAIN")
-            .ok()
-            .map(|apex| format!("{}.{apex}", parsed.slug))
-    });
-    let display_name = parsed
-        .display_name
-        .clone()
-        .unwrap_or_else(|| parsed.slug.clone());
-    let schema_name = match parsed.mode {
-        StorageMode::Schema => Some(
-            parsed
-                .schema_name
-                .clone()
-                .unwrap_or_else(|| parsed.slug.clone()),
-        ),
-        StorageMode::Database => None,
+    // Steps print as they happen rather than from the outcome, because
+    // "created tenant …" has always appeared *before* the migrations,
+    // and the summary after them.
+    let progress = CreateTenantProgress {
+        out: std::sync::Mutex::new(w),
+        slug: request.slug.clone(),
+        mode: request.mode,
     };
+    let outcome =
+        provision::provision_tenant(pools, registry_url, dir, &request, Some(&progress)).await?;
 
-    if parsed.mode == StorageMode::Database && parsed.database_url.is_none() {
-        return Err(TenancyError::Validation(
-            "create-tenant --mode database requires --database-url".into(),
-        ));
-    }
-
-    // Schema-mode: create the schema before inserting the row so
-    // a failed INSERT doesn't leave an orphan schema. Idempotent
-    // via IF NOT EXISTS.
-    if let StorageMode::Schema = parsed.mode {
-        // Schema mode is PG-only by language — `CREATE SCHEMA` /
-        // `SET search_path` don't exist on sqlite or mysql.
-        #[cfg(feature = "postgres")]
-        {
-            let pg_pools = (pools as &dyn std::any::Any)
-                .downcast_ref::<TenantPools<sqlx::Postgres>>()
-                .ok_or_else(|| {
-                    TenancyError::Validation(
-                        "schema-mode tenants require a Postgres registry — pass --mode database \
-                         on sqlite/mysql"
-                            .into(),
-                    )
-                })?;
-            let schema = schema_name.as_deref().unwrap_or(&parsed.slug);
-            let sql = format!("CREATE SCHEMA IF NOT EXISTS {}", quote_ident(schema));
-            rustango::sql::sqlx::query(&sql)
-                .execute(pg_pools.registry())
-                .await?;
-        }
-        #[cfg(not(feature = "postgres"))]
-        {
-            return Err(TenancyError::Validation(
-                "schema-mode tenants require the `postgres` feature — pass --mode database \
-                 on sqlite/mysql builds"
-                    .into(),
-            ));
-        }
-    }
-
-    let mut org = Org {
-        id: Auto::default(),
-        slug: parsed.slug.clone(),
-        display_name,
-        storage_mode: parsed.mode.as_str().into(),
-        backend_kind: parsed.backend.as_str().into(),
-        database_url: parsed.database_url.clone(),
-        schema_name,
-        host_pattern,
-        port: parsed.port,
-        path_prefix: parsed.path_prefix.clone(),
-        active: true,
-        created_at: chrono::Utc::now(),
-        brand_name: None,
-        brand_tagline: None,
-        logo_path: None,
-        favicon_path: None,
-        primary_color: None,
-        theme_mode: None,
-    };
-    org.insert_pool(&registry).await?;
-    // This pod sees the new tenant immediately; others converge on the
-    // registry fingerprint (see `resolver::sync_org_generation`).
-    super::super::invalidate_org_cache();
-    let id = org.id.get().copied().unwrap_or_default();
-    writeln!(
-        w,
-        "created tenant `{}` (id {id}, mode {})",
-        parsed.slug, parsed.mode
-    )?;
-
-    // Run tenant migrations against the freshly-provisioned tenant
-    // unless --no-migrate.
-    if parsed.no_migrate {
-        writeln!(w, "  --no-migrate: skipping tenant migrations")?;
-        return Ok(());
-    }
-    writeln!(w, "  applying tenant migrations…")?;
-    // v0.38 — on PG go through `migrate_tenants` (schema-mode +
-    // database-mode); on sqlite/mysql use `migrate_tenants_db`
-    // (database-mode only).
-    #[cfg(feature = "postgres")]
-    let report = {
-        if let Some(pg_pools) =
-            (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
-        {
-            tenant_migrate::migrate_tenants(pg_pools, dir, registry_url).await?
-        } else {
-            tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?
-        }
-    };
-    #[cfg(not(feature = "postgres"))]
-    let report = tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?;
-    let outcome = report.tenants.iter().find(|t| t.slug == parsed.slug);
-    match outcome {
-        Some(o) => {
-            if let Some(err) = &o.error {
-                writeln!(w, "  migration failed: {err}")?;
-            } else {
-                writeln!(w, "  applied {} migration(s)", o.applied.len())?;
-                for m in &o.applied {
-                    writeln!(w, "    + {}", m.name)?;
-                }
+    let w = progress.into_inner();
+    match &outcome.migrations {
+        // The observer already printed the `--no-migrate` line; the
+        // verb has never followed it with a summary.
+        provision::MigrationsOutcome::Skipped => {}
+        provision::MigrationsOutcome::Failed(err) => writeln!(w, "  migration failed: {err}")?,
+        provision::MigrationsOutcome::Applied(applied) => {
+            writeln!(w, "  applied {} migration(s)", applied.len())?;
+            for m in applied {
+                writeln!(w, "    + {}", m.name)?;
             }
         }
-        None => writeln!(w, "  no migrations matched this tenant")?,
+        provision::MigrationsOutcome::NotMatched => {
+            writeln!(w, "  no migrations matched this tenant")?;
+        }
     }
     Ok(())
 }
 
-fn parse_create_tenant_args(args: &[String]) -> Result<CreateTenantArgs, TenancyError> {
+/// Renders the engine's step events as the lines `create-tenant` has
+/// always printed.
+///
+/// The `Mutex` bridges an observer's `&self` to the verb's `&mut W`; it
+/// is uncontended, since the engine emits from one task. See
+/// `CliProgress` in `manage::migrations` for the same reasoning about
+/// why writing here does not violate the must-not-block contract.
+struct CreateTenantProgress<'w, W> {
+    out: std::sync::Mutex<&'w mut W>,
+    slug: String,
+    mode: StorageMode,
+}
+
+impl<'w, W: Write + Send> CreateTenantProgress<'w, W> {
+    fn into_inner(self) -> &'w mut W {
+        self.out.into_inner().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<W: Write + Send> provision::ProvisionObserver for CreateTenantProgress<'_, W> {
+    fn on_event(&self, event: provision::ProvisionEvent) {
+        use provision::{ProvisionEvent as E, ProvisionStep as S, StepStatus};
+
+        let Ok(mut out) = self.out.lock() else {
+            return;
+        };
+        // Progress is cosmetic; a broken pipe must not fail the verb.
+        let _ = match event {
+            E::Registered { org_id } => writeln!(
+                out,
+                "created tenant `{}` (id {org_id}, mode {})",
+                self.slug, self.mode
+            ),
+            E::Step {
+                step: S::Migrate,
+                status: StepStatus::Started,
+            } => writeln!(out, "  applying tenant migrations…"),
+            E::Step {
+                step: S::Migrate,
+                status: StepStatus::Skipped(_),
+            } => writeln!(out, "  --no-migrate: skipping tenant migrations"),
+            // Validation and storage failures come back as `Err` from
+            // the engine and are rendered by the caller; the remaining
+            // steps are detail the CLI has never printed.
+            _ => Ok(()),
+        };
+        let _ = out.flush();
+    }
+}
+
+/// `argv` → [`ProvisionRequest`]. The only place that knows
+/// `--no-migrate` exists: a negative flag is right for a command line
+/// and wrong for a struct field, so it is inverted on the way in.
+fn parse_create_tenant_args(args: &[String]) -> Result<provision::ProvisionRequest, TenancyError> {
     const HELP: &str = "create-tenant <slug> [--mode schema|database] \
         [--backend postgres|mysql|sqlite] [--display-name <s>] \
         [--database-url <url>] [--schema-name <s>] [--host-pattern <s>] \
@@ -205,7 +139,7 @@ fn parse_create_tenant_args(args: &[String]) -> Result<CreateTenantArgs, Tenancy
                 TenancyError::Validation("create-tenant requires a slug positional argument".into())
             })?,
     };
-    let mut out = CreateTenantArgs {
+    let mut out = provision::ProvisionRequest {
         slug,
         mode: StorageMode::Schema,
         backend: BackendKind::Postgres,
@@ -215,7 +149,7 @@ fn parse_create_tenant_args(args: &[String]) -> Result<CreateTenantArgs, Tenancy
         host_pattern: None,
         port: None,
         path_prefix: None,
-        no_migrate: false,
+        run_migrations: true,
     };
     while let Some(flag) = iter.next() {
         match flag.as_str() {
@@ -246,7 +180,7 @@ fn parse_create_tenant_args(args: &[String]) -> Result<CreateTenantArgs, Tenancy
                 })?);
             }
             "--path-prefix" => out.path_prefix = Some(next_value(&mut iter, "--path-prefix")?),
-            "--no-migrate" => out.no_migrate = true,
+            "--no-migrate" => out.run_migrations = false,
             "--help" | "-h" => return Err(TenancyError::Validation(HELP.to_owned())),
             other => {
                 return Err(TenancyError::Validation(format!(

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -99,6 +99,9 @@ mod pools;
 /// Who a request is acting as, whatever authenticated it (session cookie,
 /// Bearer access token, MCP agent token).
 pub mod principal;
+/// Standing up a tenant — the steps the `create-tenant` verb runs,
+/// callable from anything that is not a terminal.
+pub mod provision;
 mod resolver;
 mod resolver_cache;
 pub mod routes;

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -1,0 +1,522 @@
+//! Standing up a tenant: the steps, in order, with nothing about a
+//! terminal in them.
+//!
+//! These steps used to live inside the `create-tenant` verb, welded to a
+//! CLI by three things — a `pub(super)` visibility, an `args: &[String]`
+//! it parsed itself, and a `W: Write` it reported through. Anything that
+//! is not a terminal (an HTTP handler, a webhook, a job) would have had
+//! to fake an `argv` and hand it a `Vec<u8>`.
+//!
+//! So the sequence moves here and the verb keeps what is genuinely a
+//! CLI's job: turning `argv` into a [`ProvisionRequest`], and rendering
+//! [`ProvisionEvent`]s as lines of text.
+//!
+//! ## The steps
+//!
+//! 1. [`Validate`](ProvisionStep::Validate) — slug, mode and backend
+//!    agree with each other and with this build.
+//! 2. [`CheckConnection`](ProvisionStep::CheckConnection) — **not
+//!    implemented yet** (#1319). It reports
+//!    [`Skipped`](StepStatus::Skipped) so the shape is visible in the
+//!    stream from the start, rather than appearing later and changing
+//!    what a watcher has to handle.
+//! 3. [`ProvisionStorage`](ProvisionStep::ProvisionStorage) —
+//!    `CREATE SCHEMA` for schema-mode. Deliberately before the row
+//!    lands, so a failed `INSERT` leaves no orphan schema.
+//! 4. [`RegisterOrg`](ProvisionStep::RegisterOrg) — the `rustango_orgs`
+//!    row, after which the tenant resolves.
+//! 5. [`Migrate`](ProvisionStep::Migrate) — the tenant's own schema.
+//!
+//! ## What is deliberately still wrong here
+//!
+//! Step 5 migrates **every active tenant**, then filters the report down
+//! to the one just created. That is what the verb has always done, and
+//! changing it is not this refactor's business — but it means creating
+//! tenant B does a pass over tenant A, and an unrelated tenant's broken
+//! chain shows up in the middle of an unrelated provisioning run. See
+//! the parent epic.
+
+use std::path::Path;
+
+use sqlx::Database;
+
+use crate::core::Column as _;
+use crate::migrate::file::Migration;
+use crate::sql::{Auto, FetcherPool};
+
+use super::error::TenancyError;
+use super::migrate as tenant_migrate;
+use super::org::{BackendKind, Org, StorageMode};
+use super::pools::TenantPools;
+
+/// Everything needed to stand up one tenant.
+///
+/// The CLI's own argument struct, made public and given one rename:
+/// `no_migrate` became [`run_migrations`](Self::run_migrations). A
+/// negative flag is right for a command line, where the default is
+/// "yes" and you opt out; it is wrong for a struct field, where every
+/// reader has to hold an extra negation.
+#[derive(Debug, Clone)]
+pub struct ProvisionRequest {
+    /// Globally unique. Also the default schema name, display name, and
+    /// subdomain label.
+    pub slug: String,
+    pub mode: StorageMode,
+    pub backend: BackendKind,
+    /// Defaults to the slug.
+    pub display_name: Option<String>,
+    /// Required in database-mode; meaningless in schema-mode.
+    pub database_url: Option<String>,
+    /// Schema-mode only; defaults to the slug.
+    pub schema_name: Option<String>,
+    /// Defaults to `<slug>.<RUSTANGO_APEX_DOMAIN>` when that env var is
+    /// set, and to nothing when it is not.
+    pub host_pattern: Option<String>,
+    pub port: Option<i32>,
+    pub path_prefix: Option<String>,
+    /// Run the tenant's migrations once the row is in place.
+    pub run_migrations: bool,
+}
+
+impl ProvisionRequest {
+    /// A database-mode request with everything else defaulted.
+    #[must_use]
+    pub fn database(slug: impl Into<String>, database_url: impl Into<String>) -> Self {
+        Self {
+            slug: slug.into(),
+            mode: StorageMode::Database,
+            backend: BackendKind::default(),
+            display_name: None,
+            database_url: Some(database_url.into()),
+            schema_name: None,
+            host_pattern: None,
+            port: None,
+            path_prefix: None,
+            run_migrations: true,
+        }
+    }
+}
+
+/// One stage of provisioning, reportable on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisionStep {
+    /// Slug is free; mode, backend and build agree.
+    Validate,
+    /// Reach the target database before writing anything. Not
+    /// implemented yet — see #1319.
+    CheckConnection,
+    /// `CREATE SCHEMA` for schema-mode. Nothing to do in database-mode.
+    ProvisionStorage,
+    /// Insert the `rustango_orgs` row.
+    RegisterOrg,
+    /// Apply the tenant's migrations.
+    Migrate,
+}
+
+/// How a step went.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepStatus {
+    Started,
+    Ok,
+    /// Nothing to do, and why — a database-mode tenant has no schema to
+    /// create, a caller asked for no migrations, a step is not built
+    /// yet. Distinct from `Ok` so a console can grey it out rather than
+    /// claim work that never happened.
+    Skipped(String),
+    /// The run stops here.
+    Failed(String),
+}
+
+/// Something that happened while provisioning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProvisionEvent {
+    Step {
+        step: ProvisionStep,
+        status: StepStatus,
+    },
+    /// The row landed and the tenant now resolves. Separate from
+    /// `Step { RegisterOrg, Ok }` because it carries the id, which is
+    /// the one thing a caller cannot compute for itself.
+    Registered { org_id: i64 },
+    /// A migration-level event from the tenant's own run — forwarded
+    /// straight through, so a caller watching provisioning sees the
+    /// same per-migration detail `manage migrate` prints.
+    Migration(tenant_migrate::TenantMigrationEvent),
+}
+
+/// Receives [`ProvisionEvent`]s as a run progresses.
+///
+/// Implemented for any `Fn(ProvisionEvent)`, so a closure works
+/// directly. **Must not block**: the migration events forwarded through
+/// it are emitted with the tenant's migrate lock held. See
+/// [`crate::migrate::progress`].
+pub trait ProvisionObserver: Send + Sync {
+    /// Handle one event. Must return promptly and must not panic.
+    fn on_event(&self, event: ProvisionEvent);
+}
+
+impl<F> ProvisionObserver for F
+where
+    F: Fn(ProvisionEvent) + Send + Sync,
+{
+    fn on_event(&self, event: ProvisionEvent) {
+        self(event);
+    }
+}
+
+/// What the tenant's migration step did.
+#[derive(Debug, Clone)]
+pub enum MigrationsOutcome {
+    /// The caller asked for no migrations.
+    Skipped,
+    /// The batch ran, but its report had no row for this tenant —
+    /// usually a migration directory with nothing tenant-scoped in it.
+    NotMatched,
+    Applied(Vec<Migration>),
+    /// The tenant's chain failed. **Not** returned as an `Err`: the row
+    /// exists and the caller needs to know that, which an error return
+    /// would hide.
+    Failed(String),
+}
+
+/// The result of a completed provisioning run.
+#[derive(Debug, Clone)]
+pub struct ProvisionOutcome {
+    pub org_id: i64,
+    pub slug: String,
+    pub mode: StorageMode,
+    pub migrations: MigrationsOutcome,
+}
+
+fn emit(observer: Option<&dyn ProvisionObserver>, event: impl FnOnce() -> ProvisionEvent) {
+    if let Some(observer) = observer {
+        observer.on_event(event());
+    }
+}
+
+fn step(observer: Option<&dyn ProvisionObserver>, step: ProvisionStep, status: StepStatus) {
+    emit(observer, || ProvisionEvent::Step { step, status });
+}
+
+/// Report a step's failure to the observer, then return the error.
+///
+/// Every failure path goes through this rather than a bare `?`, so a
+/// watcher never sees a step stuck on `Started` with no explanation —
+/// which is the state the whole event stream exists to prevent.
+fn fail<T>(
+    observer: Option<&dyn ProvisionObserver>,
+    at: ProvisionStep,
+    e: TenancyError,
+) -> Result<T, TenancyError> {
+    step(observer, at, StepStatus::Failed(e.to_string()));
+    Err(e)
+}
+
+/// Stand up a tenant: validate, provision its storage, register it, and
+/// migrate it.
+///
+/// The CLI verb is a thin wrapper over this. So is anything else that
+/// needs to create a tenant.
+///
+/// # Errors
+/// Returns `Err` if the slug is taken, the request is internally
+/// inconsistent (database-mode without a URL, schema-mode on a non-PG
+/// build), the schema could not be created, or the row could not be
+/// inserted. A **migration** failure is not an error — the tenant
+/// exists at that point, so it comes back in
+/// [`ProvisionOutcome::migrations`] as
+/// [`MigrationsOutcome::Failed`].
+pub async fn provision_tenant<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    dir: &Path,
+    request: &ProvisionRequest,
+    observer: Option<&dyn ProvisionObserver>,
+) -> Result<ProvisionOutcome, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    // ---- 1. Validate ----
+    step(observer, ProvisionStep::Validate, StepStatus::Started);
+    let registry = pools.registry_pool();
+
+    // Reject a duplicate slug up front — it saves a partial-state mess
+    // where `CREATE SCHEMA` succeeds and the `INSERT` then fails.
+    let existing: Vec<Org> = match Org::objects()
+        .where_(Org::slug.eq(request.slug.clone()))
+        .fetch(&registry)
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => return fail(observer, ProvisionStep::Validate, e.into()),
+    };
+    if !existing.is_empty() {
+        return fail(
+            observer,
+            ProvisionStep::Validate,
+            TenancyError::Validation(format!("tenant slug `{}` already exists", request.slug)),
+        );
+    }
+
+    if request.mode == StorageMode::Database && request.database_url.is_none() {
+        return fail(
+            observer,
+            ProvisionStep::Validate,
+            TenancyError::Validation(
+                "create-tenant --mode database requires --database-url".into(),
+            ),
+        );
+    }
+    step(observer, ProvisionStep::Validate, StepStatus::Ok);
+
+    // ---- 2. Check the connection ----
+    //
+    // The step exists in the stream from day one even though it does
+    // nothing: a watcher written against today's events keeps working
+    // when #1319 fills it in, instead of suddenly meeting a stage it
+    // has never seen.
+    step(
+        observer,
+        ProvisionStep::CheckConnection,
+        StepStatus::Skipped("connection pre-flight is not implemented yet (#1319)".into()),
+    );
+
+    let schema_name = schema_name_for(request);
+
+    // ---- 3. Provision storage ----
+    //
+    // Before the row, not after: a failed `INSERT` must not leave an
+    // orphan schema behind. Idempotent via `IF NOT EXISTS`.
+    match request.mode {
+        StorageMode::Schema => {
+            step(
+                observer,
+                ProvisionStep::ProvisionStorage,
+                StepStatus::Started,
+            );
+            let schema = schema_name.as_deref().unwrap_or(&request.slug);
+            if let Err(e) = provision_schema(pools, schema).await {
+                return fail(observer, ProvisionStep::ProvisionStorage, e);
+            }
+            step(observer, ProvisionStep::ProvisionStorage, StepStatus::Ok);
+        }
+        StorageMode::Database => step(
+            observer,
+            ProvisionStep::ProvisionStorage,
+            StepStatus::Skipped("database-mode tenants bring their own database".into()),
+        ),
+    }
+
+    // ---- 4. Register the org ----
+    step(observer, ProvisionStep::RegisterOrg, StepStatus::Started);
+    let mut org = new_org_row(request, schema_name);
+    if let Err(e) = org.insert_pool(&registry).await {
+        return fail(observer, ProvisionStep::RegisterOrg, e.into());
+    }
+    // This pod sees the new tenant immediately; others converge on the
+    // registry fingerprint (see `resolver::sync_org_generation`).
+    super::invalidate_org_cache();
+    let org_id = org.id.get().copied().unwrap_or_default();
+    step(observer, ProvisionStep::RegisterOrg, StepStatus::Ok);
+    emit(observer, || ProvisionEvent::Registered { org_id });
+
+    // ---- 5. Migrate ----
+    let migrations = if request.run_migrations {
+        step(observer, ProvisionStep::Migrate, StepStatus::Started);
+        let outcome = migrate_new_tenant(pools, registry_url, dir, &request.slug, observer).await?;
+        match &outcome {
+            MigrationsOutcome::Failed(e) => {
+                step(
+                    observer,
+                    ProvisionStep::Migrate,
+                    StepStatus::Failed(e.clone()),
+                );
+            }
+            _ => step(observer, ProvisionStep::Migrate, StepStatus::Ok),
+        }
+        outcome
+    } else {
+        step(
+            observer,
+            ProvisionStep::Migrate,
+            StepStatus::Skipped("caller asked for no migrations".into()),
+        );
+        MigrationsOutcome::Skipped
+    };
+
+    Ok(ProvisionOutcome {
+        org_id,
+        slug: request.slug.clone(),
+        mode: request.mode,
+        migrations,
+    })
+}
+
+/// The schema a schema-mode tenant lives in: whatever the request
+/// named, or the slug. `None` in database-mode, which has no schema.
+fn schema_name_for(request: &ProvisionRequest) -> Option<String> {
+    match request.mode {
+        StorageMode::Schema => Some(
+            request
+                .schema_name
+                .clone()
+                .unwrap_or_else(|| request.slug.clone()),
+        ),
+        StorageMode::Database => None,
+    }
+}
+
+/// The registry row for a validated request, slug-derived defaults
+/// filled in.
+///
+/// `host_pattern` is the interesting one: an unset pattern becomes
+/// `<slug>.<RUSTANGO_APEX_DOMAIN>` when that env var is set, and stays
+/// unset when it is not — a tenant with no host pattern simply does not
+/// resolve by subdomain.
+fn new_org_row(request: &ProvisionRequest, schema_name: Option<String>) -> Org {
+    Org {
+        id: Auto::default(),
+        slug: request.slug.clone(),
+        display_name: request
+            .display_name
+            .clone()
+            .unwrap_or_else(|| request.slug.clone()),
+        storage_mode: request.mode.as_str().into(),
+        backend_kind: request.backend.as_str().into(),
+        database_url: request.database_url.clone(),
+        schema_name,
+        host_pattern: request.host_pattern.clone().or_else(|| {
+            std::env::var("RUSTANGO_APEX_DOMAIN")
+                .ok()
+                .map(|apex| format!("{}.{apex}", request.slug))
+        }),
+        port: request.port,
+        path_prefix: request.path_prefix.clone(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        brand_name: None,
+        brand_tagline: None,
+        logo_path: None,
+        favicon_path: None,
+        primary_color: None,
+        theme_mode: None,
+    }
+}
+
+/// `CREATE SCHEMA IF NOT EXISTS` on the registry.
+///
+/// Schema-mode is Postgres-only **by language**: `CREATE SCHEMA` and
+/// `SET search_path` do not exist on `SQLite` or `MySQL`. So there are
+/// two distinct refusals, and they say different things:
+///
+/// * this build has no `postgres` feature at all, or
+/// * it does, but these `TenantPools<DB>` are not holding a PG pool —
+///   which only a runtime downcast can tell us, since `DB` is generic.
+async fn provision_schema<DB: Database>(
+    pools: &TenantPools<DB>,
+    schema: &str,
+) -> Result<(), TenancyError> {
+    #[cfg(feature = "postgres")]
+    {
+        use crate::sql::Dialect as _;
+
+        let pg_pools = (pools as &dyn std::any::Any)
+            .downcast_ref::<TenantPools<sqlx::Postgres>>()
+            .ok_or_else(|| {
+                TenancyError::Validation(
+                    "schema-mode tenants require a Postgres registry — pass --mode database \
+                     on sqlite/mysql"
+                        .into(),
+                )
+            })?;
+        // The dialect's own quoter, not a local copy: it is the
+        // canonical one, and it doubles any embedded `"` so a schema
+        // name straight from a request survives quoting intact.
+        let sql = format!(
+            "CREATE SCHEMA IF NOT EXISTS {}",
+            crate::sql::Postgres.quote_ident(schema)
+        );
+        rustango::sql::sqlx::query(&sql)
+            .execute(pg_pools.registry())
+            .await?;
+        Ok(())
+    }
+    #[cfg(not(feature = "postgres"))]
+    {
+        let _ = (pools, schema);
+        Err(TenancyError::Validation(
+            "schema-mode tenants require the `postgres` feature — pass --mode database \
+             on sqlite/mysql builds"
+                .into(),
+        ))
+    }
+}
+
+/// Migrate the tenant that was just created.
+///
+/// Runs the whole active-tenant batch and then picks this slug out of
+/// the report — see the module docs for why that is more work than it
+/// should be.
+async fn migrate_new_tenant<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    dir: &Path,
+    slug: &str,
+    observer: Option<&dyn ProvisionObserver>,
+) -> Result<MigrationsOutcome, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    // Forward every migration event straight through, so a caller
+    // watching a provisioning run sees the same per-migration detail
+    // `manage migrate` prints (#1320).
+    let forward = observer.map(|observer| {
+        move |event: tenant_migrate::TenantMigrationEvent| {
+            observer.on_event(ProvisionEvent::Migration(event));
+        }
+    });
+    let forward = forward
+        .as_ref()
+        .map(|f| f as &dyn tenant_migrate::TenantMigrationObserver);
+
+    // v0.38 — on PG go through `migrate_tenants` (schema-mode +
+    // database-mode); on sqlite/mysql use `migrate_tenants_db`
+    // (database-mode only).
+    #[cfg(feature = "postgres")]
+    let report = {
+        if let Some(pg_pools) =
+            (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
+        {
+            match forward {
+                Some(o) => {
+                    tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, o)
+                        .await?
+                }
+                None => tenant_migrate::migrate_tenants(pg_pools, dir, registry_url).await?,
+            }
+        } else {
+            match forward {
+                Some(o) => {
+                    tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, o)
+                        .await?
+                }
+                None => tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?,
+            }
+        }
+    };
+    #[cfg(not(feature = "postgres"))]
+    let report = match forward {
+        Some(o) => {
+            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, o).await?
+        }
+        None => tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?,
+    };
+
+    Ok(match report.tenants.into_iter().find(|t| t.slug == slug) {
+        Some(o) => match o.error {
+            Some(e) => MigrationsOutcome::Failed(e.to_string()),
+            None => MigrationsOutcome::Applied(o.applied),
+        },
+        None => MigrationsOutcome::NotMatched,
+    })
+}

--- a/crates/rustango/tests/provision_sqlite_live.rs
+++ b/crates/rustango/tests/provision_sqlite_live.rs
@@ -1,0 +1,335 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! The provisioning engine, driven directly (#1318).
+//!
+//! The point of extracting it is that a caller who is not a terminal can
+//! stand up a tenant — so these drive `provision_tenant` with **no
+//! `argv` and no `Write`**, which is exactly what the operator console
+//! (#1322) and the provisioning webhook (#1323) will do.
+//!
+//! SQLite on a temp file, so every pool connection sees the same DB.
+
+use std::sync::Mutex;
+
+use rustango::sql::{sqlx, FetcherPool as _};
+use rustango::tenancy::provision::{
+    self, MigrationsOutcome, ProvisionEvent, ProvisionRequest, ProvisionStep, StepStatus,
+};
+use rustango::tenancy::TenantPools;
+
+async fn registry() -> (TenantPools<sqlx::Sqlite>, String, tempfile::TempDir) {
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tmpdir.path().join("registry.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let pool = sqlx::SqlitePool::connect(&url)
+        .await
+        .expect("sqlite connect");
+    (TenantPools::<sqlx::Sqlite>::new(pool), url, tmpdir)
+}
+
+/// Stand the registry tables up the way the CLI does.
+async fn migrate_registry(pools: &TenantPools<sqlx::Sqlite>, url: &str, dir: &std::path::Path) {
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools,
+        url,
+        dir,
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+}
+
+#[derive(Default)]
+struct Recorder(Mutex<Vec<ProvisionEvent>>);
+
+impl Recorder {
+    fn observer(&self) -> impl provision::ProvisionObserver + '_ {
+        move |e: ProvisionEvent| self.0.lock().unwrap().push(e)
+    }
+
+    /// Step transitions only — migration events are #1320's business
+    /// and are asserted there.
+    fn steps(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|e| match e {
+                ProvisionEvent::Step { step, status } => {
+                    let s = match status {
+                        StepStatus::Started => "started",
+                        StepStatus::Ok => "ok",
+                        StepStatus::Skipped(_) => "skipped",
+                        StepStatus::Failed(_) => "failed",
+                    };
+                    Some(format!("{step:?}:{s}"))
+                }
+                ProvisionEvent::Registered { .. } => Some("registered".to_owned()),
+                ProvisionEvent::Migration(_) => None,
+            })
+            .collect()
+    }
+}
+
+/// The headline: a tenant created with no `argv` and no `Write`.
+#[tokio::test]
+async fn the_engine_provisions_without_argv_or_a_writer() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("acme.db");
+    let request =
+        ProvisionRequest::database("acme", format!("sqlite://{}?mode=rwc", tenant_db.display()));
+
+    let rec = Recorder::default();
+    let outcome = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect("provision");
+
+    assert_eq!(outcome.slug, "acme");
+    assert!(outcome.org_id > 0, "org id should come back: {outcome:?}");
+
+    // Every step reports, in order, and the not-yet-built one reports
+    // as skipped rather than silently not existing.
+    assert_eq!(
+        rec.steps(),
+        vec![
+            "Validate:started",
+            "Validate:ok",
+            "CheckConnection:skipped",
+            "ProvisionStorage:skipped",
+            "RegisterOrg:started",
+            "RegisterOrg:ok",
+            "registered",
+            "Migrate:started",
+            "Migrate:ok",
+        ],
+        "{:?}",
+        rec.steps()
+    );
+
+    // The tenant actually resolves now.
+    let orgs = rustango::tenancy::Org::objects()
+        .fetch(&pools.registry_pool())
+        .await
+        .expect("fetch orgs");
+    assert_eq!(orgs.len(), 1);
+    assert_eq!(orgs[0].slug, "acme");
+    assert!(orgs[0].active);
+}
+
+/// `run_migrations: false` is the `--no-migrate` flag inverted. The
+/// step reports skipped, and no migration events are emitted at all.
+#[tokio::test]
+async fn migrations_can_be_skipped() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("globex.db");
+    let mut request = ProvisionRequest::database(
+        "globex",
+        format!("sqlite://{}?mode=rwc", tenant_db.display()),
+    );
+    request.run_migrations = false;
+
+    let rec = Recorder::default();
+    let outcome = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect("provision");
+
+    assert!(
+        matches!(outcome.migrations, MigrationsOutcome::Skipped),
+        "{:?}",
+        outcome.migrations
+    );
+    assert!(
+        rec.steps().contains(&"Migrate:skipped".to_owned()),
+        "{:?}",
+        rec.steps()
+    );
+    assert!(
+        !rec.0
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|e| matches!(e, ProvisionEvent::Migration(_))),
+        "no migration events should be emitted when migrations are skipped"
+    );
+}
+
+/// A duplicate slug fails at `Validate` and reports *which* step failed
+/// — the reason the failure path goes through the observer rather than
+/// a bare `?`. A watcher must never be left with a step stuck on
+/// "started".
+#[tokio::test]
+async fn a_duplicate_slug_fails_at_validate_and_says_so() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("dup.db");
+    let mut request =
+        ProvisionRequest::database("dup", format!("sqlite://{}?mode=rwc", tenant_db.display()));
+    request.run_migrations = false;
+    provision::provision_tenant(&pools, &url, migrations.path(), &request, None)
+        .await
+        .expect("first provision");
+
+    let rec = Recorder::default();
+    let err = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect_err("second provision must be rejected");
+
+    assert!(err.to_string().contains("already exists"), "got: {err}");
+    assert_eq!(
+        rec.steps(),
+        vec!["Validate:started", "Validate:failed"],
+        "the failing step must be named, and nothing after it should run: {:?}",
+        rec.steps()
+    );
+
+    // And nothing was written: still exactly one org.
+    let orgs = rustango::tenancy::Org::objects()
+        .fetch(&pools.registry_pool())
+        .await
+        .expect("fetch orgs");
+    assert_eq!(orgs.len(), 1);
+}
+
+/// Database-mode without a URL is rejected before anything is written.
+#[tokio::test]
+async fn database_mode_without_a_url_is_rejected_before_any_write() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let mut request = ProvisionRequest::database("nourl", "unused");
+    request.database_url = None;
+
+    let rec = Recorder::default();
+    let err = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect_err("must be rejected");
+
+    assert!(err.to_string().contains("--database-url"), "got: {err}");
+    assert_eq!(rec.steps(), vec!["Validate:started", "Validate:failed"]);
+
+    let orgs = rustango::tenancy::Org::objects()
+        .fetch(&pools.registry_pool())
+        .await
+        .expect("fetch orgs");
+    assert!(orgs.is_empty(), "nothing should have been written");
+}
+
+/// Schema-mode on a SQLite registry is refused with a message that says
+/// what to do instead — `CREATE SCHEMA` does not exist there.
+#[tokio::test]
+async fn schema_mode_on_sqlite_is_refused_with_a_useful_message() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let mut request = ProvisionRequest::database("schemamode", "unused");
+    request.mode = rustango::tenancy::StorageMode::Schema;
+    request.database_url = None;
+    request.run_migrations = false;
+
+    let rec = Recorder::default();
+    let err = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect_err("schema mode must be refused on sqlite");
+
+    assert!(
+        err.to_string().contains("--mode database"),
+        "the error should point at the fix, got: {err}"
+    );
+    // It gets past validation — the request is internally coherent —
+    // and fails at the storage step, which is where the dialect
+    // actually bites.
+    assert_eq!(
+        rec.steps(),
+        vec![
+            "Validate:started",
+            "Validate:ok",
+            "CheckConnection:skipped",
+            "ProvisionStorage:started",
+            "ProvisionStorage:failed",
+        ],
+        "{:?}",
+        rec.steps()
+    );
+}
+
+/// An observer is optional. Passing `None` must provision identically —
+/// the engine's behaviour cannot depend on whether anyone is watching.
+#[tokio::test]
+async fn provisioning_unobserved_works_the_same() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("quiet.db");
+    let request = ProvisionRequest::database(
+        "quiet",
+        format!("sqlite://{}?mode=rwc", tenant_db.display()),
+    );
+
+    let outcome = provision::provision_tenant(&pools, &url, migrations.path(), &request, None)
+        .await
+        .expect("provision");
+
+    assert_eq!(outcome.slug, "quiet");
+    assert!(outcome.org_id > 0);
+    assert!(
+        !matches!(outcome.migrations, MigrationsOutcome::Skipped),
+        "migrations were requested: {:?}",
+        outcome.migrations
+    );
+}
+
+/// `ProvisionStep` is part of the public surface a console will match
+/// on, so pin the set. Adding one is a breaking change for a watcher.
+#[test]
+fn the_step_list_is_stable() {
+    let all = [
+        ProvisionStep::Validate,
+        ProvisionStep::CheckConnection,
+        ProvisionStep::ProvisionStorage,
+        ProvisionStep::RegisterOrg,
+        ProvisionStep::Migrate,
+    ];
+    assert_eq!(all.len(), 5);
+}


### PR DESCRIPTION
Closes #1318. **Stacked on #1324** — review that first; this PR's diff is only the last commit.

## Before

Standing up a tenant was possible from exactly one place: a CLI.

```rust
pub(super) async fn create_tenant<W: Write + Send, DB: Database>(
    pools: &TenantPools<DB>, registry_url: &str, dir: &Path,
    args: &[String],   // parses argv itself
    w: &mut W,         // reports by writeln!
) -> Result<(), TenancyError>   // and tells you nothing on success
```

Three things weld it there: the visibility, the `argv`, and the writer. An HTTP handler, a webhook or a job would have had to fake an `argv` and hand it a `Vec<u8>`.

## After

The sequence lives in `tenancy::provision`; the verb keeps what is genuinely a command line's job — turning `argv` into a `ProvisionRequest` and rendering events as text.

```
Validate → CheckConnection → ProvisionStorage → RegisterOrg → Migrate
```

Each step reports `Started` / `Ok` / `Skipped(why)` / `Failed(why)`.

## Five things worth review attention

**`CheckConnection` is already in the stream**, reporting `Skipped("not implemented yet (#1319)")`. A watcher written against today's events keeps working when #1319 fills it in, rather than suddenly meeting a stage it has never seen. Cheap now, awkward to retrofit.

**Failures name their step.** Every failure path goes through a helper that reports to the observer *before* returning the error, never a bare `?`. A watcher must never be left with a step stuck on "started" and no explanation — that is the exact state this stream exists to prevent. There is a test for it.

**A migration failure is not an `Err`.** By that point the tenant exists, and an error return would hide that from the caller. It comes back as `MigrationsOutcome::Failed`. Validation and storage failures *are* errors, because nothing was written.

**Migration events forward straight through.** `ProvisionEvent::Migration` carries #1324's `TenantMigrationEvent`, so a caller watching a provisioning run sees the same per-migration detail `manage migrate` prints. This is the real reason the slice stacks on that one rather than sitting beside it.

**`no_migrate` → `run_migrations`.** A negative flag is right for a command line, where the default is yes and you opt out. It is wrong for a struct field, where every reader carries an extra negation. `parse_create_tenant_args` is now the only thing that knows `--no-migrate` exists.

## Two cleanups the move made obvious

- The schema-mode `#[cfg]` pair is one function with the cfg inside, instead of a `#[cfg]` block wrapped around a bare `return` in the middle of the verb. Both refusals still say different things — "this build has no `postgres`" vs "these pools are not PG", the latter only knowable by runtime downcast since `DB` is generic.
- It quotes the schema with the canonical `Dialect::quote_ident` rather than reaching into a private CLI module (`manage::args`) for a byte-identical copy.

## Deliberately left wrong

The migrate step still runs the **whole active-tenant batch** and then filters the report down to the new slug. That is what the verb has always done, and changing it is not this refactor's business — but it means creating tenant B does a pass over tenant A, and an unrelated tenant's broken chain surfaces in the middle of an unrelated provisioning run. Documented in the module header, flagged for the epic.

## Verification

- **`manage_live` 13/13 against live Postgres, unmodified.** That is the proof behaviour is preserved — same output text, same ordering ("created tenant …" still prints *before* the migrations, the summary after), same errors.
- **7 new tests drive the engine with no `argv` and no `Write`**, which is exactly what #1322 and #1323 will do: the full step sequence, the skip path, and three failure modes (duplicate slug, database-mode without a URL, schema-mode on SQLite) — each asserting both the error *and* that nothing was written.
- 3629 lib tests; `tenancy_manage_sqlite_live` 2/2; #1324's suite still green on this branch.
- Zero warnings on sqlite / postgres / mysql / +signals / +testkit / multi-backend / `--all-features --tests`, plus `--workspace --all-features --no-run` and `cargo fmt --check`.
- Clippy: **zero** warnings in the new module, and `tenants.rs` goes from 7 to 6 — `create_tenant` is no longer over the line limit.

## Next

#1319 fills in `CheckConnection`. #1321 persists these events as a run.