### PR TITLE
feat(tenancy): persist provisioning runs, and settle what a failed one leaves

### DIFF
--- a/crates/rustango/src/tenancy/manage/migrations.rs
+++ b/crates/rustango/src/tenancy/manage/migrations.rs
@@ -25,27 +25,13 @@ where
     // migrate-tenants` shows each migration as it lands instead of
     // sitting silent for the length of the run.
     let progress = CliProgress::new(w);
-
-    // v0.38 — on PG the legacy `migrate_tenants` handles both schema-
-    // mode and database-mode tenants; on non-PG we route through the
-    // generic `migrate_tenants_db` which is database-mode-only by
-    // design (schema-mode is PG-only by language).
-    #[cfg(feature = "postgres")]
-    let report = {
-        if let Some(pg_pools) =
-            (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
-        {
-            tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, &progress)
-                .await?
-        } else {
-            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
-                .await?
-        }
-    };
-    #[cfg(not(feature = "postgres"))]
-    let report =
-        tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
-            .await?;
+    let report = tenant_migrate::migrate_tenants_dyn_with_progress(
+        pools,
+        dir,
+        registry_url,
+        Some(&progress),
+    )
+    .await?;
     let w = progress.into_inner();
     write_tenant_report(w, &report)
 }
@@ -332,27 +318,17 @@ where
         }
     }
 
-    // Tenant phase. Branch by backend: PG goes through the legacy
-    // `migrate_tenants` (handles schema-mode + database-mode);
-    // sqlite/mysql route through `migrate_tenants_db` (database-mode
-    // only — schema-mode is PG-only by language).
+    // Tenant phase, through the one dispatch seam — see
+    // `migrate_tenants_dyn_with_progress` for why this is not a
+    // backend branch written out here.
     let progress = CliProgress::new(w);
-    #[cfg(feature = "postgres")]
-    let report = {
-        if let Some(pg_pools) =
-            (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
-        {
-            tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, &progress)
-                .await?
-        } else {
-            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
-                .await?
-        }
-    };
-    #[cfg(not(feature = "postgres"))]
-    let report =
-        tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, &progress)
-            .await?;
+    let report = tenant_migrate::migrate_tenants_dyn_with_progress(
+        pools,
+        dir,
+        registry_url,
+        Some(&progress),
+    )
+    .await?;
     let w = progress.into_inner();
     write_tenant_report(w, &report)?;
     Ok(())

--- a/crates/rustango/src/tenancy/migrate.rs
+++ b/crates/rustango/src/tenancy/migrate.rs
@@ -546,6 +546,65 @@ where
     migrate_tenants_db_opts(pools, dir, registry_url, Some(observer)).await
 }
 
+/// Migrate exactly one tenant, named by its `Org` row.
+///
+/// The batch entry points walk `Org::objects().where_(active = true)`,
+/// which makes them the wrong tool twice over for a tenant that is
+/// being stood up:
+///
+/// * a tenant mid-provision is deliberately **inactive** until its
+///   schema is in place, so the batch would skip the very tenant it was
+///   called for; and
+/// * running the whole batch means creating tenant B does a pass over
+///   tenant A, and an unrelated tenant's broken chain surfaces in the
+///   middle of an unrelated provisioning run.
+///
+/// Takes the `Org` directly and ignores `active` — the caller has
+/// already decided this is the tenant it means.
+///
+/// # Errors
+/// Anything the tenant's own migration run can raise: an unreachable
+/// tenant database, a failing migration, or a storage mode this build
+/// cannot serve.
+pub async fn migrate_one_tenant<DB: Database>(
+    pools: &TenantPools<DB>,
+    org: &Org,
+    dir: &Path,
+    registry_url: &str,
+    observer: Option<&dyn TenantMigrationObserver>,
+) -> Result<Vec<Migration>, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let scoped = scoped_subset(dir, MigrationScope::Tenant).await?;
+    let scoped_path = match &scoped {
+        ScopedDir::Owned(temp) => temp.path().to_path_buf(),
+        ScopedDir::Original => dir.to_path_buf(),
+    };
+
+    // Schema-mode is PG-only by language, and only the PG runner knows
+    // how to build a `search_path`-scoped pool for it. Route the same
+    // way the batch does.
+    #[cfg(feature = "postgres")]
+    if matches!(
+        StorageMode::parse(&org.storage_mode),
+        Ok(StorageMode::Schema)
+    ) {
+        let pg_pools = (pools as &dyn std::any::Any)
+            .downcast_ref::<TenantPools<sqlx::Postgres>>()
+            .ok_or_else(|| {
+                TenancyError::Validation(format!(
+                    "org `{}` is schema-mode but the registry is not Postgres",
+                    org.slug
+                ))
+            })?;
+        return run_for_one_tenant(pg_pools, org, &scoped_path, registry_url, observer).await;
+    }
+    let _ = registry_url;
+
+    run_for_one_tenant_db(pools, org, &scoped_path, observer).await
+}
+
 async fn migrate_tenants_db_opts<DB: Database>(
     pools: &TenantPools<DB>,
     dir: &Path,
@@ -713,11 +772,36 @@ pub async fn migrate_tenants_dyn<DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
+    migrate_tenants_dyn_with_progress(pools, dir, registry_url, None).await
+}
+
+/// [`migrate_tenants_dyn`], reporting progress to `observer`.
+///
+/// **This is the seam every caller should use.** The
+/// "downcast to `TenantPools<Postgres>`, else fall back to the generic
+/// runner" dance is easy to write from memory and was written from
+/// memory in four places; each copy is a chance to get the schema-mode
+/// branch subtly wrong on a non-PG build. One dispatch, here.
+///
+/// # Errors
+/// As [`migrate_tenants`] / [`migrate_tenants_db`].
+pub async fn migrate_tenants_dyn_with_progress<DB: Database>(
+    pools: &TenantPools<DB>,
+    dir: &Path,
+    registry_url: &str,
+    observer: Option<&dyn TenantMigrationObserver>,
+) -> Result<TenantMigrationReport, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    // On PG the legacy `migrate_tenants` handles schema-mode as well as
+    // database-mode; everywhere else `migrate_tenants_db` is the only
+    // one that applies, because schema-mode is PG-only by language.
     #[cfg(feature = "postgres")]
     if let Some(pg) = (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>() {
-        return migrate_tenants(pg, dir, registry_url).await;
+        return migrate_tenants_opts(pg, dir, registry_url, observer).await;
     }
-    migrate_tenants_db(pools, dir, registry_url).await
+    migrate_tenants_db_opts(pools, dir, registry_url, observer).await
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -96,15 +96,18 @@ pub mod org_host;
 pub mod password;
 pub mod permissions;
 mod pools;
-/// Who a request is acting as, whatever authenticated it (session cookie,
-/// Bearer access token, MCP agent token).
 /// Reaching a tenant's database before anything is written to the
 /// registry, so a bad URL cannot leave a half-provisioned tenant.
 pub mod preflight;
+/// Who a request is acting as, whatever authenticated it (session cookie,
+/// Bearer access token, MCP agent token).
 pub mod principal;
 /// Standing up a tenant — the steps the `create-tenant` verb runs,
 /// callable from anything that is not a terminal.
 pub mod provision;
+/// Durable record of provisioning runs and their events, so a run
+/// survives a reconnect and is readable from a second pod.
+pub mod provision_store;
 mod resolver;
 mod resolver_cache;
 pub mod routes;
@@ -168,9 +171,10 @@ pub use error::TenancyError;
 #[cfg(all(feature = "tenancy", feature = "sso"))]
 pub use member_auth::{member_sso_router, CurrentMember, MemberAuthConfig, MEMBER_COOKIE};
 pub use migrate::{
-    migrate_registry, migrate_registry_pool, migrate_tenants_db, migrate_tenants_db_with_progress,
-    migrate_tenants_dyn, Chain, TenantMigrationEvent, TenantMigrationObserver,
-    TenantMigrationOutcome, TenantMigrationReport,
+    migrate_one_tenant, migrate_registry, migrate_registry_pool, migrate_tenants_db,
+    migrate_tenants_db_with_progress, migrate_tenants_dyn, migrate_tenants_dyn_with_progress,
+    Chain, TenantMigrationEvent, TenantMigrationObserver, TenantMigrationOutcome,
+    TenantMigrationReport,
 };
 #[cfg(feature = "postgres")]
 pub use migrate::{migrate_tenants, migrate_tenants_with_progress};

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -24,17 +24,34 @@
 //!    `CREATE SCHEMA` for schema-mode. Deliberately before the row
 //!    lands, so a failed `INSERT` leaves no orphan schema.
 //! 4. [`RegisterOrg`](ProvisionStep::RegisterOrg) — the `rustango_orgs`
-//!    row, after which the tenant resolves.
-//! 5. [`Migrate`](ProvisionStep::Migrate) — the tenant's own schema.
+//!    row, written **inactive**.
+//! 5. [`Migrate`](ProvisionStep::Migrate) — the tenant's own schema,
+//!    through [`tenant_migrate::migrate_one_tenant`]: this tenant, not
+//!    the whole active batch.
+//! 6. [`Activate`](ProvisionStep::Activate) — flip `active`, after
+//!    which the tenant resolves.
 //!
-//! ## What is deliberately still wrong here
+//! ## Inactive until ready, and what a failed run leaves
 //!
-//! Step 5 migrates **every active tenant**, then filters the report down
-//! to the one just created. That is what the verb has always done, and
-//! changing it is not this refactor's business — but it means creating
-//! tenant B does a pass over tenant A, and an unrelated tenant's broken
-//! chain shows up in the middle of an unrelated provisioning run. See
-//! the parent epic.
+//! The row goes in inactive and is activated last. That is the whole
+//! answer to "what does a half-provisioned tenant do": nothing, because
+//! the resolver filters on `active` and it is not set yet. There is no
+//! window in which a tenant resolves to a database with no schema.
+//!
+//! A run that fails at the migrate step therefore leaves an **inactive
+//! `Org` row plus whatever schema landed**. The row stays on purpose:
+//! an operator needs to see what was half-made, and rolling it back is
+//! not always possible once a schema or a database exists. Nothing
+//! routes to it in the meantime.
+//!
+//! This overloads `active`, which until now meant "suspended customer"
+//! and now also means "never finished provisioning". The two are
+//! identical to the resolver — do not serve — and the distinction that
+//! does matter is answerable from
+//! [`super::provision_store`], which is where the detail belongs. A
+//! dedicated `provisioning_state` column would be tidier and would cost
+//! a core-model change rippling through every hand-written test schema,
+//! for a distinction only the console needs.
 
 use std::path::Path;
 
@@ -113,10 +130,15 @@ pub enum ProvisionStep {
     CheckConnection,
     /// `CREATE SCHEMA` for schema-mode. Nothing to do in database-mode.
     ProvisionStorage,
-    /// Insert the `rustango_orgs` row.
+    /// Insert the `rustango_orgs` row — **inactive**, so nothing routes
+    /// to the tenant until its schema is in place.
     RegisterOrg,
     /// Apply the tenant's migrations.
     Migrate,
+    /// Flip `active`, after which the tenant resolves. Last on purpose:
+    /// it is what closes the window where a half-provisioned tenant
+    /// serves requests against a database with no schema.
+    Activate,
 }
 
 /// How a step went.
@@ -194,28 +216,229 @@ pub struct ProvisionOutcome {
     pub migrations: MigrationsOutcome,
 }
 
-fn emit(observer: Option<&dyn ProvisionObserver>, event: impl FnOnce() -> ProvisionEvent) {
-    if let Some(observer) = observer {
-        observer.on_event(event());
+/// Where a run reports: the caller's observer, and optionally the
+/// durable store.
+///
+/// ## Why migration events are buffered and step transitions are not
+///
+/// Step transitions happen between steps, with no lock held, so they
+/// are written as they occur — which is what makes a run readable from
+/// a second pod while it is still going.
+///
+/// Migration events are different: they arrive **synchronously from
+/// inside the migrate lock** (see [`crate::migrate::progress`]), where
+/// an `await` on a registry write would extend a lock every other
+/// migrating pod is queued behind. So they are buffered and flushed
+/// once the migrate step ends.
+///
+/// The cost is that a watcher sees `Migrate: started`, then a pause,
+/// then the whole per-migration log at once — rather than line by line.
+/// The alternative is a bounded channel and a drain task, which trades
+/// that for dropped events when the channel fills, and a `seq` with
+/// holes in it is no use as a replay log. Worth revisiting when the
+/// console (#1322) shows whether the pause actually matters.
+pub(super) struct Reporter<'a> {
+    observer: Option<&'a dyn ProvisionObserver>,
+    store: Option<RunStore<'a>>,
+}
+
+struct RunStore<'a> {
+    registry: &'a crate::sql::Pool,
+    run_id: i64,
+    /// Next `seq`. Dense and per-run, because `Last-Event-ID` counts
+    /// from it.
+    seq: std::sync::atomic::AtomicI64,
+    buffered: std::sync::Mutex<Vec<(String, String, String)>>,
+}
+
+impl<'a> Reporter<'a> {
+    pub(super) fn new(observer: Option<&'a dyn ProvisionObserver>) -> Self {
+        Self {
+            observer,
+            store: None,
+        }
+    }
+
+    /// Also persist to `run_id` in the registry.
+    pub(super) fn persisting(mut self, registry: &'a crate::sql::Pool, run_id: i64) -> Self {
+        self.store = Some(RunStore {
+            registry,
+            run_id,
+            seq: std::sync::atomic::AtomicI64::new(1),
+            buffered: std::sync::Mutex::new(Vec::new()),
+        });
+        self
+    }
+
+    fn notify(&self, event: ProvisionEvent) {
+        if let Some(observer) = self.observer {
+            observer.on_event(event);
+        }
+    }
+
+    /// Write one row now. Failures are logged, never propagated: the
+    /// record of a provisioning run must not be what fails it.
+    async fn write(&self, step: &str, status: &str, message: &str) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        let seq = store.seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Err(e) = super::provision_store::append_event(
+            store.registry,
+            store.run_id,
+            seq,
+            step,
+            status,
+            message,
+        )
+        .await
+        {
+            tracing::warn!(
+                target: "rustango::tenancy::provision",
+                run_id = store.run_id,
+                error = %e,
+                "could not record a provisioning event; the run continues"
+            );
+        }
+    }
+
+    /// Queue a migration event for the next [`flush`](Self::flush).
+    fn buffer(&self, step: &str, status: &str, message: &str) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        if let Ok(mut buf) = store.buffered.lock() {
+            buf.push((step.to_owned(), status.to_owned(), message.to_owned()));
+        }
+    }
+
+    /// Write everything buffered, in order.
+    async fn flush(&self) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        let pending = match store.buffered.lock() {
+            Ok(mut buf) => std::mem::take(&mut *buf),
+            Err(_) => return,
+        };
+        for (step, status, message) in pending {
+            self.write(&step, &status, &message).await;
+        }
     }
 }
 
-fn step(observer: Option<&dyn ProvisionObserver>, step: ProvisionStep, status: StepStatus) {
-    emit(observer, || ProvisionEvent::Step { step, status });
+impl Reporter<'_> {
+    /// Announce a step transition — to the observer, and to the store.
+    async fn step(&self, step: ProvisionStep, status: StepStatus) {
+        self.write(step.as_str(), status.as_str(), status.detail())
+            .await;
+        self.notify(ProvisionEvent::Step { step, status });
+    }
+
+    /// Report a step's failure, then hand back the error.
+    ///
+    /// Every failure path goes through this rather than a bare `?`, so
+    /// a watcher never sees a step stuck on `Started` with no
+    /// explanation — which is the state the whole event stream exists
+    /// to prevent.
+    async fn fail<T>(&self, at: ProvisionStep, e: TenancyError) -> Result<T, TenancyError> {
+        self.step(at, StepStatus::Failed(e.to_string())).await;
+        Err(e)
+    }
+
+    /// A migration event from the tenant's own run. Buffered rather
+    /// than written — see the type docs.
+    fn migration(&self, event: tenant_migrate::TenantMigrationEvent) {
+        self.buffer("migration", "info", &render_migration(&event));
+        self.notify(ProvisionEvent::Migration(event));
+    }
 }
 
-/// Report a step's failure to the observer, then return the error.
-///
-/// Every failure path goes through this rather than a bare `?`, so a
-/// watcher never sees a step stuck on `Started` with no explanation —
-/// which is the state the whole event stream exists to prevent.
-fn fail<T>(
-    observer: Option<&dyn ProvisionObserver>,
-    at: ProvisionStep,
-    e: TenancyError,
-) -> Result<T, TenancyError> {
-    step(observer, at, StepStatus::Failed(e.to_string()));
-    Err(e)
+impl ProvisionStep {
+    /// Stable wire name, stored in `rustango_provisioning_events.step`
+    /// and matched on by a console. Written out rather than derived
+    /// from `Debug`, which is not a stable format.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Validate => "validate",
+            Self::CheckConnection => "check_connection",
+            Self::ProvisionStorage => "provision_storage",
+            Self::RegisterOrg => "register_org",
+            Self::Migrate => "migrate",
+            Self::Activate => "activate",
+        }
+    }
+}
+
+impl StepStatus {
+    /// Stable wire name.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Started => "started",
+            Self::Ok => "ok",
+            Self::Skipped(_) => "skipped",
+            Self::Failed(_) => "failed",
+        }
+    }
+
+    /// The reason carried by `Skipped` / `Failed`, or empty.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::Started | Self::Ok => "",
+            Self::Skipped(why) | Self::Failed(why) => why,
+        }
+    }
+}
+
+/// One line describing a migration event, for the stored log.
+fn render_migration(event: &tenant_migrate::TenantMigrationEvent) -> String {
+    use crate::migrate::{MigrationEvent as M, Outcome};
+    use tenant_migrate::{Chain, TenantMigrationEvent as E};
+
+    let chain_tag = |c: Chain| match c {
+        Chain::System => "system",
+        Chain::Project => "app",
+    };
+    match event {
+        E::Planned { tenants } => format!("migrating {tenants} tenant(s)"),
+        E::TenantStarted { slug, .. } => format!("tenant {slug}"),
+        E::TenantFinished {
+            slug,
+            applied,
+            error,
+            ..
+        } => match error {
+            Some(e) => format!("tenant {slug} failed: {e}"),
+            None => format!("tenant {slug}: {applied} migration(s)"),
+        },
+        E::Migration { chain, event, .. } => match event {
+            M::Planned { total } => format!("{}: {total} pending", chain_tag(*chain)),
+            M::Started { name, .. } => format!("{}/{name} started", chain_tag(*chain)),
+            M::Finished {
+                name,
+                outcome,
+                elapsed,
+                ..
+            } => {
+                let verb = match outcome {
+                    Outcome::Ran => "applied",
+                    Outcome::RanPartial { .. } => "applied (partial)",
+                    Outcome::Faked => "faked",
+                };
+                format!(
+                    "{verb} {}/{name} ({:.1}s)",
+                    chain_tag(*chain),
+                    elapsed.as_secs_f64()
+                )
+            }
+            M::Failed { name, error, .. } => {
+                format!("{}/{name} failed: {error}", chain_tag(*chain))
+            }
+        },
+    }
 }
 
 /// Stand up a tenant: validate, provision its storage, register it, and
@@ -242,8 +465,86 @@ pub async fn provision_tenant<DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
+    let rep = Reporter::new(observer);
+    provision_reported(pools, registry_url, dir, request, &rep).await
+}
+
+/// [`provision_tenant`], with the run persisted to
+/// [`super::provision_store`] as it goes.
+///
+/// The durable half of the same call: step transitions are written as
+/// they happen, so a run started on one pod is readable — and
+/// replayable from the beginning — on another.
+///
+/// # Errors
+/// As [`provision_tenant`]. A failure to *record* the run is logged and
+/// never propagated: the bookkeeping must not be what fails a tenant
+/// creation.
+pub async fn provision_tenant_recorded<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    dir: &Path,
+    request: &ProvisionRequest,
+    observer: Option<&dyn ProvisionObserver>,
+    requested_by: Option<&str>,
+    idempotency_key: Option<&str>,
+) -> Result<(super::provision_store::ProvisioningRun, ProvisionOutcome), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    use super::provision_store::{self as store, RunState};
+
+    let registry = pools.registry_pool();
+    let run = store::open_run(
+        &registry,
+        &request.slug,
+        request.mode.as_str(),
+        request.backend.as_str(),
+        request.database_url.as_deref(),
+        requested_by,
+        idempotency_key,
+    )
+    .await?;
+    let run_id = run.id.get().copied().unwrap_or_default();
+
+    let rep = Reporter::new(observer).persisting(&registry, run_id);
+    let result = provision_reported(pools, registry_url, dir, request, &rep).await;
+
+    // Whatever happened, close the run — including on the error paths,
+    // where a run left `running` forever is exactly the ambiguity this
+    // table exists to remove.
+    let (state, error) = match &result {
+        Ok(outcome) => match &outcome.migrations {
+            MigrationsOutcome::Failed(e) => (RunState::Failed, Some(e.clone())),
+            _ => (RunState::Succeeded, None),
+        },
+        Err(e) => (RunState::Failed, Some(e.to_string())),
+    };
+    if let Ok(outcome) = &result {
+        if let Err(e) = store::attach_org(&registry, run_id, outcome.org_id).await {
+            tracing::warn!(target: "rustango::tenancy::provision", error = %e, "could not attach org id to run");
+        }
+    }
+    if let Err(e) = store::finish_run(&registry, run_id, state, error.as_deref()).await {
+        tracing::warn!(target: "rustango::tenancy::provision", error = %e, "could not close provisioning run");
+    }
+
+    let refreshed = store::run_by_id(&registry, run_id).await?.unwrap_or(run);
+    result.map(|outcome| (refreshed, outcome))
+}
+
+async fn provision_reported<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    dir: &Path,
+    request: &ProvisionRequest,
+    rep: &Reporter<'_>,
+) -> Result<ProvisionOutcome, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
     // ---- 1. Validate ----
-    step(observer, ProvisionStep::Validate, StepStatus::Started);
+    rep.step(ProvisionStep::Validate, StepStatus::Started).await;
     let registry = pools.registry_pool();
 
     // Reject a duplicate slug up front — it saves a partial-state mess
@@ -254,26 +555,28 @@ where
         .await
     {
         Ok(rows) => rows,
-        Err(e) => return fail(observer, ProvisionStep::Validate, e.into()),
+        Err(e) => return rep.fail(ProvisionStep::Validate, e.into()).await,
     };
     if !existing.is_empty() {
-        return fail(
-            observer,
-            ProvisionStep::Validate,
-            TenancyError::Validation(format!("tenant slug `{}` already exists", request.slug)),
-        );
+        return rep
+            .fail(
+                ProvisionStep::Validate,
+                TenancyError::Validation(format!("tenant slug `{}` already exists", request.slug)),
+            )
+            .await;
     }
 
     if request.mode == StorageMode::Database && request.database_url.is_none() {
-        return fail(
-            observer,
-            ProvisionStep::Validate,
-            TenancyError::Validation(
-                "create-tenant --mode database requires --database-url".into(),
-            ),
-        );
+        return rep
+            .fail(
+                ProvisionStep::Validate,
+                TenancyError::Validation(
+                    "create-tenant --mode database requires --database-url".into(),
+                ),
+            )
+            .await;
     }
-    step(observer, ProvisionStep::Validate, StepStatus::Ok);
+    rep.step(ProvisionStep::Validate, StepStatus::Ok).await;
 
     // ---- 2. Check the connection ----
     //
@@ -281,7 +584,7 @@ where
     // typo'd host, wrong password, database not created yet — used to
     // be discovered *after* the `Org` row landed, leaving a tenant the
     // resolver matches in front of a database with no schema.
-    check_connection(request, observer).await?;
+    check_connection(request, rep).await?;
 
     let schema_name = schema_name_for(request);
 
@@ -289,62 +592,73 @@ where
     //
     // Before the row, not after: a failed `INSERT` must not leave an
     // orphan schema behind. Idempotent via `IF NOT EXISTS`.
-    match request.mode {
-        StorageMode::Schema => {
-            step(
-                observer,
-                ProvisionStep::ProvisionStorage,
-                StepStatus::Started,
-            );
-            let schema = schema_name.as_deref().unwrap_or(&request.slug);
-            if let Err(e) = provision_schema(pools, schema).await {
-                return fail(observer, ProvisionStep::ProvisionStorage, e);
-            }
-            step(observer, ProvisionStep::ProvisionStorage, StepStatus::Ok);
-        }
-        StorageMode::Database => step(
-            observer,
-            ProvisionStep::ProvisionStorage,
-            StepStatus::Skipped("database-mode tenants bring their own database".into()),
-        ),
-    }
+    provision_storage(pools, request, schema_name.as_deref(), rep).await?;
 
     // ---- 4. Register the org ----
-    step(observer, ProvisionStep::RegisterOrg, StepStatus::Started);
+    rep.step(ProvisionStep::RegisterOrg, StepStatus::Started)
+        .await;
     let mut org = new_org_row(request, schema_name);
     if let Err(e) = org.insert_pool(&registry).await {
-        return fail(observer, ProvisionStep::RegisterOrg, e.into());
+        return rep.fail(ProvisionStep::RegisterOrg, e.into()).await;
     }
     // This pod sees the new tenant immediately; others converge on the
     // registry fingerprint (see `resolver::sync_org_generation`).
     super::invalidate_org_cache();
     let org_id = org.id.get().copied().unwrap_or_default();
-    step(observer, ProvisionStep::RegisterOrg, StepStatus::Ok);
-    emit(observer, || ProvisionEvent::Registered { org_id });
+    rep.step(ProvisionStep::RegisterOrg, StepStatus::Ok).await;
+    rep.notify(ProvisionEvent::Registered { org_id });
 
     // ---- 5. Migrate ----
     let migrations = if request.run_migrations {
-        step(observer, ProvisionStep::Migrate, StepStatus::Started);
-        let outcome = migrate_new_tenant(pools, registry_url, dir, &request.slug, observer).await?;
+        rep.step(ProvisionStep::Migrate, StepStatus::Started).await;
+        let outcome = migrate_new_tenant(pools, registry_url, dir, &org, rep).await;
+        // The migration events arrived synchronously while the migrate
+        // lock was held, so they were buffered. The lock is released by
+        // now — write them before reporting the step's own outcome, so
+        // the stored log reads in the order things happened.
+        rep.flush().await;
         match &outcome {
             MigrationsOutcome::Failed(e) => {
-                step(
-                    observer,
-                    ProvisionStep::Migrate,
-                    StepStatus::Failed(e.clone()),
-                );
+                rep.step(ProvisionStep::Migrate, StepStatus::Failed(e.clone()))
+                    .await;
             }
-            _ => step(observer, ProvisionStep::Migrate, StepStatus::Ok),
+            _ => rep.step(ProvisionStep::Migrate, StepStatus::Ok).await,
         }
         outcome
     } else {
-        step(
-            observer,
+        rep.step(
             ProvisionStep::Migrate,
             StepStatus::Skipped("caller asked for no migrations".into()),
-        );
+        )
+        .await;
         MigrationsOutcome::Skipped
     };
+
+    // ---- 6. Activate ----
+    //
+    // The row went in inactive (see `new_org_row`), so up to this point
+    // the tenant does not resolve. Flipping it last is what closes the
+    // window where a half-provisioned tenant serves requests against a
+    // database with no schema in it.
+    //
+    // A migration failure leaves it inactive, deliberately. The row
+    // stays — an operator needs to see what was half-made, and rolling
+    // it back is not always possible anyway once a schema or database
+    // exists — but nothing routes to it.
+    if matches!(migrations, MigrationsOutcome::Failed(_)) {
+        rep.step(
+            ProvisionStep::Activate,
+            StepStatus::Skipped("migrations failed; the tenant stays inactive".into()),
+        )
+        .await;
+    } else {
+        rep.step(ProvisionStep::Activate, StepStatus::Started).await;
+        if let Err(e) = activate(&registry, org_id).await {
+            return rep.fail(ProvisionStep::Activate, e).await;
+        }
+        super::invalidate_org_cache();
+        rep.step(ProvisionStep::Activate, StepStatus::Ok).await;
+    }
 
     Ok(ProvisionOutcome {
         org_id,
@@ -360,36 +674,68 @@ where
 /// tenant lives in the registry's, which is already connected.
 async fn check_connection(
     request: &ProvisionRequest,
-    observer: Option<&dyn ProvisionObserver>,
+    rep: &Reporter<'_>,
 ) -> Result<(), TenancyError> {
     let (Some(url), StorageMode::Database) = (&request.database_url, request.mode) else {
-        step(
-            observer,
+        rep.step(
             ProvisionStep::CheckConnection,
             StepStatus::Skipped("schema-mode tenants share the registry's database".into()),
-        );
+        )
+        .await;
         return Ok(());
     };
 
-    step(
-        observer,
-        ProvisionStep::CheckConnection,
-        StepStatus::Started,
-    );
+    rep.step(ProvisionStep::CheckConnection, StepStatus::Started)
+        .await;
     match preflight::check(url, &request.preflight).await {
         Ok(_) => {
-            step(observer, ProvisionStep::CheckConnection, StepStatus::Ok);
+            rep.step(ProvisionStep::CheckConnection, StepStatus::Ok)
+                .await;
             Ok(())
         }
         // `Validation`, not a driver error: nothing is broken in
         // rustango, the URL the caller supplied is wrong, and the
         // diagnosis already says what to change.
-        Err(d) => fail(
-            observer,
-            ProvisionStep::CheckConnection,
-            TenancyError::Validation(d.to_string()),
-        ),
+        Err(d) => {
+            rep.fail(
+                ProvisionStep::CheckConnection,
+                TenancyError::Validation(d.to_string()),
+            )
+            .await
+        }
     }
+}
+
+/// Make the tenant's storage, if it needs making.
+///
+/// Schema-mode gets a `CREATE SCHEMA`; database-mode brings its own
+/// database, already reached by the connection check. Deliberately
+/// before the `Org` row lands, so a failed `INSERT` leaves no orphan
+/// schema.
+async fn provision_storage<DB: Database>(
+    pools: &TenantPools<DB>,
+    request: &ProvisionRequest,
+    schema_name: Option<&str>,
+    rep: &Reporter<'_>,
+) -> Result<(), TenancyError> {
+    if request.mode != StorageMode::Schema {
+        rep.step(
+            ProvisionStep::ProvisionStorage,
+            StepStatus::Skipped("database-mode tenants bring their own database".into()),
+        )
+        .await;
+        return Ok(());
+    }
+
+    rep.step(ProvisionStep::ProvisionStorage, StepStatus::Started)
+        .await;
+    let schema = schema_name.unwrap_or(&request.slug);
+    if let Err(e) = provision_schema(pools, schema).await {
+        return rep.fail(ProvisionStep::ProvisionStorage, e).await;
+    }
+    rep.step(ProvisionStep::ProvisionStorage, StepStatus::Ok)
+        .await;
+    Ok(())
 }
 
 /// The schema a schema-mode tenant lives in: whatever the request
@@ -432,7 +778,11 @@ fn new_org_row(request: &ProvisionRequest, schema_name: Option<String>) -> Org {
         }),
         port: request.port,
         path_prefix: request.path_prefix.clone(),
-        active: true,
+        // Inactive until the schema is in place. The resolver already
+        // filters on this column, so it costs nothing on the hot path
+        // and is the only signal that keeps a half-provisioned tenant
+        // from serving. `ProvisionStep::Activate` flips it.
+        active: false,
         created_at: chrono::Utc::now(),
         brand_name: None,
         brand_tagline: None,
@@ -492,71 +842,57 @@ async fn provision_schema<DB: Database>(
     }
 }
 
-/// Migrate the tenant that was just created.
+/// Flip the tenant live.
+async fn activate(registry: &crate::sql::Pool, org_id: i64) -> Result<(), TenancyError> {
+    use crate::sql::UpdaterPool as _;
+    let updated = Org::objects()
+        .where_(Org::id.eq(org_id))
+        .update()
+        .set("active", true)
+        .execute_pool(registry)
+        .await?;
+    if updated == 0 {
+        return Err(TenancyError::Validation(format!(
+            "activate: no row updated for org {org_id} — was it deleted mid-provision?"
+        )));
+    }
+    Ok(())
+}
+
+/// Migrate the tenant that was just created — and only that one.
 ///
-/// Runs the whole active-tenant batch and then picks this slug out of
-/// the report — see the module docs for why that is more work than it
-/// should be.
+/// Goes through [`tenant_migrate::migrate_one_tenant`] rather than the
+/// batch, for two reasons. The tenant is still inactive at this point,
+/// so the batch (which filters `active = true`) would skip the very
+/// tenant it was called for. And the batch would migrate every *other*
+/// tenant too, so creating tenant B did a pass over tenant A and an
+/// unrelated broken chain surfaced mid-provision.
+///
+/// Never returns `Err`: by this point the `Org` row exists, and an
+/// error return would hide that from the caller. A failure comes back
+/// as [`MigrationsOutcome::Failed`].
 async fn migrate_new_tenant<DB: Database>(
     pools: &TenantPools<DB>,
     registry_url: &str,
     dir: &Path,
-    slug: &str,
-    observer: Option<&dyn ProvisionObserver>,
-) -> Result<MigrationsOutcome, TenancyError>
+    org: &Org,
+    rep: &Reporter<'_>,
+) -> MigrationsOutcome
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
-    // Forward every migration event straight through, so a caller
+    // Forward every migration event to the reporter, so a caller
     // watching a provisioning run sees the same per-migration detail
-    // `manage migrate` prints (#1320).
-    let forward = observer.map(|observer| {
-        move |event: tenant_migrate::TenantMigrationEvent| {
-            observer.on_event(ProvisionEvent::Migration(event));
-        }
-    });
-    let forward = forward
-        .as_ref()
-        .map(|f| f as &dyn tenant_migrate::TenantMigrationObserver);
+    // `manage migrate` prints (#1320). The reporter decides what to do
+    // with them — the observer gets them now, the store when the lock
+    // is released.
+    let forward = move |event: tenant_migrate::TenantMigrationEvent| rep.migration(event);
+    let forward: Option<&dyn tenant_migrate::TenantMigrationObserver> = Some(&forward);
 
-    // v0.38 — on PG go through `migrate_tenants` (schema-mode +
-    // database-mode); on sqlite/mysql use `migrate_tenants_db`
-    // (database-mode only).
-    #[cfg(feature = "postgres")]
-    let report = {
-        if let Some(pg_pools) =
-            (pools as &dyn std::any::Any).downcast_ref::<TenantPools<sqlx::Postgres>>()
-        {
-            match forward {
-                Some(o) => {
-                    tenant_migrate::migrate_tenants_with_progress(pg_pools, dir, registry_url, o)
-                        .await?
-                }
-                None => tenant_migrate::migrate_tenants(pg_pools, dir, registry_url).await?,
-            }
-        } else {
-            match forward {
-                Some(o) => {
-                    tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, o)
-                        .await?
-                }
-                None => tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?,
-            }
-        }
-    };
-    #[cfg(not(feature = "postgres"))]
-    let report = match forward {
-        Some(o) => {
-            tenant_migrate::migrate_tenants_db_with_progress(pools, dir, registry_url, o).await?
-        }
-        None => tenant_migrate::migrate_tenants_db(pools, dir, registry_url).await?,
-    };
-
-    Ok(match report.tenants.into_iter().find(|t| t.slug == slug) {
-        Some(o) => match o.error {
-            Some(e) => MigrationsOutcome::Failed(e.to_string()),
-            None => MigrationsOutcome::Applied(o.applied),
-        },
-        None => MigrationsOutcome::NotMatched,
-    })
+    // One call, no backend branch: `migrate_one_tenant` owns the
+    // schema-mode-is-PG-only dispatch that used to be duplicated here.
+    match tenant_migrate::migrate_one_tenant(pools, org, dir, registry_url, forward).await {
+        Ok(applied) => MigrationsOutcome::Applied(applied),
+        Err(e) => MigrationsOutcome::Failed(e.to_string()),
+    }
 }

--- a/crates/rustango/src/tenancy/provision_store.rs
+++ b/crates/rustango/src/tenancy/provision_store.rs
@@ -1,0 +1,392 @@
+//! Where a provisioning run lives while it happens, and after.
+//!
+//! Slices [#1318] and [#1320] produce a stream of events. Holding them
+//! only in memory fails two ways that matter:
+//!
+//! **Replay.** [`crate::sse::EventBus`] is a `tokio::sync::broadcast`
+//! wrapper, so a subscriber sees only what is sent *after* it connects.
+//! Provisioning starts on a POST and the browser connects on the *next*
+//! request — the opening steps are gone before anyone is listening, and
+//! a mid-run reload loses the rest.
+//!
+//! **Two pods.** Behind a load balancer the operator watching the
+//! stream may not be on the pod doing the work. In-process state means
+//! they watch an empty page while provisioning runs fine elsewhere.
+//! This is the same problem the resolver solved with a registry
+//! fingerprint rather than a shared cache: put it in the database both
+//! pods already have.
+//!
+//! [#1318]: https://github.com/ujeenet/rustango/issues/1318
+//! [#1320]: https://github.com/ujeenet/rustango/issues/1320
+//!
+//! ## Credentials are never stored
+//!
+//! A run records the URL it was asked to provision, and a connection
+//! URL has a password in it. [`crate::sql::connect_diagnosis::redact`]
+//! is applied on the way in — not on the way out, so there is no
+//! reading path that can forget it. The same goes for event messages,
+//! which carry connection diagnoses.
+
+use serde::Serialize;
+
+use crate::core::Column as _;
+use crate::sql::{Auto, FetcherPool, Pool, UpdaterPool};
+
+use super::error::TenancyError;
+
+/// Where a provisioning run has got to.
+///
+/// Stored as a short string rather than an enum column so a state can
+/// be added without a migration, and so a human reading the table with
+/// `psql` can see what it says.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunState {
+    /// Accepted, not started. The state a webhook returns on.
+    Pending,
+    Running,
+    Succeeded,
+    /// Stopped at some step. `ProvisioningRun::error` says which.
+    Failed,
+}
+
+impl RunState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Parse a stored value. Unknown strings read as `Failed` rather
+    /// than panicking: a row written by a newer build should not take
+    /// down an older one, and "something went wrong" is the safe
+    /// reading of a state this binary does not know.
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "pending" => Self::Pending,
+            "running" => Self::Running,
+            "succeeded" => Self::Succeeded,
+            _ => Self::Failed,
+        }
+    }
+
+    /// Nothing more will happen to this run.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed)
+    }
+}
+
+/// One attempt to stand up a tenant.
+#[derive(crate::Model, Debug, Clone, Serialize)]
+#[rustango(
+    table = "rustango_provisioning_runs",
+    scope = "registry",
+    display = "slug",
+    admin(
+        list_display = "slug, state, started_at, finished_at",
+        ordering = "-started_at",
+    )
+)]
+pub struct ProvisioningRun {
+    #[rustango(primary_key)]
+    pub id: crate::sql::Auto<i64>,
+
+    /// The tenant this run is for. Not a foreign key: the row is
+    /// written *before* the `Org` exists, and must survive the tenant
+    /// later being purged — a run is a record of what happened, and an
+    /// `ON DELETE CASCADE` would erase exactly the history someone
+    /// comes looking for.
+    #[rustango(max_length = 100, index)]
+    pub slug: String,
+
+    /// Set once the `Org` row lands. `None` while a run is still before
+    /// that step, or if it failed before reaching it.
+    pub org_id: Option<i64>,
+
+    /// `pending` / `running` / `succeeded` / `failed`. See [`RunState`].
+    #[rustango(max_length = 16, index)]
+    pub state: String,
+
+    #[rustango(max_length = 16)]
+    pub storage_mode: String,
+
+    #[rustango(max_length = 16)]
+    pub backend_kind: String,
+
+    /// **Redacted.** The password is replaced before this is stored;
+    /// see the module docs.
+    #[rustango(max_length = 500)]
+    pub database_url: Option<String>,
+
+    /// Who asked for this run — an operator username, a webhook's
+    /// caller id, or `cli`. Free text on purpose: the sources are not
+    /// one namespace.
+    #[rustango(max_length = 150)]
+    pub requested_by: Option<String>,
+
+    /// The caller-supplied key that makes a retried request return this
+    /// run instead of creating a second tenant. Unique so the database,
+    /// not the handler, is what wins a race between two simultaneous
+    /// deliveries of one event.
+    #[rustango(max_length = 200, unique)]
+    pub idempotency_key: Option<String>,
+
+    /// Why it failed, if it did. Already rendered for display.
+    pub error: Option<String>,
+
+    #[rustango(auto_now_add)]
+    pub started_at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
+
+    pub finished_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// One thing that happened during a run.
+///
+/// The stream a console replays. Deliberately append-only: an event is
+/// a fact about the past, and the value of the log is that it is what
+/// actually happened rather than a summary someone kept up to date.
+#[derive(crate::Model, Debug, Clone, Serialize)]
+#[rustango(
+    table = "rustango_provisioning_events",
+    scope = "registry",
+    display = "message",
+    admin(list_display = "run_id, seq, step, status", ordering = "run_id, seq")
+)]
+pub struct ProvisioningEvent {
+    #[rustango(primary_key)]
+    pub id: crate::sql::Auto<i64>,
+
+    #[rustango(fk = "rustango_provisioning_runs", on = "id", index)]
+    pub run_id: i64,
+
+    /// Monotonic within a run, from 1. **This is what `Last-Event-ID`
+    /// resumes from**, so it has to be dense and ordered — an
+    /// autoincrement `id` would be globally ordered but not per-run,
+    /// and a reconnecting client would have nothing to count from.
+    pub seq: i64,
+
+    /// Which provisioning step, or `migration` for a forwarded
+    /// migration event.
+    #[rustango(max_length = 32)]
+    pub step: String,
+
+    /// `started` / `ok` / `skipped` / `failed` / `info`.
+    #[rustango(max_length = 16)]
+    pub status: String,
+
+    /// Human-readable detail. Empty for a bare transition.
+    pub message: String,
+
+    #[rustango(auto_now_add)]
+    pub at: crate::sql::Auto<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Open a run, before any work starts.
+///
+/// `database_url` is redacted here rather than by the caller: this is
+/// the only way into the table, so redacting on the way in means there
+/// is no path that can forget.
+///
+/// # Errors
+/// A registry write failure — or a unique-constraint violation on
+/// `idempotency_key`, which is the intended way two simultaneous
+/// deliveries of one event resolve to one run.
+pub async fn open_run(
+    registry: &Pool,
+    slug: &str,
+    storage_mode: &str,
+    backend_kind: &str,
+    database_url: Option<&str>,
+    requested_by: Option<&str>,
+    idempotency_key: Option<&str>,
+) -> Result<ProvisioningRun, TenancyError> {
+    let mut run = ProvisioningRun {
+        id: Auto::default(),
+        slug: slug.to_owned(),
+        org_id: None,
+        state: RunState::Running.as_str().to_owned(),
+        storage_mode: storage_mode.to_owned(),
+        backend_kind: backend_kind.to_owned(),
+        database_url: database_url.map(crate::sql::connect_diagnosis::redact),
+        requested_by: requested_by.map(ToOwned::to_owned),
+        idempotency_key: idempotency_key.map(ToOwned::to_owned),
+        error: None,
+        started_at: Auto::default(),
+        finished_at: None,
+    };
+    run.insert_pool(registry).await?;
+    Ok(run)
+}
+
+/// Append an event to a run.
+///
+/// `seq` is supplied by the caller rather than computed here: the
+/// caller is emitting a known sequence and a `SELECT MAX(seq)` per
+/// event would be a round-trip per line of a progress stream, plus a
+/// race between two writers.
+///
+/// # Errors
+/// A registry write failure.
+pub async fn append_event(
+    registry: &Pool,
+    run_id: i64,
+    seq: i64,
+    step: &str,
+    status: &str,
+    message: &str,
+) -> Result<(), TenancyError> {
+    let mut event = ProvisioningEvent {
+        id: Auto::default(),
+        run_id,
+        seq,
+        step: step.to_owned(),
+        status: status.to_owned(),
+        message: message.to_owned(),
+        at: Auto::default(),
+    };
+    event.insert_pool(registry).await?;
+    Ok(())
+}
+
+/// Record that the `Org` row now exists, so a run that fails later
+/// still says which tenant it half-made.
+///
+/// # Errors
+/// A registry write failure.
+pub async fn attach_org(registry: &Pool, run_id: i64, org_id: i64) -> Result<(), TenancyError> {
+    ProvisioningRun::objects()
+        .where_(ProvisioningRun::id.eq(run_id))
+        .update()
+        .set("org_id", org_id)
+        .execute_pool(registry)
+        .await?;
+    Ok(())
+}
+
+/// Close a run.
+///
+/// # Errors
+/// A registry write failure.
+pub async fn finish_run(
+    registry: &Pool,
+    run_id: i64,
+    state: RunState,
+    error: Option<&str>,
+) -> Result<(), TenancyError> {
+    ProvisioningRun::objects()
+        .where_(ProvisioningRun::id.eq(run_id))
+        .update()
+        .set("state", state.as_str())
+        .set("error", error)
+        .set("finished_at", chrono::Utc::now())
+        .execute_pool(registry)
+        .await?;
+    Ok(())
+}
+
+/// Read a run by id.
+///
+/// # Errors
+/// A registry read failure.
+pub async fn run_by_id(
+    registry: &Pool,
+    run_id: i64,
+) -> Result<Option<ProvisioningRun>, TenancyError> {
+    Ok(ProvisioningRun::objects()
+        .where_(ProvisioningRun::id.eq(run_id))
+        .fetch(registry)
+        .await?
+        .into_iter()
+        .next())
+}
+
+/// Find the run a caller's idempotency key already opened.
+///
+/// # Errors
+/// A registry read failure.
+pub async fn run_by_idempotency_key(
+    registry: &Pool,
+    key: &str,
+) -> Result<Option<ProvisioningRun>, TenancyError> {
+    Ok(ProvisioningRun::objects()
+        .where_(ProvisioningRun::idempotency_key.eq(Some(key.to_owned())))
+        .fetch(registry)
+        .await?
+        .into_iter()
+        .next())
+}
+
+/// Replay a run's events, in order, from `after_seq` exclusive.
+///
+/// `after_seq` of 0 is the whole log — what a fresh subscriber wants.
+/// A reconnecting one passes the last `seq` it saw (its
+/// `Last-Event-ID`) and gets only what it missed.
+///
+/// # Errors
+/// A registry read failure.
+pub async fn events_since(
+    registry: &Pool,
+    run_id: i64,
+    after_seq: i64,
+) -> Result<Vec<ProvisioningEvent>, TenancyError> {
+    Ok(ProvisioningEvent::objects()
+        .where_(ProvisioningEvent::run_id.eq(run_id))
+        .where_(ProvisioningEvent::seq.gt(after_seq))
+        // Ascending — the bool is `desc`. A replay handed back newest
+        // first is not a replay.
+        .order_by(&[("seq", false)])
+        .fetch(registry)
+        .await?)
+}
+
+/// Delete finished runs older than `cutoff`, and their events.
+///
+/// Runs are append-only and one per tenant creation, so the table grows
+/// with provisioning activity and nothing removes it. Unfinished runs
+/// are never pruned regardless of age — one stuck in `running` is
+/// evidence of a pod that died mid-provision, which is exactly what
+/// someone will come looking for.
+///
+/// Returns how many runs were removed.
+///
+/// # Errors
+/// A registry write failure.
+pub async fn prune_runs(
+    registry: &Pool,
+    cutoff: chrono::DateTime<chrono::Utc>,
+) -> Result<usize, TenancyError> {
+    let stale: Vec<ProvisioningRun> = ProvisioningRun::objects()
+        .where_(ProvisioningRun::finished_at.lt(Some(cutoff)))
+        .fetch(registry)
+        .await?;
+
+    let mut removed = 0;
+    for run in stale {
+        let Some(id) = run.id.get().copied() else {
+            continue;
+        };
+        // Children first: the FK points this way, and a database with
+        // it enforced would refuse the parent delete otherwise.
+        //
+        // Row at a time because the ORM has no queryset-level delete
+        // through a `Pool`. Acceptable here — this is a maintenance
+        // verb over a couple of dozen events per run, not a request
+        // path — but it is why `prune_runs` is not something to call
+        // in a loop.
+        let events: Vec<ProvisioningEvent> = ProvisioningEvent::objects()
+            .where_(ProvisioningEvent::run_id.eq(id))
+            .fetch(registry)
+            .await?;
+        for event in events {
+            event.delete_pool(registry).await?;
+        }
+        run.delete_pool(registry).await?;
+        removed += 1;
+    }
+    Ok(removed)
+}

--- a/crates/rustango/tests/provision_sqlite_live.rs
+++ b/crates/rustango/tests/provision_sqlite_live.rs
@@ -113,6 +113,9 @@ async fn the_engine_provisions_without_argv_or_a_writer() {
             "registered",
             "Migrate:started",
             "Migrate:ok",
+            // Last, and only now does the tenant resolve (#1321).
+            "Activate:started",
+            "Activate:ok",
         ],
         "{:?}",
         rec.steps()
@@ -390,12 +393,19 @@ async fn an_unreachable_database_is_caught_before_the_org_row_is_written() {
 /// on, so pin the set. Adding one is a breaking change for a watcher.
 #[test]
 fn the_step_list_is_stable() {
+    // The wire names are what a console matches on and what lands in
+    // `rustango_provisioning_events.step`, so they are pinned here
+    // rather than left to `Debug`.
     let all = [
-        ProvisionStep::Validate,
-        ProvisionStep::CheckConnection,
-        ProvisionStep::ProvisionStorage,
-        ProvisionStep::RegisterOrg,
-        ProvisionStep::Migrate,
+        (ProvisionStep::Validate, "validate"),
+        (ProvisionStep::CheckConnection, "check_connection"),
+        (ProvisionStep::ProvisionStorage, "provision_storage"),
+        (ProvisionStep::RegisterOrg, "register_org"),
+        (ProvisionStep::Migrate, "migrate"),
+        (ProvisionStep::Activate, "activate"),
     ];
-    assert_eq!(all.len(), 5);
+    assert_eq!(all.len(), 6);
+    for (step, name) in all {
+        assert_eq!(step.as_str(), name);
+    }
 }

--- a/crates/rustango/tests/provision_store_sqlite_live.rs
+++ b/crates/rustango/tests/provision_store_sqlite_live.rs
@@ -1,0 +1,449 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Durable provisioning runs (#1321).
+//!
+//! Four things have to hold, and each of them is a failure mode that
+//! only shows up in production:
+//!
+//! * a run **replays** from persistence, so a console that connects
+//!   after the POST still sees the opening steps;
+//! * a run started on one pod is **readable from another**;
+//! * a failed run leaves **nothing that resolves and serves**; and
+//! * the stored row **never contains a password**.
+
+use rustango::sql::{sqlx, FetcherPool as _};
+use rustango::tenancy::provision::{self, MigrationsOutcome, ProvisionRequest};
+use rustango::tenancy::provision_store::{self as store, RunState};
+use rustango::tenancy::TenantPools;
+
+async fn registry() -> (TenantPools<sqlx::Sqlite>, String, tempfile::TempDir) {
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tmpdir.path().join("registry.db");
+    let url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let pool = sqlx::SqlitePool::connect(&url)
+        .await
+        .expect("sqlite connect");
+    (TenantPools::<sqlx::Sqlite>::new(pool), url, tmpdir)
+}
+
+async fn migrate_registry(pools: &TenantPools<sqlx::Sqlite>, url: &str, dir: &std::path::Path) {
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools,
+        url,
+        dir,
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+}
+
+/// The tables arrive through the generated system-migration chain, the
+/// same way `rustango_org_hosts` does — no hand-written DDL anywhere.
+#[tokio::test]
+async fn the_run_tables_come_from_the_registry_migration_chain() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let names: Vec<(String,)> =
+        sqlx::query_as("SELECT name FROM sqlite_master WHERE type = 'table'")
+            .fetch_all(&pool)
+            .await
+            .expect("list tables");
+    let names: Vec<&str> = names.iter().map(|(n,)| n.as_str()).collect();
+
+    assert!(
+        names.contains(&"rustango_provisioning_runs"),
+        "runs table missing: {names:?}"
+    );
+    assert!(
+        names.contains(&"rustango_provisioning_events"),
+        "events table missing: {names:?}"
+    );
+}
+
+/// A recorded run is replayable from the beginning, in order, by
+/// something that was not watching while it happened. This is the whole
+/// reason the events are in a table rather than a broadcast channel.
+#[tokio::test]
+async fn a_run_replays_in_order_for_a_subscriber_that_was_not_there() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("replay.db");
+    let request = ProvisionRequest::database(
+        "replay",
+        format!("sqlite://{}?mode=rwc", tenant_db.display()),
+    );
+
+    // No observer at all — nobody watching live.
+    let (run, outcome) = provision::provision_tenant_recorded(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        None,
+        Some("cli"),
+        None,
+    )
+    .await
+    .expect("provision");
+
+    let run_id = run.id.get().copied().expect("run id");
+    assert_eq!(RunState::parse(&run.state), RunState::Succeeded);
+    assert_eq!(run.org_id, Some(outcome.org_id));
+
+    // Replay the whole log.
+    let registry_pool = pools.registry_pool();
+    let events = store::events_since(&registry_pool, run_id, 0)
+        .await
+        .expect("replay");
+    assert!(!events.is_empty(), "a run should leave a log");
+
+    // `seq` is dense and ordered — `Last-Event-ID` counts on it.
+    let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+    let expected: Vec<i64> = (1..=seqs.len() as i64).collect();
+    assert_eq!(seqs, expected, "seq must be dense and ordered: {seqs:?}");
+
+    // The opening step is there, which a broadcast bus would have lost.
+    let steps: Vec<&str> = events.iter().map(|e| e.step.as_str()).collect();
+    assert_eq!(steps.first(), Some(&"validate"), "{steps:?}");
+    assert!(steps.contains(&"activate"), "{steps:?}");
+
+    // And a reconnect resumes from where it left off.
+    let tail = store::events_since(&registry_pool, run_id, seqs[2])
+        .await
+        .expect("resume");
+    assert_eq!(tail.len(), events.len() - 3);
+    assert_eq!(tail.first().map(|e| e.seq), Some(seqs[3]));
+}
+
+/// A run written by one connection is readable from another — the
+/// stand-in for a second pod, which is the case in-process state gets
+/// wrong.
+#[tokio::test]
+async fn a_run_is_readable_from_a_separate_connection() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let tenant_db = _tmp.path().join("otherpod.db");
+    let request = ProvisionRequest::database(
+        "otherpod",
+        format!("sqlite://{}?mode=rwc", tenant_db.display()),
+    );
+    let (run, _) = provision::provision_tenant_recorded(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("provision");
+    let run_id = run.id.get().copied().expect("run id");
+
+    // A completely separate pool — as far as this process is
+    // concerned, another pod.
+    let other =
+        rustango::sql::Pool::Sqlite(sqlx::SqlitePool::connect(&url).await.expect("second pool"));
+    let seen = store::run_by_id(&other, run_id)
+        .await
+        .expect("read")
+        .expect("the run should be visible");
+    assert_eq!(seen.slug, "otherpod");
+    assert_eq!(RunState::parse(&seen.state), RunState::Succeeded);
+    assert!(!store::events_since(&other, run_id, 0)
+        .await
+        .expect("events")
+        .is_empty());
+}
+
+/// The stored URL must never carry a password. The single most likely
+/// place for a credential to escape into a log or an HTTP response.
+#[tokio::test]
+async fn the_stored_url_never_contains_the_password() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+    let registry_pool = pools.registry_pool();
+
+    // Straight at the store, with a URL shaped like a real one. (The
+    // engine would refuse to connect to this, which is beside the
+    // point — redaction happens on the way in.)
+    let run = store::open_run(
+        &registry_pool,
+        "secretive",
+        "database",
+        "postgres",
+        Some("postgres://app:hunter2@db.internal:5432/acme"),
+        Some("operator@example.com"),
+        None,
+    )
+    .await
+    .expect("open run");
+
+    assert_eq!(
+        run.database_url.as_deref(),
+        Some("postgres://app:***@db.internal:5432/acme"),
+        "the password must be gone before it is stored"
+    );
+
+    // And nothing reading the row back can recover it.
+    let run_id = run.id.get().copied().expect("id");
+    let read = store::run_by_id(&registry_pool, run_id)
+        .await
+        .expect("read")
+        .expect("row");
+    assert!(
+        !read.database_url.unwrap_or_default().contains("hunter2"),
+        "password survived a round-trip"
+    );
+}
+
+/// **The disposition decision.** A run that fails at the migrate step
+/// leaves an `Org` row — an operator needs to see what was half-made —
+/// but it is inactive, so nothing resolves to it.
+#[tokio::test]
+async fn a_failed_migration_leaves_an_inactive_tenant_and_a_failed_run() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    // A migration directory with a broken tenant-scoped migration:
+    // two files creating the same table, so the second collides.
+    let broken = tempfile::tempdir().expect("broken dir");
+    for name in ["0001_make", "0002_again"] {
+        let mig = rustango::migrate::Migration {
+            name: name.to_owned(),
+            created_at: "2026-09-10T00:00:00Z".into(),
+            prev: None,
+            atomic: true,
+            scope: rustango::migrate::MigrationScope::Tenant,
+            replaces: Vec::new(),
+            snapshot: serde_json::from_value(serde_json::json!({
+                "tables": [{
+                    "name": "collide", "model": "T",
+                    "fields": [{"name": "id", "column": "id", "ty": "i64",
+                                "nullable": false, "primary_key": true}]
+                }]
+            }))
+            .unwrap(),
+            forward: vec![rustango::migrate::Operation::Schema(
+                rustango::migrate::SchemaChange::CreateTable("collide".into()),
+            )],
+        };
+        rustango::migrate::file::write(&broken.path().join(format!("{name}.json")), &mig).unwrap();
+    }
+
+    let tenant_db = _tmp.path().join("broken.db");
+    let request = ProvisionRequest::database(
+        "broken",
+        format!("sqlite://{}?mode=rwc", tenant_db.display()),
+    );
+    let (run, outcome) = provision::provision_tenant_recorded(
+        &pools,
+        &url,
+        broken.path(),
+        &request,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("provisioning itself succeeds — the migration is what fails");
+
+    assert!(
+        matches!(outcome.migrations, MigrationsOutcome::Failed(_)),
+        "{:?}",
+        outcome.migrations
+    );
+    assert_eq!(RunState::parse(&run.state), RunState::Failed);
+    assert!(run.error.is_some(), "a failed run must say why");
+    assert!(run.finished_at.is_some(), "a failed run is still finished");
+
+    // The row exists — and does not serve.
+    let registry_pool = pools.registry_pool();
+    let orgs = rustango::tenancy::Org::objects()
+        .fetch(&registry_pool)
+        .await
+        .expect("fetch orgs");
+    assert_eq!(
+        orgs.len(),
+        1,
+        "the half-made tenant is kept for the operator"
+    );
+    assert!(
+        !orgs[0].active,
+        "a tenant whose migrations failed must not resolve"
+    );
+
+    // And the log names the step that failed.
+    let run_id = run.id.get().copied().expect("id");
+    let events = store::events_since(&registry_pool, run_id, 0)
+        .await
+        .expect("events");
+    assert!(
+        events
+            .iter()
+            .any(|e| e.step == "migrate" && e.status == "failed"),
+        "{:?}",
+        events
+            .iter()
+            .map(|e| (&e.step, &e.status))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| e.step == "activate" && e.status == "skipped"),
+        "activation must be skipped, not attempted"
+    );
+}
+
+/// A run that fails *before* the row lands leaves no tenant at all, and
+/// still closes rather than sitting in `running` forever.
+#[tokio::test]
+async fn a_run_that_fails_early_still_closes() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+
+    let mut request = ProvisionRequest::database("nowhere", "unused");
+    request.database_url = None; // rejected at Validate
+
+    let err = provision::provision_tenant_recorded(
+        &pools,
+        &url,
+        migrations.path(),
+        &request,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect_err("must be rejected");
+    assert!(err.to_string().contains("--database-url"), "got: {err}");
+
+    let registry_pool = pools.registry_pool();
+    let runs: Vec<store::ProvisioningRun> = store::ProvisioningRun::objects()
+        .fetch(&registry_pool)
+        .await
+        .expect("fetch runs");
+    assert_eq!(runs.len(), 1, "the attempt is still recorded");
+    assert_eq!(RunState::parse(&runs[0].state), RunState::Failed);
+    assert!(
+        runs[0].finished_at.is_some(),
+        "a run must never be left in `running`"
+    );
+    assert_eq!(runs[0].org_id, None, "no tenant was created");
+}
+
+/// The idempotency key is unique, so two deliveries of one event cannot
+/// both open a run — the constraint, not the handler, is what wins.
+#[tokio::test]
+async fn an_idempotency_key_cannot_open_two_runs() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+    let registry_pool = pools.registry_pool();
+
+    store::open_run(
+        &registry_pool,
+        "once",
+        "database",
+        "sqlite",
+        None,
+        None,
+        Some("evt-1"),
+    )
+    .await
+    .expect("first");
+    let second = store::open_run(
+        &registry_pool,
+        "twice",
+        "database",
+        "sqlite",
+        None,
+        None,
+        Some("evt-1"),
+    )
+    .await;
+    assert!(second.is_err(), "the unique constraint must refuse this");
+
+    let found = store::run_by_idempotency_key(&registry_pool, "evt-1")
+        .await
+        .expect("lookup")
+        .expect("the first run");
+    assert_eq!(found.slug, "once");
+}
+
+/// Pruning removes finished runs and their events, and leaves
+/// unfinished ones alone however old — one stuck in `running` is
+/// evidence of a pod that died, which is what someone comes looking for.
+#[tokio::test]
+async fn pruning_removes_finished_runs_and_keeps_unfinished_ones() {
+    let (pools, url, _tmp) = registry().await;
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    migrate_registry(&pools, &url, migrations.path()).await;
+    let registry_pool = pools.registry_pool();
+
+    let done = store::open_run(
+        &registry_pool,
+        "done",
+        "database",
+        "sqlite",
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("open");
+    let done_id = done.id.get().copied().expect("id");
+    store::append_event(&registry_pool, done_id, 1, "validate", "ok", "")
+        .await
+        .expect("event");
+    store::finish_run(&registry_pool, done_id, RunState::Succeeded, None)
+        .await
+        .expect("finish");
+
+    let stuck = store::open_run(
+        &registry_pool,
+        "stuck",
+        "database",
+        "sqlite",
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("open");
+    let stuck_id = stuck.id.get().copied().expect("id");
+
+    let cutoff = chrono::Utc::now() + chrono::Duration::minutes(1);
+    let removed = store::prune_runs(&registry_pool, cutoff)
+        .await
+        .expect("prune");
+    assert_eq!(removed, 1, "only the finished run should go");
+
+    assert!(store::run_by_id(&registry_pool, done_id)
+        .await
+        .expect("read")
+        .is_none());
+    assert!(store::events_since(&registry_pool, done_id, 0)
+        .await
+        .expect("events")
+        .is_empty());
+    assert!(
+        store::run_by_id(&registry_pool, stuck_id)
+            .await
+            .expect("read")
+            .is_some(),
+        "an unfinished run must survive pruning at any age"
+    );
+}


### PR DESCRIPTION
Closes #1321. **Stacked on #1326** → #1325 → #1324. This PR's diff is only the last commit.

## Why a table and not a channel

Slices #1320 and #1318 produce a stream of events. In memory they fail two ways:

- **Replay.** `sse::EventBus` is a broadcast wrapper — a subscriber sees only what arrives *after* it connects. Provisioning starts on a POST and the browser connects on the *next* request, so the opening steps are gone before anyone is listening. A mid-run reload loses the rest.
- **Two pods.** Behind a load balancer, the operator watching may not be on the pod doing the work.

`rustango_provisioning_runs` and `rustango_provisioning_events`, registry-scope, arriving through the generated migration chain exactly the way `rustango_org_hosts` does. A dense per-run `seq` is what `Last-Event-ID` resumes from.

## The decision this slice had to make

**What a failed run leaves behind.** The answer: the row goes in **inactive** and is **activated last**.

There is now no window in which a tenant resolves to a database with no schema — not a small one, none. A run that fails at migrate leaves an inactive `Org` plus whatever schema landed. The row stays on purpose: an operator needs to see what was half-made, and rolling back isn't always possible once a database exists.

This **overloads `active`**, which meant "suspended customer" and now also means "never finished provisioning". I think that's right, and here's the argument:

- the two are identical to the resolver — *do not serve*;
- the resolver already filters on that column, so it costs nothing on the hot path;
- the distinction that *does* matter (why is it inactive?) is answerable from the runs table, which is where the detail belongs;
- a dedicated `provisioning_state` column would be tidier and would ripple through every hand-written test schema across three dialects, for a distinction only the console needs.

Happy to be overruled — it's the one call in this stack I'd most want a second opinion on.

## What that forced, and fixed along the way

Inserting inactive breaks the batch migrate, which filters `active = true` — it would skip the very tenant it was called for. So provisioning now goes through a new **`migrate_one_tenant`**, which also closes the wart #1325 documented: creating tenant B no longer does a pass over tenant A, and an unrelated tenant's broken chain no longer surfaces mid-provision.

## Deduplicating the backend dispatch

The "downcast to `TenantPools<Postgres>`, else the generic runner" block had been written from memory in **four** places. One seam now — `migrate_tenants_dyn_with_progress` — and `manage migrate-tenants`, `manage migrate`, and the provisioning engine all route through it. Each copy was a chance to get the schema-mode branch wrong on a non-PG build.

## Where events are written, and where they aren't

Step transitions are written **as they happen**, between steps with no lock held — that's what makes a run readable from another pod while it's still going.

Migration events are different: they arrive **synchronously from inside the migrate lock**, where an `await` on a registry write would extend a lock every other migrating pod is queued behind. So they're buffered and flushed when the step ends. A watcher sees `Migrate: started`, a pause, then the whole per-migration log at once.

The alternative is a bounded channel and a drain task, which trades the pause for dropped events when the channel fills — and a `seq` with holes in it is no use as a replay log. Worth revisiting when #1322 shows whether the pause actually matters. Flagged in the type docs rather than left implicit.

## Credentials

`redact` is applied on the way **in**, so there's no reading path that can forget. Tested both directions.

## A real bug the tests caught

`order_by`'s bool is `desc`, not `asc` — so replay was coming back **newest-first**. That would have broken `Last-Event-ID` resume in exactly the way nobody notices until a reconnect silently skips half a log.

## Verification

- **8 new store tests**: replay order and density, resume from a given seq, a second connection standing in for a second pod, redaction round-trip, the failed-run disposition, an early failure still closing (never left in `running`), idempotency-key uniqueness, and pruning that spares unfinished runs.
- 8 engine tests, updated for the new `Activate` step.
- **`manage_live` 13/13 against live Postgres** — including the assertion that a freshly created tenant *is* active, which is what proves activate-last works end to end.
- 3636 lib tests. #1324, #1326 and the tenancy-manage suites still green.
- Zero warnings across seven feature combos, `--all-features --tests`, `--workspace --all-features --no-run`, `fmt --check`, clippy clean on both new files.

## Next

Everything #1322 (operator console) and #1323 (webhook) need now exists: an engine, a pre-flight, a progress stream, and a durable run to replay.