### PR TITLE
feat(tenancy): connect-test a tenant database before provisioning it

### DIFF
--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -734,14 +734,20 @@ impl Cli {
         // what makes `cargo run -- migrate` work against a sqlite
         // DATABASE_URL without going through the `runserver_tenancy`
         // path.
+        // `redact`, not `url`: this string goes to a terminal and into
+        // whatever log is capturing it, and a DATABASE_URL has a
+        // password in it. The error itself already names the endpoint
+        // it tried (see `sql::connect_diagnosis`), so nothing useful is
+        // lost.
+        let shown = crate::sql::connect_diagnosis::redact(&url);
         let pool = if no_db_verb {
             crate::sql::Pool::connect_lazy(&url)
-                .map_err(|e| format!("connect_lazy({url}): {e}").into())
+                .map_err(|e| format!("connect_lazy({shown}): {e}").into())
                 as Result<_, Box<dyn std::error::Error>>
         } else {
             crate::sql::Pool::connect(&url)
                 .await
-                .map_err(|e| format!("connect({url}): {e}").into())
+                .map_err(|e| format!("connect({shown}): {e}").into())
                 as Result<_, Box<dyn std::error::Error>>
         }?;
         crate::migrate::manage::run(&pool, &self.migrations_dir, args).await?;

--- a/crates/rustango/src/sql/connect_diagnosis.rs
+++ b/crates/rustango/src/sql/connect_diagnosis.rs
@@ -1,0 +1,356 @@
+//! Turning a driver's connect failure into something an operator can act
+//! on.
+//!
+//! `sqlx` reports what went wrong at its own layer, which is often three
+//! layers below the thing the reader has to change. The motivating case
+//! (#1306) cost a reporter a debugging session:
+//!
+//! ```text
+//! encountered unexpected or invalid data: Postgres protocol error
+//! (reading ErrorResponse): Postgres returned a non-UTF-8 string for its
+//! error message. This is most likely due to an error that occurred
+//! during authentication and the default lc_messages locale is not
+//! binary-compatible with UTF-8.
+//! ```
+//!
+//! What had actually happened: a local PostgreSQL install was already on
+//! 5432, so the Docker container was never reached at all. The local
+//! server answered, rejected the container's credentials, and returned
+//! the rejection in cp1252. Every word of that message is true and none
+//! of it points at the port conflict — and it names `lc_messages`, which
+//! sends the reader off configuring server locales.
+//!
+//! So: classify the failure into something that names the fix.
+//!
+//! ## Classification is on the variant, not the message
+//!
+//! Matching driver strings is brittle and localised. Every rule here
+//! keys on an `sqlx::Error` variant or a `SQLSTATE`/errno, both of which
+//! are stable and language-independent. The driver's own text is still
+//! carried through as `detail` — it is genuinely useful once you know
+//! which *kind* of problem you are reading about.
+//!
+//! ## Credentials never appear
+//!
+//! A connection URL has a password in it, and these strings end up in
+//! terminals, logs and HTTP responses. [`redact`] is applied to every
+//! endpoint this module renders.
+
+use std::fmt;
+
+/// What went wrong, in terms of what the operator has to change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectFault {
+    /// Nothing answered: connection refused, host not found, network
+    /// unreachable, or the attempt timed out.
+    Unreachable,
+    /// Something answered but the conversation made no sense — the
+    /// classic symptom of a *different* server on the expected port.
+    UnexpectedServer,
+    /// TLS could not be negotiated.
+    TlsRejected,
+    /// Reached the server; it refused the credentials.
+    AuthFailed,
+    /// Reached the server and authenticated; the named database is not
+    /// there.
+    NoSuchDatabase,
+    /// Connected fine, but this role may not do what a tenant needs —
+    /// create tables, most importantly. The failure a naive `SELECT 1`
+    /// check sails straight past and a migration then dies on.
+    PermissionDenied,
+    /// Nothing above matched.
+    Other,
+}
+
+impl ConnectFault {
+    /// One line naming what to change. Deliberately imperative: the
+    /// reader is stuck, and a description of the symptom does not help
+    /// them.
+    #[must_use]
+    pub fn advice(self) -> &'static str {
+        match self {
+            Self::Unreachable => {
+                "nothing is listening there — check the host and port, that the server is \
+                 running, and that a firewall or container network is not in the way"
+            }
+            // The #1306 hint. Leading with the port conflict because on
+            // a developer machine that is overwhelmingly what it is.
+            Self::UnexpectedServer => {
+                "something other than the expected database answered on this port — often a \
+                 local PostgreSQL or MySQL install shadowing a Docker container. Check what \
+                 is actually listening, and that the URL's scheme matches that server"
+            }
+            Self::TlsRejected => {
+                "TLS could not be negotiated — check the `sslmode`/`ssl-mode` in the URL and \
+                 whether the server requires (or refuses) encryption"
+            }
+            Self::AuthFailed => {
+                "the server refused these credentials — check the username and password"
+            }
+            Self::NoSuchDatabase => {
+                "the server is reachable but has no such database — create it, or fix the \
+                 name in the URL"
+            }
+            Self::PermissionDenied => {
+                "connected, but this role cannot create tables — grant it schema-level CREATE, \
+                 or migrations will fail partway through"
+            }
+            Self::Other => "the connection attempt failed",
+        }
+    }
+}
+
+/// A classified connect failure, ready to show someone.
+#[derive(Debug, Clone)]
+pub struct ConnectDiagnosis {
+    pub fault: ConnectFault,
+    /// Where we tried, with any password removed.
+    pub endpoint: String,
+    /// The driver's own message. Kept because it is the detail that
+    /// distinguishes two failures of the same kind.
+    pub detail: String,
+}
+
+impl ConnectDiagnosis {
+    /// Classify `err`, which came from trying to connect to `url`.
+    #[must_use]
+    pub fn of(url: &str, err: &sqlx::Error) -> Self {
+        Self {
+            fault: classify(err),
+            endpoint: redact(url),
+            detail: err.to_string(),
+        }
+    }
+
+    /// Build one directly — for a fault detected by a probe rather than
+    /// raised by the driver, such as a `CREATE TABLE` that came back
+    /// denied.
+    #[must_use]
+    pub fn new(fault: ConnectFault, url: &str, detail: impl Into<String>) -> Self {
+        Self {
+            fault,
+            endpoint: redact(url),
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for ConnectDiagnosis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Advice first: it is the part that is actionable, and the part
+        // a reader skimming a wall of output needs to land on.
+        write!(
+            f,
+            "{} (tried {}) — driver said: {}",
+            self.fault.advice(),
+            self.endpoint,
+            self.detail
+        )
+    }
+}
+
+/// Classify an `sqlx::Error` raised while connecting.
+fn classify(err: &sqlx::Error) -> ConnectFault {
+    match err {
+        // A protocol error *at connect time* means the bytes coming back
+        // were not what this driver speaks. On a dev machine that is
+        // nearly always another server on the port. (#1306's non-UTF-8
+        // `ErrorResponse` lands here, as does pointing a `postgres://`
+        // URL at a MySQL server.)
+        sqlx::Error::Protocol(_) => ConnectFault::UnexpectedServer,
+        sqlx::Error::Tls(_) => ConnectFault::TlsRejected,
+        // Every I/O failure at connect time — refused, no such host,
+        // network unreachable, timed out — is one story to the reader:
+        // nothing answered. `PoolTimedOut` is the same story told by
+        // the pool rather than the socket.
+        sqlx::Error::Io(_) | sqlx::Error::PoolTimedOut => ConnectFault::Unreachable,
+        sqlx::Error::Database(db) => classify_db(db.as_ref()),
+        _ => ConnectFault::Other,
+    }
+}
+
+/// Map a backend's own error code.
+///
+/// Three vocabularies with one meaning each — and one trap. `code()` on
+/// the `DatabaseError` trait is the `SQLSTATE`, which `MySQL` also
+/// reports, but its `SQLSTATE`s are far coarser than its error numbers:
+/// a missing database is `42000`, the same generic class as a syntax
+/// error. So `MySQL` is classified on `number()`, reached by downcast,
+/// with `SQLSTATE` only as a fallback.
+fn classify_db(db: &dyn sqlx::error::DatabaseError) -> ConnectFault {
+    #[cfg(feature = "mysql")]
+    if let Some(my) = db.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>() {
+        return match my.number() {
+            // 1045 access denied for user
+            1045 => ConnectFault::AuthFailed,
+            // 1049 unknown database
+            1049 => ConnectFault::NoSuchDatabase,
+            // 1044 access denied to database, 1142 table command denied
+            1044 | 1142 => ConnectFault::PermissionDenied,
+            _ => ConnectFault::Other,
+        };
+    }
+
+    let Some(code) = db.code() else {
+        return ConnectFault::Other;
+    };
+    // Two dialects' codes share a couple of meanings, so some arms have
+    // identical bodies. Merging them is what clippy wants and would
+    // make this unreadable: the grouping by dialect is the only thing
+    // that makes a five-character SQLSTATE and a bare `8` legible side
+    // by side, and the next person adding a code needs to see where it
+    // goes.
+    #[allow(clippy::match_same_arms)]
+    match code.as_ref() {
+        // ---- PostgreSQL (SQLSTATE) ----
+        // 28P01 invalid_password, 28000 invalid_authorization_specification
+        "28P01" | "28000" => ConnectFault::AuthFailed,
+        // 3D000 invalid_catalog_name
+        "3D000" => ConnectFault::NoSuchDatabase,
+        // 42501 insufficient_privilege
+        "42501" => ConnectFault::PermissionDenied,
+
+        // ---- SQLite (extended result codes, as strings) ----
+        // 14 SQLITE_CANTOPEN — the file (or its directory) is not there
+        "14" => ConnectFault::Unreachable,
+        // 8 SQLITE_READONLY, 3 SQLITE_PERM, 1032 READONLY_DBMOVED
+        "8" | "3" | "1032" => ConnectFault::PermissionDenied,
+
+        _ => ConnectFault::Other,
+    }
+}
+
+/// A connection URL with its password replaced.
+///
+/// These strings reach terminals, log files and — once the operator
+/// console lands — HTTP responses. A URL is the single most likely place
+/// for a credential to escape into one of those, so redaction happens
+/// here rather than at each call site, where it would eventually be
+/// forgotten.
+///
+/// Everything else is kept: the host, the port and the database name are
+/// exactly what the reader needs to see.
+#[must_use]
+pub fn redact(url: &str) -> String {
+    // `scheme://user:password@host:port/db?params`. Only the segment
+    // between the last `:` of the userinfo and the `@` is secret, and
+    // userinfo is whatever precedes the *first* `@` after `://`.
+    let Some((scheme, rest)) = url.split_once("://") else {
+        // `sqlite:path` and friends carry no credentials.
+        return url.to_owned();
+    };
+    let Some((userinfo, hostpart)) = rest.split_once('@') else {
+        return url.to_owned();
+    };
+    let user = userinfo.split_once(':').map_or(userinfo, |(u, _)| u);
+    if userinfo.contains(':') {
+        format!("{scheme}://{user}:***@{hostpart}")
+    } else {
+        format!("{scheme}://{userinfo}@{hostpart}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_removes_the_password_and_keeps_everything_useful() {
+        assert_eq!(
+            redact("postgres://app:s3cret@db.internal:5432/acme"),
+            "postgres://app:***@db.internal:5432/acme"
+        );
+    }
+
+    #[test]
+    fn redact_leaves_a_url_with_no_password_alone() {
+        assert_eq!(
+            redact("postgres://app@localhost:5432/acme"),
+            "postgres://app@localhost:5432/acme"
+        );
+        assert_eq!(
+            redact("postgres://localhost:5432/acme"),
+            "postgres://localhost:5432/acme"
+        );
+    }
+
+    #[test]
+    fn redact_leaves_sqlite_paths_alone() {
+        assert_eq!(
+            redact("sqlite:./dev.db?mode=rwc"),
+            "sqlite:./dev.db?mode=rwc"
+        );
+        assert_eq!(redact("sqlite://./dev.db"), "sqlite://./dev.db");
+    }
+
+    /// An `@` inside the password must not be mistaken for the userinfo
+    /// separator in a way that leaks the rest of it.
+    #[test]
+    fn redact_handles_an_at_sign_in_the_password() {
+        // Split on the FIRST `@`: everything after it is host-ish, and
+        // the tail of a password containing `@` would otherwise survive.
+        let out = redact("mysql://root:p@ss@127.0.0.1:3306/app");
+        assert!(!out.contains("p@ss"), "password leaked: {out}");
+        assert!(out.starts_with("mysql://root:***@"), "{out}");
+    }
+
+    #[test]
+    fn a_protocol_error_reads_as_a_port_conflict_not_a_locale_problem() {
+        // #1306: the exact class of error a shadowing local server
+        // produces.
+        let err = sqlx::Error::Protocol(
+            "Postgres returned a non-UTF-8 string for its error message. This is most likely \
+             due to an error that occurred during authentication and the default lc_messages \
+             locale is not binary-compatible with UTF-8."
+                .into(),
+        );
+        let d = ConnectDiagnosis::of(
+            "postgres://rustango:rustango@localhost:5432/backend_dev",
+            &err,
+        );
+
+        assert_eq!(d.fault, ConnectFault::UnexpectedServer);
+        let rendered = d.to_string();
+        assert!(
+            rendered.contains("something other than the expected database answered"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("localhost:5432"), "{rendered}");
+        assert!(
+            !rendered.contains("rustango:rustango"),
+            "credentials leaked: {rendered}"
+        );
+        // The driver's own text is still there for anyone who wants it —
+        // just no longer the headline.
+        assert!(rendered.contains("lc_messages"), "{rendered}");
+    }
+
+    #[test]
+    fn a_refused_connection_reads_as_unreachable() {
+        let err = sqlx::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "Connection refused (os error 61)",
+        ));
+        let d = ConnectDiagnosis::of("postgres://app:pw@127.0.0.1:5999/x", &err);
+        assert_eq!(d.fault, ConnectFault::Unreachable);
+        assert!(d.to_string().contains("nothing is listening"), "{d}");
+    }
+
+    #[test]
+    fn advice_is_distinct_for_every_fault() {
+        let all = [
+            ConnectFault::Unreachable,
+            ConnectFault::UnexpectedServer,
+            ConnectFault::TlsRejected,
+            ConnectFault::AuthFailed,
+            ConnectFault::NoSuchDatabase,
+            ConnectFault::PermissionDenied,
+            ConnectFault::Other,
+        ];
+        let mut seen: Vec<&str> = all.iter().map(|f| f.advice()).collect();
+        seen.sort_unstable();
+        let before = seen.len();
+        seen.dedup();
+        assert_eq!(before, seen.len(), "two faults share advice text");
+    }
+}

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -10,6 +10,9 @@ mod array;
 mod auto;
 mod backend;
 mod compiled;
+/// Turning a driver's connect failure into something an operator can
+/// act on — which host, which cause, what to change.
+pub mod connect_diagnosis;
 mod dialect;
 mod error;
 mod executor;
@@ -36,6 +39,7 @@ pub use backend::{
     AssignAutoPkPool, MyReturningRow, MysqlAutoIdSet, PgReturningRow, SqliteReturningRow,
 };
 pub use compiled::CompiledStatement;
+pub use connect_diagnosis::{ConnectDiagnosis, ConnectFault};
 pub use dialect::Dialect;
 pub use error::{is_mysql_dup_index_error, ExecError, SqlError};
 pub use geometry::{Point, SRID_WGS84};

--- a/crates/rustango/src/sql/pool.rs
+++ b/crates/rustango/src/sql/pool.rs
@@ -58,7 +58,19 @@ use std::time::Duration;
 
 use crate::env::{database_url_from_env, EnvError};
 
+use super::connect_diagnosis::{ConnectDiagnosis, ConnectFault};
 use super::Dialect;
+
+/// Why a connect attempt failed, before it is rendered into whichever
+/// error type the caller asked for.
+///
+/// The two are genuinely different: a driver failure has a host, a
+/// cause and advice; a scheme or missing-feature failure never dialled
+/// anything and wants `PoolError`'s typed variants instead.
+enum ConnectFail {
+    Driver(ConnectDiagnosis),
+    Pool(PoolError),
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum PoolError {
@@ -141,6 +153,45 @@ impl Pool {
     /// Same set as [`Self::connect`], plus a `Connect` error if `sqlx`
     /// times out before the database accepts the connection.
     pub async fn connect_with_timeout(url: &str, timeout: Duration) -> Result<Self, PoolError> {
+        Self::connect_inner(url, timeout)
+            .await
+            .map_err(|f| match f {
+                ConnectFail::Driver(d) => PoolError::Connect(d.to_string()),
+                ConnectFail::Pool(e) => e,
+            })
+    }
+
+    /// [`Self::connect_with_timeout`], but a failure comes back as a
+    /// structured [`ConnectDiagnosis`] rather than a rendered string.
+    ///
+    /// `PoolError::Connect` carries a `String`, so the classification
+    /// made during the attempt is gone by the time a caller sees it.
+    /// A caller that needs to *branch* on the fault — the tenant
+    /// pre-flight, an operator console rendering per-fault advice —
+    /// wants the enum, not prose it has to parse back.
+    ///
+    /// # Errors
+    /// A `ConnectDiagnosis` naming the fault, the endpoint tried (with
+    /// the password removed) and the driver's own message.
+    pub async fn connect_diagnosed(url: &str, timeout: Duration) -> Result<Self, ConnectDiagnosis> {
+        Self::connect_inner(url, timeout)
+            .await
+            .map_err(|f| match f {
+                ConnectFail::Driver(d) => d,
+                // A scheme this build cannot speak is not a *connection*
+                // fault — nothing was dialled — but a caller asking for a
+                // diagnosis still needs one, and the message is already
+                // specific about what to add to Cargo.toml.
+                ConnectFail::Pool(e) => {
+                    ConnectDiagnosis::new(ConnectFault::Other, url, e.to_string())
+                }
+            })
+    }
+
+    /// The one place the scheme dispatch lives. Keeps the driver's
+    /// classified failure and a scheme/feature failure distinct, so
+    /// each public wrapper can render whichever shape it promises.
+    async fn connect_inner(url: &str, timeout: Duration) -> Result<Self, ConnectFail> {
         let scheme = url.split(':').next().unwrap_or("").to_ascii_lowercase();
         match scheme.as_str() {
             #[cfg(feature = "postgres")]
@@ -149,44 +200,46 @@ impl Pool {
                     .acquire_timeout(timeout)
                     .connect(url)
                     .await
-                    .map_err(|e| PoolError::Connect(e.to_string()))?;
+                    .map_err(|e| ConnectFail::Driver(ConnectDiagnosis::of(url, &e)))?;
                 Ok(Self::Postgres(pool))
             }
             #[cfg(not(feature = "postgres"))]
-            "postgres" | "postgresql" => Err(PoolError::FeatureNotEnabled {
+            "postgres" | "postgresql" => Err(ConnectFail::Pool(PoolError::FeatureNotEnabled {
                 scheme: "postgres",
                 feature: "postgres",
-            }),
+            })),
             #[cfg(feature = "mysql")]
             "mysql" => {
                 let pool = sqlx::mysql::MySqlPoolOptions::new()
                     .acquire_timeout(timeout)
                     .connect(url)
                     .await
-                    .map_err(|e| PoolError::Connect(e.to_string()))?;
+                    .map_err(|e| ConnectFail::Driver(ConnectDiagnosis::of(url, &e)))?;
                 Ok(Self::Mysql(pool))
             }
             #[cfg(not(feature = "mysql"))]
-            "mysql" => Err(PoolError::FeatureNotEnabled {
+            "mysql" => Err(ConnectFail::Pool(PoolError::FeatureNotEnabled {
                 scheme: "mysql",
                 feature: "mysql",
-            }),
+            })),
             #[cfg(feature = "sqlite")]
             "sqlite" => {
-                let opts = sqlite_connect_options(url)?;
+                let opts = sqlite_connect_options(url).map_err(ConnectFail::Pool)?;
                 let pool = sqlx::sqlite::SqlitePoolOptions::new()
                     .acquire_timeout(timeout)
                     .connect_with(opts)
                     .await
-                    .map_err(|e| PoolError::Connect(e.to_string()))?;
+                    .map_err(|e| ConnectFail::Driver(ConnectDiagnosis::of(url, &e)))?;
                 Ok(Self::Sqlite(pool))
             }
             #[cfg(not(feature = "sqlite"))]
-            "sqlite" => Err(PoolError::FeatureNotEnabled {
+            "sqlite" => Err(ConnectFail::Pool(PoolError::FeatureNotEnabled {
                 scheme: "sqlite",
                 feature: "sqlite",
-            }),
-            _ => Err(PoolError::UnsupportedScheme(url.to_owned())),
+            })),
+            _ => Err(ConnectFail::Pool(PoolError::UnsupportedScheme(
+                url.to_owned(),
+            ))),
         }
     }
 
@@ -220,7 +273,7 @@ impl Pool {
             #[cfg(feature = "postgres")]
             "postgres" | "postgresql" => {
                 let pool = sqlx::PgPool::connect_lazy(url)
-                    .map_err(|e| PoolError::Connect(e.to_string()))?;
+                    .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
                 Ok(Self::Postgres(pool))
             }
             #[cfg(not(feature = "postgres"))]
@@ -231,7 +284,7 @@ impl Pool {
             #[cfg(feature = "mysql")]
             "mysql" => {
                 let pool = sqlx::MySqlPool::connect_lazy(url)
-                    .map_err(|e| PoolError::Connect(e.to_string()))?;
+                    .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
                 Ok(Self::Mysql(pool))
             }
             #[cfg(not(feature = "mysql"))]
@@ -255,6 +308,24 @@ impl Pool {
     }
 
     /// Borrow the dialect for this pool. Stable [`Dialect`] reference
+    /// Close the pool, waiting for its connections to be released.
+    ///
+    /// Dropping a pool schedules the close but does not wait for it, so
+    /// a short-lived pool — a connection probe, a one-shot migration
+    /// against a tenant — can outlive the code that made it and hold a
+    /// socket open. Call this when the pool is finished with and the
+    /// release should have happened by the time you return.
+    pub async fn close(&self) {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Postgres(p) => p.close().await,
+            #[cfg(feature = "mysql")]
+            Self::Mysql(p) => p.close().await,
+            #[cfg(feature = "sqlite")]
+            Self::Sqlite(p) => p.close().await,
+        }
+    }
+
     /// usable by callers who need to inspect identifier quoting,
     /// placeholder syntax, etc., without caring which backend the
     /// pool actually wraps.
@@ -336,7 +407,7 @@ impl Pool {
             .acquire_timeout(default_acquire_timeout())
             .connect(url)
             .await
-            .map_err(|e| PoolError::Connect(e.to_string()))?;
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
         Ok(Self::Postgres(pool))
     }
 
@@ -354,7 +425,7 @@ impl Pool {
             .acquire_timeout(default_acquire_timeout())
             .connect(url)
             .await
-            .map_err(|e| PoolError::Connect(e.to_string()))?;
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
         Ok(Self::Mysql(pool))
     }
 
@@ -389,7 +460,7 @@ impl Pool {
             .acquire_timeout(default_acquire_timeout())
             .connect_with(opts)
             .await
-            .map_err(|e| PoolError::Connect(e.to_string()))?;
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
         Ok(Self::Sqlite(pool))
     }
 
@@ -474,7 +545,7 @@ pub(crate) fn sqlite_connect_options(
     use std::str::FromStr;
     let url_with_default = ensure_sqlite_rwc_default(url);
     let mut opts = sqlx::sqlite::SqliteConnectOptions::from_str(&url_with_default)
-        .map_err(|e| PoolError::Connect(e.to_string()))?
+        .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?
         .foreign_keys(true)
         .busy_timeout(Duration::from_secs(5));
     if !url_with_default.contains(":memory:") && !url_with_default.contains("mode=memory") {

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -172,6 +172,7 @@ where
         "create-tenant" => {
             tenants::create_tenant(pools, registry_url, dir, &args[1..], writer).await
         }
+        "test-tenant-connection" => tenants::test_tenant_connection(&args[1..], writer).await,
         "drop-tenant" => tenants::drop_tenant(pools, &args[1..], writer).await,
         "purge-tenant" => tenants::purge_tenant(pools, &args[1..], writer).await,
         "list-tenants" => tenants::list_tenants(pools, writer).await,
@@ -348,6 +349,10 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
     writeln!(
         w,
         "                       [--host-pattern <s>] [--database-url <s>] [--no-migrate]"
+    )?;
+    writeln!(
+        w,
+        "  test-tenant-connection <url> [--no-write-probe] [--timeout <secs>]"
     )?;
     writeln!(
         w,

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -120,6 +120,71 @@ impl<W: Write + Send> provision::ProvisionObserver for CreateTenantProgress<'_, 
     }
 }
 
+// ---------- test-tenant-connection ----------
+
+/// Reach a candidate tenant database and report what is wrong with it,
+/// without writing anything to the registry.
+///
+/// Takes no pools: the point is to answer "can I use this URL?" before
+/// there is a tenant, so it is deliberately independent of the registry
+/// the rest of the CLI is holding.
+pub(super) async fn test_tenant_connection<W: Write + Send>(
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError> {
+    const HELP: &str =
+        "test-tenant-connection <database-url> [--no-write-probe] [--timeout <secs>]";
+    reject_leading_flag(args, "test-tenant-connection", "database-url", HELP)?;
+
+    let mut iter = args.iter();
+    let url = iter.next().cloned().ok_or_else(|| {
+        TenancyError::Validation(
+            "test-tenant-connection requires a database URL positional argument".into(),
+        )
+    })?;
+
+    let mut opts = crate::tenancy::preflight::Preflight::default();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--no-write-probe" => opts.probe_writes = false,
+            "--timeout" => {
+                let v = next_value(&mut iter, "--timeout")?;
+                let secs: u64 = v.parse().map_err(|_| {
+                    TenancyError::Validation(format!(
+                        "--timeout must be a whole number of seconds, got `{v}`"
+                    ))
+                })?;
+                opts.timeout = std::time::Duration::from_secs(secs);
+            }
+            "--help" | "-h" => return Err(TenancyError::Validation(HELP.to_owned())),
+            other => {
+                return Err(TenancyError::Validation(format!(
+                    "test-tenant-connection: unknown argument `{other}`"
+                )));
+            }
+        }
+    }
+
+    match crate::tenancy::preflight::check(&url, &opts).await {
+        Ok(ok) => {
+            writeln!(w, "ok: reached {}", ok.endpoint)?;
+            if ok.writes_verified {
+                writeln!(w, "  this role can create tables — migrations will run")?;
+            } else {
+                writeln!(
+                    w,
+                    "  --no-write-probe: did NOT check whether this role can create tables"
+                )?;
+            }
+            Ok(())
+        }
+        // A `Validation` error rather than a driver one: nothing is
+        // broken in rustango, the URL the operator supplied is wrong,
+        // and the diagnosis already says what to change.
+        Err(d) => Err(TenancyError::Validation(d.to_string())),
+    }
+}
+
 /// `argv` → [`ProvisionRequest`]. The only place that knows
 /// `--no-migrate` exists: a negative flag is right for a command line
 /// and wrong for a struct field, so it is inverted on the way in.
@@ -150,6 +215,7 @@ fn parse_create_tenant_args(args: &[String]) -> Result<provision::ProvisionReque
         port: None,
         path_prefix: None,
         run_migrations: true,
+        preflight: crate::tenancy::preflight::Preflight::default(),
     };
     while let Some(flag) = iter.next() {
         match flag.as_str() {

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -98,6 +98,9 @@ pub mod permissions;
 mod pools;
 /// Who a request is acting as, whatever authenticated it (session cookie,
 /// Bearer access token, MCP agent token).
+/// Reaching a tenant's database before anything is written to the
+/// registry, so a bad URL cannot leave a half-provisioned tenant.
+pub mod preflight;
 pub mod principal;
 /// Standing up a tenant — the steps the `create-tenant` verb runs,
 /// callable from anything that is not a terminal.

--- a/crates/rustango/src/tenancy/preflight.rs
+++ b/crates/rustango/src/tenancy/preflight.rs
@@ -1,0 +1,167 @@
+//! Reaching a tenant's database *before* anything is written to the
+//! registry.
+//!
+//! `create-tenant` used to take `--database-url` on faith: it inserted
+//! the `Org` row and only then ran migrations against whatever the URL
+//! pointed at. A typo'd host, a wrong password, or a database that did
+//! not exist yet left a **half-provisioned tenant** — a live registry
+//! row the resolver will happily match, in front of a database with no
+//! schema in it.
+//!
+//! (Schema-mode dodged this by accident: it runs `CREATE SCHEMA` before
+//! the `INSERT`, so a failed insert orphans nothing. Database-mode had
+//! no equivalent.)
+//!
+//! ## Why `SELECT 1` is not enough
+//!
+//! A tenant database this role can *read* but not `CREATE TABLE` in
+//! passes a connect-and-ping check and then dies twenty migrations
+//! later, having already been registered. So the probe optionally
+//! creates a table and drops it — the only check that actually proves
+//! the thing migrations are about to need.
+//!
+//! That is a write, so it is a flag. It defaults **on** for
+//! provisioning (where a migration run is seconds away and a table is
+//! nothing next to it) and can be turned off for a read-only look.
+
+use std::time::Duration;
+
+use crate::sql::connect_diagnosis::{redact, ConnectDiagnosis, ConnectFault};
+use crate::sql::Pool;
+
+/// How long to wait for the database to answer.
+///
+/// Deliberately **not** the pool's `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS`
+/// (5s by default). That value is tuned for a request path, where
+/// failing fast protects the server. A pre-flight is an operator
+/// standing at a form waiting for an answer, often against a cold or
+/// distant database, and a false "unreachable" is worse than a wait.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What to check.
+#[derive(Debug, Clone)]
+pub struct Preflight {
+    pub timeout: Duration,
+    /// Create and drop a table, proving this role can do what
+    /// migrations will need. See the module docs.
+    pub probe_writes: bool,
+}
+
+impl Default for Preflight {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_TIMEOUT,
+            probe_writes: true,
+        }
+    }
+}
+
+impl Preflight {
+    /// Connect and ping only — no writes.
+    #[must_use]
+    pub fn read_only() -> Self {
+        Self {
+            probe_writes: false,
+            ..Self::default()
+        }
+    }
+}
+
+/// What a successful pre-flight found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reachable {
+    /// Where we reached, password removed.
+    pub endpoint: String,
+    /// Whether the write probe ran and passed. `false` means it was
+    /// switched off, not that it failed — a failure is an `Err`.
+    pub writes_verified: bool,
+}
+
+/// Reach `url` and report whether it is usable as a tenant database.
+///
+/// # Errors
+/// A [`ConnectDiagnosis`] naming the fault and what to change. Never a
+/// raw driver string: the whole point is that "connection refused on
+/// :5432" and "database `acme` does not exist" and "role `app` cannot
+/// create tables" are three different operator actions.
+pub async fn check(url: &str, opts: &Preflight) -> Result<Reachable, ConnectDiagnosis> {
+    // A dedicated pool with its own timeout, closed before returning —
+    // never the shared one. A probe that leaves a pool registered for a
+    // tenant that then fails to provision is a leak, and one that
+    // borrows the request path's 5s timeout reports healthy databases
+    // as unreachable.
+    let pool = Pool::connect_diagnosed(url, opts.timeout).await?;
+
+    let result = probe(&pool, url, opts).await;
+    // Close explicitly rather than letting the drop handler get to it
+    // whenever: this function is called in a loop by an operator
+    // retyping a URL, and each attempt should release its socket now.
+    pool.close().await;
+    result
+}
+
+async fn probe(pool: &Pool, url: &str, opts: &Preflight) -> Result<Reachable, ConnectDiagnosis> {
+    // A real round-trip, not just a handshake: sqlx can hand back a
+    // pooled connection that has not spoken to the server since it was
+    // opened, so "connected" alone proves less than it looks.
+    raw(pool, "SELECT 1").await.map_err(|e| diagnose(url, &e))?;
+
+    if opts.probe_writes {
+        verify_writes(pool, url).await?;
+    }
+
+    Ok(Reachable {
+        endpoint: redact(url),
+        writes_verified: opts.probe_writes,
+    })
+}
+
+/// One raw statement against whichever backend this is.
+async fn raw(pool: &Pool, sql: &str) -> Result<(), crate::sql::ExecError> {
+    crate::sql::raw_execute_pool(pool, sql, Vec::new()).await?;
+    Ok(())
+}
+
+/// Classify an `ExecError` the same way a connect failure is
+/// classified, by reaching the `sqlx::Error` it wraps.
+fn diagnose(url: &str, e: &crate::sql::ExecError) -> ConnectDiagnosis {
+    match e {
+        crate::sql::ExecError::Driver(inner) => ConnectDiagnosis::of(url, inner),
+        other => ConnectDiagnosis::new(ConnectFault::Other, url, other.to_string()),
+    }
+}
+
+/// Create a table and drop it.
+///
+/// The name is unique per process *and* per call: two pre-flights
+/// running at once against one database — an operator on the console
+/// while a webhook provisions, say — must not collide, or a perfectly
+/// good database gets reported as broken.
+async fn verify_writes(pool: &Pool, url: &str) -> Result<(), ConnectDiagnosis> {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let table = format!(
+        "rustango_preflight_{}_{}",
+        std::process::id(),
+        SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+
+    if let Err(e) = raw(pool, &format!("CREATE TABLE {table} (id INTEGER)")).await {
+        // A failed CREATE here is almost always a grant problem, but
+        // the driver's code is what decides — a disk-full or a
+        // read-only replica is not a permissions story and should not
+        // be reported as one.
+        let d = diagnose(url, &e);
+        return Err(match d.fault {
+            ConnectFault::Other => {
+                ConnectDiagnosis::new(ConnectFault::PermissionDenied, url, d.detail)
+            }
+            _ => d,
+        });
+    }
+
+    // Best-effort: the grant question is already answered, and leaving
+    // a one-column table behind is a smaller problem than failing a
+    // pre-flight that actually passed.
+    let _ = raw(pool, &format!("DROP TABLE {table}")).await;
+    Ok(())
+}

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -15,11 +15,11 @@
 //!
 //! 1. [`Validate`](ProvisionStep::Validate) — slug, mode and backend
 //!    agree with each other and with this build.
-//! 2. [`CheckConnection`](ProvisionStep::CheckConnection) — **not
-//!    implemented yet** (#1319). It reports
-//!    [`Skipped`](StepStatus::Skipped) so the shape is visible in the
-//!    stream from the start, rather than appearing later and changing
-//!    what a watcher has to handle.
+//! 2. [`CheckConnection`](ProvisionStep::CheckConnection) — reach the
+//!    tenant's database and prove this role can create tables in it,
+//!    **before** anything is written. See [`super::preflight`].
+//!    Schema-mode skips it: those tenants live in the registry's own
+//!    database, which is already connected.
 //! 3. [`ProvisionStorage`](ProvisionStep::ProvisionStorage) —
 //!    `CREATE SCHEMA` for schema-mode. Deliberately before the row
 //!    lands, so a failed `INSERT` leaves no orphan schema.
@@ -48,6 +48,7 @@ use super::error::TenancyError;
 use super::migrate as tenant_migrate;
 use super::org::{BackendKind, Org, StorageMode};
 use super::pools::TenantPools;
+use super::preflight;
 
 /// Everything needed to stand up one tenant.
 ///
@@ -76,6 +77,10 @@ pub struct ProvisionRequest {
     pub path_prefix: Option<String>,
     /// Run the tenant's migrations once the row is in place.
     pub run_migrations: bool,
+    /// How hard to check the target database before writing anything.
+    /// Defaults to a full check including the write probe — see
+    /// [`preflight`] for why a bare `SELECT 1` is not enough.
+    pub preflight: preflight::Preflight,
 }
 
 impl ProvisionRequest {
@@ -93,6 +98,7 @@ impl ProvisionRequest {
             port: None,
             path_prefix: None,
             run_migrations: true,
+            preflight: preflight::Preflight::default(),
         }
     }
 }
@@ -102,8 +108,8 @@ impl ProvisionRequest {
 pub enum ProvisionStep {
     /// Slug is free; mode, backend and build agree.
     Validate,
-    /// Reach the target database before writing anything. Not
-    /// implemented yet — see #1319.
+    /// Reach the target database, and prove this role can create
+    /// tables in it, before anything is written.
     CheckConnection,
     /// `CREATE SCHEMA` for schema-mode. Nothing to do in database-mode.
     ProvisionStorage,
@@ -271,15 +277,11 @@ where
 
     // ---- 2. Check the connection ----
     //
-    // The step exists in the stream from day one even though it does
-    // nothing: a watcher written against today's events keeps working
-    // when #1319 fills it in, instead of suddenly meeting a stage it
-    // has never seen.
-    step(
-        observer,
-        ProvisionStep::CheckConnection,
-        StepStatus::Skipped("connection pre-flight is not implemented yet (#1319)".into()),
-    );
+    // Before anything is written. A database-mode URL that is wrong —
+    // typo'd host, wrong password, database not created yet — used to
+    // be discovered *after* the `Org` row landed, leaving a tenant the
+    // resolver matches in front of a database with no schema.
+    check_connection(request, observer).await?;
 
     let schema_name = schema_name_for(request);
 
@@ -350,6 +352,44 @@ where
         mode: request.mode,
         migrations,
     })
+}
+
+/// Reach the tenant's own database before anything is written.
+///
+/// Only database-mode has a separate database to reach; a schema-mode
+/// tenant lives in the registry's, which is already connected.
+async fn check_connection(
+    request: &ProvisionRequest,
+    observer: Option<&dyn ProvisionObserver>,
+) -> Result<(), TenancyError> {
+    let (Some(url), StorageMode::Database) = (&request.database_url, request.mode) else {
+        step(
+            observer,
+            ProvisionStep::CheckConnection,
+            StepStatus::Skipped("schema-mode tenants share the registry's database".into()),
+        );
+        return Ok(());
+    };
+
+    step(
+        observer,
+        ProvisionStep::CheckConnection,
+        StepStatus::Started,
+    );
+    match preflight::check(url, &request.preflight).await {
+        Ok(_) => {
+            step(observer, ProvisionStep::CheckConnection, StepStatus::Ok);
+            Ok(())
+        }
+        // `Validation`, not a driver error: nothing is broken in
+        // rustango, the URL the caller supplied is wrong, and the
+        // diagnosis already says what to change.
+        Err(d) => fail(
+            observer,
+            ProvisionStep::CheckConnection,
+            TenancyError::Validation(d.to_string()),
+        ),
+    }
 }
 
 /// The schema a schema-mode tenant lives in: whatever the request

--- a/crates/rustango/tests/preflight_live.rs
+++ b/crates/rustango/tests/preflight_live.rs
@@ -1,0 +1,372 @@
+#![cfg(feature = "tenancy")]
+//! Tenant-database pre-flight (#1319) and the connect-failure taxonomy
+//! (#1306), on all three dialects.
+//!
+//! The point is not "did it return an error" — the old code managed
+//! that. It is that **connection refused on :5432**, **database `acme`
+//! does not exist**, **role `app` cannot create tables** and **something
+//! else is on this port** are four different operator actions, and the
+//! message has to name which one.
+//!
+//! PG reads `DATABASE_URL`, MySQL reads `MYSQL_TEST_URL`; both skip when
+//! unset. SQLite always runs.
+
+use rustango::sql::ConnectFault;
+use rustango::tenancy::preflight::{self, Preflight};
+
+/// A port nothing is on. High and odd enough to be safe in CI.
+const DEAD_PORT: u16 = 59_417;
+
+// ---------------------------------------------------------------- SQLite
+
+#[cfg(feature = "sqlite")]
+mod sqlite {
+    use super::{preflight, ConnectFault, Preflight};
+
+    #[tokio::test]
+    async fn a_writable_file_passes_including_the_write_probe() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let url = format!("sqlite://{}?mode=rwc", tmp.path().join("ok.db").display());
+
+        let ok = preflight::check(&url, &Preflight::default())
+            .await
+            .expect("a fresh sqlite file should be usable");
+        assert!(
+            ok.writes_verified,
+            "the write probe should have run and passed"
+        );
+    }
+
+    /// SQLite's "nothing there" needs an explicit `mode=ro`.
+    ///
+    /// rustango appends `?mode=rwc` to any sqlite URL that does not
+    /// name a mode (`ensure_sqlite_rwc_default`), so a missing file is
+    /// *created*, deliberately — which means "the file does not exist"
+    /// is simply not a failure on this dialect. Pinning that here so
+    /// the asymmetry with PG/MySQL is recorded rather than rediscovered.
+    #[tokio::test]
+    async fn a_missing_file_is_created_unless_the_url_says_read_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let absent = tmp.path().join("absent.db");
+
+        // Default mode: created, and usable.
+        let created = preflight::check(
+            &format!("sqlite://{}", absent.display()),
+            &Preflight::default(),
+        )
+        .await
+        .expect("rustango defaults sqlite to mode=rwc, so this is created");
+        assert!(created.writes_verified);
+
+        // Explicit read-only against a path that really is not there.
+        let url = format!("sqlite://{}?mode=ro", tmp.path().join("nope.db").display());
+        let err = preflight::check(&url, &Preflight::read_only())
+            .await
+            .expect_err("a read-only open of a missing file must fail");
+        assert!(
+            matches!(
+                err.fault,
+                ConnectFault::Unreachable | ConnectFault::PermissionDenied | ConnectFault::Other
+            ),
+            "got {:?}: {err}",
+            err.fault
+        );
+    }
+
+    /// `read_only()` must genuinely not write. Proven by the absence of
+    /// any `rustango_preflight_*` table afterwards.
+    #[tokio::test]
+    async fn the_read_only_probe_leaves_no_table_behind() {
+        use rustango::sql::sqlx;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("ro.db");
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+
+        let ok = preflight::check(&url, &Preflight::read_only())
+            .await
+            .expect("reachable");
+        assert!(!ok.writes_verified);
+
+        let pool = sqlx::SqlitePool::connect(&url).await.expect("reconnect");
+        let names: Vec<(String,)> =
+            sqlx::query_as("SELECT name FROM sqlite_master WHERE type = 'table'")
+                .fetch_all(&pool)
+                .await
+                .expect("list tables");
+        assert!(
+            names
+                .iter()
+                .all(|(n,)| !n.starts_with("rustango_preflight")),
+            "read-only probe wrote a table: {names:?}"
+        );
+    }
+
+    /// And the full probe cleans up after itself.
+    #[tokio::test]
+    async fn the_write_probe_drops_its_own_table() {
+        use rustango::sql::sqlx;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("cleanup.db");
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+
+        preflight::check(&url, &Preflight::default())
+            .await
+            .expect("reachable");
+
+        let pool = sqlx::SqlitePool::connect(&url).await.expect("reconnect");
+        let names: Vec<(String,)> =
+            sqlx::query_as("SELECT name FROM sqlite_master WHERE type = 'table'")
+                .fetch_all(&pool)
+                .await
+                .expect("list tables");
+        assert!(
+            names
+                .iter()
+                .all(|(n,)| !n.starts_with("rustango_preflight")),
+            "probe table was left behind: {names:?}"
+        );
+    }
+}
+
+// ------------------------------------------------------------ PostgreSQL
+
+#[cfg(feature = "postgres")]
+mod pg {
+    use super::{preflight, ConnectFault, Preflight, DEAD_PORT};
+
+    fn base() -> Option<String> {
+        std::env::var("DATABASE_URL").ok()
+    }
+
+    /// Swap the database name in a `postgres://…/name` URL.
+    fn with_db(url: &str, db: &str) -> String {
+        let (head, _) = url.rsplit_once('/').expect("url has a database segment");
+        format!("{head}/{db}")
+    }
+
+    /// Swap the password.
+    fn with_password(url: &str, pw: &str) -> String {
+        let (scheme, rest) = url.split_once("://").expect("scheme");
+        let (userinfo, hostpart) = rest.split_once('@').expect("userinfo");
+        let user = userinfo.split_once(':').map_or(userinfo, |(u, _)| u);
+        format!("{scheme}://{user}:{pw}@{hostpart}")
+    }
+
+    #[tokio::test]
+    async fn a_healthy_database_passes_the_write_probe() {
+        let Some(url) = base() else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let ok = preflight::check(&url, &Preflight::default())
+            .await
+            .expect("healthy postgres");
+        assert!(ok.writes_verified);
+        // The endpoint is echoed back with no password in it.
+        assert!(
+            !ok.endpoint.contains("postgres:postgres"),
+            "{}",
+            ok.endpoint
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dead_port_reads_as_unreachable() {
+        let Some(url) = base() else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let dead = url.replace("5457", &DEAD_PORT.to_string());
+        let err = preflight::check(&dead, &Preflight::default())
+            .await
+            .expect_err("nothing is listening there");
+        assert_eq!(err.fault, ConnectFault::Unreachable, "{err}");
+        assert!(err.to_string().contains("nothing is listening"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_wrong_password_reads_as_auth_failed_not_as_unreachable() {
+        let Some(url) = base() else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let err = preflight::check(
+            &with_password(&url, "definitely-not-it"),
+            &Preflight::default(),
+        )
+        .await
+        .expect_err("bad credentials");
+        assert_eq!(err.fault, ConnectFault::AuthFailed, "{err}");
+        assert!(
+            err.to_string().contains("refused these credentials"),
+            "{err}"
+        );
+        // The bad password must not be echoed back.
+        assert!(
+            !err.to_string().contains("definitely-not-it"),
+            "password leaked: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_database_says_so_rather_than_failing_generically() {
+        let Some(url) = base() else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let err = preflight::check(&with_db(&url, "no_such_db_here"), &Preflight::default())
+            .await
+            .expect_err("database does not exist");
+        assert_eq!(err.fault, ConnectFault::NoSuchDatabase, "{err}");
+        assert!(err.to_string().contains("no such database"), "{err}");
+    }
+
+    /// The case a naive `SELECT 1` check sails past and a migration
+    /// then dies on: a role that can connect and read but cannot
+    /// create tables.
+    #[tokio::test]
+    async fn a_role_that_cannot_create_tables_is_caught_by_the_write_probe() {
+        use rustango::sql::sqlx;
+
+        let Some(url) = base() else {
+            eprintln!("skipping: DATABASE_URL unset");
+            return;
+        };
+        let admin = sqlx::PgPool::connect(&url).await.expect("admin connect");
+        // A role with LOGIN and nothing else. `public` in PG 15+ no
+        // longer grants CREATE to everyone, which is what makes this
+        // reproducible.
+        let _ = sqlx::query("DROP ROLE IF EXISTS rgo_nocreate")
+            .execute(&admin)
+            .await;
+        sqlx::query("CREATE ROLE rgo_nocreate LOGIN PASSWORD 'pw'")
+            .execute(&admin)
+            .await
+            .expect("create role");
+        sqlx::query("REVOKE CREATE ON SCHEMA public FROM PUBLIC")
+            .execute(&admin)
+            .await
+            .expect("revoke");
+
+        let (_, hostpart) = url.split_once('@').expect("userinfo");
+        let limited = format!("postgres://rgo_nocreate:pw@{hostpart}");
+
+        // Read-only: passes, because reading is all it checks.
+        preflight::check(&limited, &Preflight::read_only())
+            .await
+            .expect("a read-only check should pass — which is the problem");
+
+        // Full: caught.
+        let err = preflight::check(&limited, &Preflight::default())
+            .await
+            .expect_err("the write probe must catch this");
+        assert_eq!(err.fault, ConnectFault::PermissionDenied, "{err}");
+        assert!(err.to_string().contains("cannot create tables"), "{err}");
+
+        let _ = sqlx::query("GRANT CREATE ON SCHEMA public TO PUBLIC")
+            .execute(&admin)
+            .await;
+        let _ = sqlx::query("DROP ROLE IF EXISTS rgo_nocreate")
+            .execute(&admin)
+            .await;
+    }
+
+    /// #1306: pointing a `postgres://` URL at a server that does not
+    /// speak the Postgres protocol must read as "wrong server on this
+    /// port", not as a locale problem. MySQL stands in for "a different
+    /// server", which is exactly the shape of the original bug.
+    #[tokio::test]
+    async fn a_mysql_server_on_a_postgres_url_reads_as_the_wrong_server() {
+        let Ok(my) = std::env::var("MYSQL_TEST_URL") else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let (_, hostpart) = my.split_once('@').expect("userinfo");
+        let confused = format!("postgres://root:my@{hostpart}");
+
+        let err = preflight::check(&confused, &Preflight::default())
+            .await
+            .expect_err("a MySQL server does not speak the Postgres protocol");
+        assert!(
+            matches!(
+                err.fault,
+                ConnectFault::UnexpectedServer | ConnectFault::Unreachable
+            ),
+            "got {:?}: {err}",
+            err.fault
+        );
+    }
+}
+
+// ------------------------------------------------------------------ MySQL
+
+#[cfg(feature = "mysql")]
+mod mysql {
+    use super::{preflight, ConnectFault, Preflight, DEAD_PORT};
+
+    fn base() -> Option<String> {
+        std::env::var("MYSQL_TEST_URL").ok()
+    }
+
+    #[tokio::test]
+    async fn a_healthy_database_passes_the_write_probe() {
+        let Some(url) = base() else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let ok = preflight::check(&url, &Preflight::default())
+            .await
+            .expect("healthy mysql");
+        assert!(ok.writes_verified);
+        assert!(!ok.endpoint.contains("root:my"), "{}", ok.endpoint);
+    }
+
+    #[tokio::test]
+    async fn a_dead_port_reads_as_unreachable() {
+        let Some(url) = base() else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let dead = url.replace("3408", &DEAD_PORT.to_string());
+        let err = preflight::check(&dead, &Preflight::default())
+            .await
+            .expect_err("nothing is listening there");
+        assert_eq!(err.fault, ConnectFault::Unreachable, "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_wrong_password_reads_as_auth_failed() {
+        let Some(url) = base() else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let (scheme, rest) = url.split_once("://").expect("scheme");
+        let (userinfo, hostpart) = rest.split_once('@').expect("userinfo");
+        let user = userinfo.split_once(':').map_or(userinfo, |(u, _)| u);
+        let bad = format!("{scheme}://{user}:nope@{hostpart}");
+
+        let err = preflight::check(&bad, &Preflight::default())
+            .await
+            .expect_err("bad credentials");
+        assert_eq!(err.fault, ConnectFault::AuthFailed, "{err}");
+        assert!(
+            !err.to_string().contains(":nope@"),
+            "password leaked: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_database_says_so() {
+        let Some(url) = base() else {
+            eprintln!("skipping: MYSQL_TEST_URL unset");
+            return;
+        };
+        let (head, _) = url.rsplit_once('/').expect("database segment");
+        let err = preflight::check(&format!("{head}/no_such_db_here"), &Preflight::default())
+            .await
+            .expect_err("database does not exist");
+        assert_eq!(err.fault, ConnectFault::NoSuchDatabase, "{err}");
+    }
+}

--- a/crates/rustango/tests/preflight_live.rs
+++ b/crates/rustango/tests/preflight_live.rs
@@ -17,6 +17,50 @@ use rustango::tenancy::preflight::{self, Preflight};
 /// A port nothing is on. High and odd enough to be safe in CI.
 const DEAD_PORT: u16 = 59_417;
 
+/// Point a URL at [`DEAD_PORT`], whatever port it currently names.
+///
+/// The obvious version — `url.replace("5457", …)` — hardcodes whatever
+/// port the developer's local container happened to use, so in CI
+/// (where the URL says `:5432`) the replace silently does nothing and
+/// the "unreachable" test connects to a perfectly healthy database.
+/// That is not a test failing loudly; it is a test asserting the
+/// opposite of what it claims, and only the `expect_err` caught it.
+fn at_a_dead_port(url: &str) -> String {
+    let (scheme, rest) = url.split_once("://").expect("url has a scheme");
+    // Userinfo may contain `@` and `:`; the authority is what follows
+    // the LAST `@`, and the path starts at the first `/` after that.
+    let (userinfo, authority) = match rest.rsplit_once('@') {
+        Some((u, a)) => (format!("{u}@"), a),
+        None => (String::new(), rest),
+    };
+    let (hostport, tail) = match authority.find('/') {
+        Some(i) => (&authority[..i], &authority[i..]),
+        None => (authority, ""),
+    };
+    let host = hostport.rsplit_once(':').map_or(hostport, |(h, _)| h);
+    format!("{scheme}://{userinfo}{host}:{DEAD_PORT}{tail}")
+}
+
+#[test]
+fn the_dead_port_helper_rewrites_whatever_port_is_there() {
+    assert_eq!(
+        at_a_dead_port("postgres://u:p@localhost:5432/db"),
+        format!("postgres://u:p@localhost:{DEAD_PORT}/db")
+    );
+    // No port at all — one still has to be added, or the test would
+    // hit the backend's default and reach a real server.
+    assert_eq!(
+        at_a_dead_port("mysql://root@127.0.0.1/app"),
+        format!("mysql://root@127.0.0.1:{DEAD_PORT}/app")
+    );
+    // A password containing `@` must not be mistaken for the
+    // authority separator.
+    assert_eq!(
+        at_a_dead_port("postgres://u:p@ss@db.internal:5432/x"),
+        format!("postgres://u:p@ss@db.internal:{DEAD_PORT}/x")
+    );
+}
+
 // ---------------------------------------------------------------- SQLite
 
 #[cfg(feature = "sqlite")]
@@ -134,7 +178,7 @@ mod sqlite {
 
 #[cfg(feature = "postgres")]
 mod pg {
-    use super::{preflight, ConnectFault, Preflight, DEAD_PORT};
+    use super::{preflight, ConnectFault, Preflight};
 
     fn base() -> Option<String> {
         std::env::var("DATABASE_URL").ok()
@@ -178,7 +222,7 @@ mod pg {
             eprintln!("skipping: DATABASE_URL unset");
             return;
         };
-        let dead = url.replace("5457", &DEAD_PORT.to_string());
+        let dead = super::at_a_dead_port(&url);
         let err = preflight::check(&dead, &Preflight::default())
             .await
             .expect_err("nothing is listening there");
@@ -304,7 +348,7 @@ mod pg {
 
 #[cfg(feature = "mysql")]
 mod mysql {
-    use super::{preflight, ConnectFault, Preflight, DEAD_PORT};
+    use super::{preflight, ConnectFault, Preflight};
 
     fn base() -> Option<String> {
         std::env::var("MYSQL_TEST_URL").ok()
@@ -329,7 +373,7 @@ mod mysql {
             eprintln!("skipping: MYSQL_TEST_URL unset");
             return;
         };
-        let dead = url.replace("3408", &DEAD_PORT.to_string());
+        let dead = super::at_a_dead_port(&url);
         let err = preflight::check(&dead, &Preflight::default())
             .await
             .expect_err("nothing is listening there");

--- a/crates/rustango/tests/provision_sqlite_live.rs
+++ b/crates/rustango/tests/provision_sqlite_live.rs
@@ -97,14 +97,16 @@ async fn the_engine_provisions_without_argv_or_a_writer() {
     assert_eq!(outcome.slug, "acme");
     assert!(outcome.org_id > 0, "org id should come back: {outcome:?}");
 
-    // Every step reports, in order, and the not-yet-built one reports
-    // as skipped rather than silently not existing.
+    // Every step reports, in order. `ProvisionStorage` skips because a
+    // database-mode tenant brings its own database — there is no schema
+    // to create — and says so rather than silently not appearing.
     assert_eq!(
         rec.steps(),
         vec![
             "Validate:started",
             "Validate:ok",
-            "CheckConnection:skipped",
+            "CheckConnection:started",
+            "CheckConnection:ok",
             "ProvisionStorage:skipped",
             "RegisterOrg:started",
             "RegisterOrg:ok",
@@ -317,6 +319,70 @@ async fn provisioning_unobserved_works_the_same() {
         !matches!(outcome.migrations, MigrationsOutcome::Skipped),
         "migrations were requested: {:?}",
         outcome.migrations
+    );
+}
+
+/// The half-provisioned-tenant bug, closed (#1319).
+///
+/// A database URL that cannot be reached must be caught at
+/// `CheckConnection` — before the `Org` row exists. Previously the row
+/// landed first and the failure surfaced at migration time, leaving a
+/// tenant the resolver matches in front of a database with no schema.
+#[tokio::test]
+async fn an_unreachable_database_is_caught_before_the_org_row_is_written() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    // `mode=ro` on a path that does not exist: sqlite will not create
+    // it, so this is genuinely unreachable. (Without a mode, rustango
+    // defaults to `rwc` and would create the file — see
+    // `preflight_live`.)
+    let missing = _tmp.path().join("nowhere").join("tenant.db");
+    let request = ProvisionRequest::database(
+        "unreachable",
+        format!("sqlite://{}?mode=ro", missing.display()),
+    );
+
+    let rec = Recorder::default();
+    let err = provision::provision_tenant(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        Some(&rec.observer()),
+    )
+    .await
+    .expect_err("an unreachable database must stop the run");
+
+    // The message names the endpoint and what to do, not a raw driver
+    // string.
+    let text = err.to_string();
+    assert!(
+        text.contains("tenant.db"),
+        "should name the endpoint: {text}"
+    );
+
+    assert_eq!(
+        rec.steps(),
+        vec![
+            "Validate:started",
+            "Validate:ok",
+            "CheckConnection:started",
+            "CheckConnection:failed",
+        ],
+        "the run must stop at the connection check: {:?}",
+        rec.steps()
+    );
+
+    // The whole point: nothing was registered.
+    let orgs = rustango::tenancy::Org::objects()
+        .fetch(&pools.registry_pool())
+        .await
+        .expect("fetch orgs");
+    assert!(
+        orgs.is_empty(),
+        "a failed connection check must leave no Org row: {orgs:?}"
     );
 }
 


### PR DESCRIPTION
Closes #1319 and #1306. **Stacked on #1325** (which is stacked on #1324) — this PR's diff is only the last commit.

## Before

`create-tenant` took `--database-url` on faith: insert the `Org` row, *then* migrate against whatever it pointed at. A typo'd host, a wrong password, or a database nobody had created yet left a **half-provisioned tenant** — a live registry row the resolver happily matches, in front of a database with no schema.

The `CheckConnection` step #1325 left as a stub now actually runs, and nothing is written until it passes.

## A taxonomy, not a boolean

The old code already managed "it failed". The point is that these are four different operator actions:

| what happened | what to do |
|---|---|
| connection refused on :5432 | fix the host/port, or the firewall |
| database `acme` does not exist | create it, or fix the name |
| role `app` cannot create tables | grant it schema-level CREATE |
| something else is on this port | check what is actually listening |

`ConnectFault` names each and carries advice saying what to change. **Classification keys on `sqlx::Error` variants and on SQLSTATE/errno — never on message text**, which is brittle and localised. The driver's own words are still carried as `detail`; they're useful once you know which kind of problem you're reading.

## #1306 falls out of this

The reported symptom was a non-UTF-8 `ErrorResponse` blaming `lc_messages` — three layers from the real cause, a local Postgres shadowing a Docker container on 5432. A protocol error *at connect time* means the bytes coming back aren't what this driver speaks, so it classifies as `UnexpectedServer` and leads with the port conflict.

Because every connect path in `sql::pool` routes through the classifier, **`migrate` — the first command a new user runs — gets this for free**, which is where #1306 was actually reported.

## Why `SELECT 1` is not the check

A database this role can read but not `CREATE TABLE` in passes connect-and-ping, then dies twenty migrations later, already registered. So the probe creates a table and drops it. That's a write, so it's a flag: on by default for provisioning (a migration run is seconds away), off for `Preflight::read_only()`.

There's a test for exactly this: a PG role with `CREATE ON SCHEMA public` revoked **passes** the read-only check and **fails** the full one.

## Credentials

`connect(postgres://user:password@host/db)` was printed verbatim to the terminal on a failed `manage` connect. Every endpoint this code renders now goes through `redact`, with three tests asserting no password survives — including one where the password itself contains an `@`.

## Also here

- **`Pool::connect_diagnosed`** — same connect, structured error, so a caller can branch on the fault instead of parsing prose back out of `PoolError::Connect(String)`. Scheme dispatch now lives in one private `connect_inner` instead of being duplicated. `PoolError` is untouched, so this is additive.
- **`Pool::close`** — dropping a pool schedules the close without waiting, so a short-lived probe could outlive its socket.
- **`manage test-tenant-connection <url> [--no-write-probe] [--timeout <secs>]`** — the taxonomy without needing a tenant, and a test surface that isn't an HTTP handler.

## Two bugs the tests caught in my own code

**MySQL reports `SQLSTATE 42000` for a missing database** — the same generic class as a syntax error. My first cut matched errno strings against `code()`, which returns SQLSTATE, so `1049` never fired. MySQL is now classified on `number()` via downcast, with SQLSTATE as fallback.

**rustango deliberately appends `?mode=rwc` to sqlite URLs** (`ensure_sqlite_rwc_default`), so "the file does not exist" is simply not a failure on that dialect — it gets created. My test asserted the opposite. It now pins the real asymmetry with PG/MySQL so the next person finds it written down.

## Verification

- **14 new pre-flight tests against live Postgres 16, MySQL 8 and SQLite**, covering healthy, dead port, wrong password, missing database, the revoked-CREATE role, and a MySQL server behind a `postgres://` URL (#1306's shape).
- 7 unit tests on the classifier and redactor, including the exact `lc_messages` string from the #1306 report.
- 8 engine tests — one proves a failed connection check leaves **no** `Org` row, which is the bug this closes.
- `manage_live` 13/13 against PG, unmodified. #1324's 13 still green. 3636 lib tests.
- Zero warnings on sqlite / postgres / mysql / +tenancy / +signals / +testkit / multi-backend / `--all-features --tests`, plus `--workspace --all-features --no-run`, `fmt --check`, and clippy clean on all three new files.

## Next

#1321 (persist provisioning runs) is the last prerequisite before the console (#1322) and the webhook (#1323).