### PR TITLE
feat(tenancy): create tenants from the operator console, and watch it happen

### DIFF
--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -449,6 +449,12 @@ tenancy = [
     "storage",
     "uploads",
     "_async_trait",
+    # #1322 — the operator console streams a provisioning run as SSE, and
+    # the handler needs a `Stream` to hand axum. `async-stream` was
+    # already an optional dep pulled by `mcp` for the same reason; the
+    # console ships with tenancy, so tenancy is where it belongs now
+    # rather than being reachable only from an unrelated feature.
+    "dep:async-stream",
     "dep:argon2",
     "dep:cookie",
     # Deliberately the exact pair tenancy carried before #1208, not `_signing`

--- a/crates/rustango/src/sql/dialect.rs
+++ b/crates/rustango/src/sql/dialect.rs
@@ -55,7 +55,11 @@ fn write_pg_array_keys(
 /// plus the small bag of per-dialect DDL primitives the migration
 /// runner needs (identifier quoting, placeholder syntax, `SERIAL` /
 /// `AUTOINCREMENT` spelling, etc.).
-pub trait Dialect {
+/// `Send + Sync` because the migration runner holds a
+/// `&'static dyn Dialect` across `await` points, and a future that
+/// does so is only `Send` if the reference is. Free to require: every
+/// implementor is a unit struct with no state to share.
+pub trait Dialect: Send + Sync {
     // ====== Identity ======
 
     /// Short identifier for this dialect — `"postgres"`, `"sqlite"`,

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -38,6 +38,10 @@
 //! let app = axum::Router::new().merge(console);
 //! ```
 
+/// Creating a tenant from the console, and watching it happen (#1322).
+/// Mounted only by [`router_with_provisioning`].
+mod provisioning;
+
 use crate::core::Column as _;
 // v0.34 — operator console no longer imports `PgPool` directly.
 // ConsoleState.registry is `crate::sql::Pool` (the backend-erasing
@@ -85,6 +89,13 @@ struct ConsoleState {
     /// When `None` (the legacy [`router`] entry point), edit routes
     /// aren't mounted and the console stays read-only.
     pools: Option<Arc<dyn crate::tenancy::TenantPoolInvalidator>>,
+    /// When `Some`, the console can **create** tenants — see
+    /// [`provisioning`]. Separate from `pools` on purpose: creating a
+    /// tenant is strictly more dangerous than editing one (it takes a
+    /// database URL and connects to it), so a deployment opts into it
+    /// explicitly through [`router_with_provisioning`] rather than
+    /// getting it for free with the edit routes.
+    provisioner: Option<Arc<dyn crate::tenancy::provision::TenantProvisioner>>,
     session_secret: Arc<SessionSecret>,
     tera: Arc<Tera>,
     /// Storage backend for per-tenant brand assets (logo, favicon).
@@ -235,10 +246,59 @@ impl OpBrand {
 /// `./var/brand` or `RUSTANGO_BRAND_STORAGE_DIR`). To plug in S3 /
 /// R2 / B2 / MinIO / a CDN-fronted bucket, use
 /// [`router_with_brand_storage`].
+/// [`router_with_pools`] plus the routes that **create** tenants:
+/// `GET`/`POST /orgs/new`, `POST /orgs/test-connection`, and the
+/// provisioning run view + SSE stream.
+///
+/// Separate constructor rather than a flag on the others, because
+/// creating a tenant is strictly more dangerous than editing one — it
+/// takes a database URL from a form and connects to it. A deployment
+/// says yes to that explicitly.
+///
+/// Build the provisioner with
+/// [`crate::tenancy::provision::Provisioner::new`], which closes over
+/// the pools, the registry URL and the migrations directory:
+///
+/// ```ignore
+/// let provisioner = tenancy::provision::Provisioner::new(
+///     pools.clone(), registry_url.clone(), "migrations",
+/// ).erased();
+/// let console = operator_console::router_with_provisioning(
+///     registry, pools.into_invalidator(), provisioner, secret,
+/// );
+/// ```
+///
+/// ## Authorization
+///
+/// Every authenticated operator who can reach the console can use
+/// these routes. That is not an oversight to work around with a
+/// wrapper — `Operator` has no permission model at all today, so a
+/// single flag for a single route would be half a system. Mounting is
+/// the boundary that currently means something. A real operator
+/// permission model is tracked separately.
+#[must_use]
+pub fn router_with_provisioning(
+    registry: impl Into<crate::sql::Pool>,
+    pools: Arc<dyn crate::tenancy::TenantPoolInvalidator>,
+    provisioner: Arc<dyn crate::tenancy::provision::TenantProvisioner>,
+    secret: SessionSecret,
+) -> Router {
+    router_inner(
+        registry.into(),
+        Some(pools),
+        Some(provisioner),
+        secret,
+        branding::default_brand_storage(),
+        None,
+        default_tenant_handoff_url(),
+    )
+}
+
 #[must_use]
 pub fn router(registry: impl Into<crate::sql::Pool>, secret: SessionSecret) -> Router {
     router_inner(
         registry.into(),
+        None,
         None,
         secret,
         branding::default_brand_storage(),
@@ -261,6 +321,7 @@ pub fn router_with_pools(
     router_inner(
         registry.into(),
         Some(pools),
+        None,
         secret,
         branding::default_brand_storage(),
         None,
@@ -300,6 +361,7 @@ pub fn router_with_impersonation(
     router_inner(
         registry.into(),
         Some(pools),
+        None,
         secret,
         brand_storage,
         Some(tenant_session_secret),
@@ -329,6 +391,7 @@ pub fn router_with_brand_storage(
     router_inner(
         registry.into(),
         pools,
+        None,
         secret,
         brand_storage,
         None,
@@ -348,6 +411,7 @@ fn default_tenant_handoff_url() -> String {
 fn router_inner(
     registry: crate::sql::Pool,
     pools: Option<Arc<dyn crate::tenancy::TenantPoolInvalidator>>,
+    provisioner: Option<Arc<dyn crate::tenancy::provision::TenantProvisioner>>,
     secret: SessionSecret,
     brand_storage: BoxedStorage,
     tenant_session_secret: Option<SessionSecret>,
@@ -393,13 +457,23 @@ fn router_inner(
             "op_sso_shared.html",
             include_str!("../templates/op_sso_shared.html"),
         ),
+        (
+            "op_orgs_new.html",
+            include_str!("../templates/op_orgs_new.html"),
+        ),
+        (
+            "op_provision_run.html",
+            include_str!("../templates/op_provision_run.html"),
+        ),
     ])
     .expect("operator-console templates parse");
     let edit_enabled = pools.is_some();
     let impersonation_enabled = tenant_session_secret.is_some() && pools.is_some();
+    let provisioning_enabled = provisioner.is_some();
     let state = ConsoleState {
         registry,
         pools,
+        provisioner,
         session_secret: Arc::new(secret),
         tera: Arc::new(tera),
         brand_storage,
@@ -448,6 +522,27 @@ fn router_inner(
             .route(
                 "/orgs/{slug}/edit/branding",
                 get(org_post_only_redirect).post(org_edit_branding),
+            );
+    }
+    if provisioning_enabled {
+        // #1322 — creating a tenant, and watching it happen. Mounted
+        // only when the deployment supplied a provisioner: this is the
+        // console's most dangerous capability (it takes a database URL
+        // and connects to it), so it is opt-in rather than riding on
+        // the edit routes.
+        private = private
+            .route(
+                "/orgs/new",
+                get(provisioning::org_new_form).post(provisioning::org_new_submit),
+            )
+            .route("/orgs/test-connection", post(provisioning::test_connection))
+            .route(
+                "/orgs/provision/{run_id}",
+                get(provisioning::provision_run_view),
+            )
+            .route(
+                "/orgs/provision/{run_id}/stream",
+                get(provisioning::provision_run_stream),
             );
     }
     if impersonation_enabled {

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -1,0 +1,482 @@
+//! Creating a tenant from the operator console (#1322).
+//!
+//! Until now the console could list, edit, re-brand and impersonate —
+//! but not create. An operator who needed a new tenant needed shell
+//! access to a box holding registry credentials.
+//!
+//! ## Why the stream reads the table instead of a channel
+//!
+//! The obvious design is an in-process broadcast: provisioning pushes
+//! events, the SSE handler subscribes. It does not survive contact
+//! with two pods — the operator's stream can land on a different pod
+//! from the one doing the work, and they watch an empty page while
+//! provisioning succeeds somewhere else. It does not survive a reload
+//! either, because a broadcast has no history.
+//!
+//! So the run is persisted (#1321) and this polls it. Unglamorous, and
+//! it is what makes a reconnect resume exactly where it left off and a
+//! second pod see everything. `Last-Event-ID` is the `seq` column.
+//!
+//! ## Who may do this
+//!
+//! Provisioning routes are mounted **only** when the deployment builds
+//! the console through [`super::router_with_provisioning`]. That is a
+//! deliberate deployment-level gate rather than a per-operator
+//! permission, because `Operator` has no permission model at all
+//! today — every authenticated operator can already do everything the
+//! console exposes. Adding one flag for one route would be half a
+//! permission system; the gate that actually means something right now
+//! is whether the console can create tenants *at all*. A real operator
+//! permission model is worth its own issue.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use axum::Form;
+use tera::Context;
+
+use super::{inject_op_brand, ConsoleState};
+use crate::tenancy::auth;
+use crate::tenancy::org::{BackendKind, StorageMode};
+use crate::tenancy::preflight::{self, Preflight};
+use crate::tenancy::provision::ProvisionRequest;
+use crate::tenancy::provision_store::{self as store, RunState};
+
+/// How often the stream looks for new events.
+///
+/// Short enough that a checklist feels live, long enough that an idle
+/// stream is not a busy loop against the registry. Each poll is one
+/// indexed `SELECT … WHERE run_id = ? AND seq > ?`.
+const POLL_EVERY: Duration = Duration::from_millis(500);
+
+/// Stop streaming a run that never terminates, so an abandoned browser
+/// tab cannot hold a connection (and a poll loop) open indefinitely.
+/// A provisioning run that has not finished in this long is stuck, and
+/// the non-streaming view still shows whatever it did manage.
+const STREAM_MAX: Duration = Duration::from_secs(30 * 60);
+
+// ---------------------------------------------------------------- new
+
+/// The create form.
+pub(super) async fn org_new_form(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+) -> Response<Body> {
+    render_form(&state, &op, &HashMap::new(), None)
+}
+
+fn render_form(
+    state: &ConsoleState,
+    op: &auth::Operator,
+    prefill: &HashMap<String, String>,
+    error: Option<&str>,
+) -> Response<Body> {
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "orgs");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("prefill", prefill);
+    ctx.insert("error", &error);
+    // Schema-mode is Postgres-only by language. Offering it on a
+    // SQLite or MySQL registry would be offering a choice that can
+    // only fail, so the form does not.
+    ctx.insert(
+        "schema_mode_available",
+        &(state.registry.dialect().name() == "postgres"),
+    );
+    render(state, "op_orgs_new.html", &ctx)
+}
+
+/// Render, or say why not.
+///
+/// The console's older handlers use `.unwrap_or_default()`, which turns
+/// a template error into an empty `200` — a blank page with no clue
+/// anywhere. That cost real time on this very module: a missing key in
+/// a Tera comparison rendered nothing and looked like a routing
+/// problem. A 500 naming the template is worth far more than a page
+/// that lies about having worked.
+fn render(state: &ConsoleState, template: &str, ctx: &Context) -> Response<Body> {
+    match state.tera.render(template, ctx) {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            let mut detail = e.to_string();
+            let mut source = std::error::Error::source(&e);
+            while let Some(s) = source {
+                detail.push_str(": ");
+                detail.push_str(&s.to_string());
+                source = s.source();
+            }
+            tracing::error!(
+                target: "rustango::tenancy::operator_console",
+                template,
+                error = %detail,
+                "operator console template failed to render"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not render {template}: {detail}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Turn the submitted form into a request, or say what is wrong with it.
+fn request_from_form(form: &HashMap<String, String>) -> Result<ProvisionRequest, String> {
+    let field = |k: &str| form.get(k).map(|v| v.trim()).filter(|v| !v.is_empty());
+
+    let slug = field("slug")
+        .ok_or("A slug is required — it is the tenant's globally unique name.")?
+        .to_owned();
+
+    let mode = match field("storage_mode").unwrap_or("database") {
+        "schema" => StorageMode::Schema,
+        _ => StorageMode::Database,
+    };
+    let backend = BackendKind::parse(field("backend_kind").unwrap_or("postgres"))
+        .map_err(|got| format!("Unknown backend `{got}`."))?;
+    backend
+        .validate_storage_mode(mode)
+        .map_err(ToOwned::to_owned)?;
+
+    let port = match field("port") {
+        Some(raw) => Some(
+            raw.parse::<i32>()
+                .map_err(|_| format!("Port must be a whole number, got `{raw}`."))?,
+        ),
+        None => None,
+    };
+
+    Ok(ProvisionRequest {
+        slug,
+        mode,
+        backend,
+        display_name: field("display_name").map(ToOwned::to_owned),
+        database_url: field("database_url").map(ToOwned::to_owned),
+        schema_name: field("schema_name").map(ToOwned::to_owned),
+        host_pattern: field("host_pattern").map(ToOwned::to_owned),
+        port,
+        path_prefix: field("path_prefix").map(ToOwned::to_owned),
+        run_migrations: !form.contains_key("no_migrate"),
+        preflight: Preflight::default(),
+    })
+}
+
+/// Create the tenant, then redirect to its run.
+pub(super) async fn org_new_submit(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Form(form): Form<HashMap<String, String>>,
+) -> Response<Body> {
+    let provisioner = state
+        .provisioner
+        .as_ref()
+        .expect("provisioning routes are only mounted when a provisioner is supplied");
+
+    let request = match request_from_form(&form) {
+        Ok(r) => r,
+        Err(msg) => return render_form(&state, &op, &form, Some(&msg)),
+    };
+
+    // Provisioning runs inline. It is slower than a request should be
+    // — the migrate step is seconds — but the alternative is spawning
+    // and losing the failure, and the operator is watching a form they
+    // just submitted. The stream view is for *re*-connecting, not for
+    // escaping this wait.
+    match provisioner
+        .provision(&request, Some(&op.username), None)
+        .await
+    {
+        Ok((run, _)) => {
+            let run_id = run.id.get().copied().unwrap_or_default();
+            Redirect::to(&format!("provision/{run_id}")).into_response()
+        }
+        // A failure before the row lands — a taken slug, an unreachable
+        // database — comes back here rather than as a run to watch,
+        // because there is nothing to watch. Re-render with the
+        // operator's input intact so they can fix one field.
+        Err(e) => render_form(&state, &op, &form, Some(&e.to_string())),
+    }
+}
+
+// ---------------------------------------------------- test connection
+
+/// Reach the database the form names, and report the taxonomy.
+///
+/// Writes nothing, creates nothing. Returns a fragment the form drops
+/// in place, so this is usable from a button without a page reload.
+pub(super) async fn test_connection(
+    State(_state): State<ConsoleState>,
+    Extension(_op): Extension<auth::Operator>,
+    Form(form): Form<HashMap<String, String>>,
+) -> Response<Body> {
+    let Some(url) = form
+        .get("database_url")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    else {
+        return Html("<p class=\"probe probe-bad\">Enter a database URL first.</p>".to_owned())
+            .into_response();
+    };
+
+    match preflight::check(url, &Preflight::default()).await {
+        Ok(ok) => Html(format!(
+            "<p class=\"probe probe-ok\">Reached <code>{}</code>. \
+             This role can create tables, so migrations will run.</p>",
+            html_escape(&ok.endpoint)
+        ))
+        .into_response(),
+        // The diagnosis already leads with what to change — see
+        // `sql::connect_diagnosis`. Rendering it verbatim is the point.
+        Err(d) => Html(format!(
+            "<p class=\"probe probe-bad\">{}</p>",
+            html_escape(&d.to_string())
+        ))
+        .into_response(),
+    }
+}
+
+// ------------------------------------------------------------ run view
+
+/// The non-streaming view of a run: what it did, whether it finished.
+///
+/// Also the page a finished run settles into, and the audit trail
+/// someone comes back to later.
+pub(super) async fn provision_run_view(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(run_id): Path<i64>,
+) -> Response<Body> {
+    let Some(run) = (match store::run_by_id(&state.registry, run_id).await {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }) else {
+        return (StatusCode::NOT_FOUND, format!("no run {run_id}")).into_response();
+    };
+    let events = store::events_since(&state.registry, run_id, 0)
+        .await
+        .unwrap_or_default();
+
+    let state_str = run.state.clone();
+    let parsed = RunState::parse(&state_str);
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "orgs");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("run_id", &run_id);
+    ctx.insert("slug", &run.slug);
+    ctx.insert("state", &state_str);
+    ctx.insert("terminal", &parsed.is_terminal());
+    ctx.insert("error", &run.error);
+    ctx.insert(
+        "events",
+        &events
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "seq": e.seq,
+                    "step": e.step,
+                    "status": e.status,
+                    "message": e.message,
+                })
+            })
+            .collect::<Vec<_>>(),
+    );
+    render(&state, "op_provision_run.html", &ctx)
+}
+
+#[derive(serde::Deserialize, Default)]
+pub(super) struct StreamQuery {
+    /// Resume point, for clients that would rather pass it explicitly
+    /// than through the `Last-Event-ID` header.
+    after: Option<i64>,
+}
+
+/// Stream a run's events as they land.
+///
+/// Replays everything from `after` (or `Last-Event-ID`, or the
+/// beginning) and then follows, **terminating** when the run reaches a
+/// terminal state. A stream that never ends is a connection leak and
+/// gives a browser no way to know it is watching a finished run.
+pub(super) async fn provision_run_stream(
+    State(state): State<ConsoleState>,
+    Extension(_op): Extension<auth::Operator>,
+    Path(run_id): Path<i64>,
+    Query(q): Query<StreamQuery>,
+    headers: HeaderMap,
+    // `impl IntoResponse` rather than naming `Sse<impl Stream<…>>`:
+    // the `Stream` trait lives in `futures-core`, which is in the tree
+    // transitively but not a declared dependency. Not worth adding one
+    // to spell a return type.
+) -> impl IntoResponse {
+    // `Last-Event-ID` is how the browser's own EventSource resumes
+    // after a dropped connection — it replays the header without being
+    // asked. Honouring it is what makes a reconnect seamless rather
+    // than a duplicate log.
+    let resume = q.after.or_else(|| {
+        headers
+            .get(axum::http::header::HeaderName::from_static("last-event-id"))
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok())
+    });
+
+    let registry = state.registry.clone();
+    // The error type is pinned once here: nothing in this stream can
+    // fail in a way axum has to render — a store read that errors is
+    // reported *as an event* and closes the stream, which is what a
+    // watcher can actually act on.
+    type Item = Result<Event, std::convert::Infallible>;
+    let stream = async_stream::stream! {
+        let mut last = resume.unwrap_or(0);
+        let started = std::time::Instant::now();
+
+        loop {
+            match store::events_since(&registry, run_id, last).await {
+                Ok(events) => {
+                    for event in events {
+                        last = event.seq;
+                        let data = serde_json::json!({
+                            "seq": event.seq,
+                            "step": event.step,
+                            "status": event.status,
+                            "message": event.message,
+                        });
+                        yield Item::Ok(Event::default()
+                            // The id IS the resume point. Without it a
+                            // reconnect starts over.
+                            .id(event.seq.to_string())
+                            .event("step")
+                            .data(data.to_string()));
+                    }
+                }
+                Err(e) => {
+                    yield Item::Ok(Event::default()
+                        .event("error")
+                        .data(e.to_string()));
+                    return;
+                }
+            }
+
+            // Terminal check *after* draining, so the last events are
+            // always delivered before the stream closes.
+            let finished = matches!(
+                store::run_by_id(&registry, run_id).await,
+                Ok(Some(run)) if RunState::parse(&run.state).is_terminal()
+            );
+            if finished {
+                yield Item::Ok(Event::default().event("done").data(last.to_string()));
+                return;
+            }
+            if started.elapsed() > STREAM_MAX {
+                yield Item::Ok(Event::default()
+                    .event("error")
+                    .data("stream timed out; the run is still unfinished"));
+                return;
+            }
+            tokio::time::sleep(POLL_EVERY).await;
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Minimal escaping for the two fragments this module builds by hand.
+///
+/// Both carry a connection diagnosis, which contains a hostname and a
+/// driver message — neither of which is ours, so neither goes into a
+/// page unescaped.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn form(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn a_minimal_form_becomes_a_database_mode_request() {
+        let r = request_from_form(&form(&[
+            ("slug", "acme"),
+            ("database_url", "postgres://u:p@h/acme"),
+        ]))
+        .expect("valid");
+        assert_eq!(r.slug, "acme");
+        assert_eq!(r.mode, StorageMode::Database);
+        assert!(r.run_migrations, "migrations run unless opted out");
+    }
+
+    /// Blank fields are absent fields. A form posts every input it
+    /// has, so treating "" as `Some("")` would write empty strings
+    /// into columns that mean something by being NULL.
+    #[test]
+    fn blank_fields_are_treated_as_unset() {
+        let r = request_from_form(&form(&[
+            ("slug", "acme"),
+            ("database_url", "postgres://u:p@h/acme"),
+            ("display_name", "   "),
+            ("host_pattern", ""),
+        ]))
+        .expect("valid");
+        assert_eq!(r.display_name, None);
+        assert_eq!(r.host_pattern, None);
+    }
+
+    #[test]
+    fn a_missing_slug_is_refused_with_a_useful_message() {
+        let err = request_from_form(&form(&[("database_url", "x")])).expect_err("no slug");
+        assert!(err.contains("slug"), "{err}");
+    }
+
+    #[test]
+    fn a_non_numeric_port_is_refused() {
+        let err =
+            request_from_form(&form(&[("slug", "a"), ("port", "eighty")])).expect_err("bad port");
+        assert!(err.contains("whole number"), "{err}");
+    }
+
+    /// The checkbox is absent when unticked, which is how HTML forms
+    /// work — so its *presence* is what turns migrations off.
+    #[test]
+    fn the_no_migrate_checkbox_inverts_correctly() {
+        let on = request_from_form(&form(&[("slug", "a"), ("no_migrate", "on")])).unwrap();
+        assert!(!on.run_migrations);
+        let off = request_from_form(&form(&[("slug", "a")])).unwrap();
+        assert!(off.run_migrations);
+    }
+
+    /// Schema-mode on a non-PG backend is refused at the form, not
+    /// deep in the pool layer.
+    #[test]
+    fn schema_mode_on_a_non_pg_backend_is_refused_early() {
+        let err = request_from_form(&form(&[
+            ("slug", "a"),
+            ("storage_mode", "schema"),
+            ("backend_kind", "sqlite"),
+        ]))
+        .expect_err("sqlite cannot do schema mode");
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn escaping_covers_the_characters_that_break_out_of_a_fragment() {
+        assert_eq!(
+            html_escape(r#"<script>"&"</script>"#),
+            "&lt;script&gt;&quot;&amp;&quot;&lt;/script&gt;"
+        );
+    }
+}

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -896,3 +896,111 @@ where
         Err(e) => MigrationsOutcome::Failed(e.to_string()),
     }
 }
+
+/// Provisioning for surfaces that have erased the backend type.
+///
+/// The operator console holds its pools as
+/// `Arc<dyn TenantPoolInvalidator>` — deliberately, so `<DB>` does not
+/// cascade through every handler — while [`provision_tenant`] is
+/// generic over `DB`. This is the bridge, following the same
+/// boxed-future shape [`super::TenantPoolInvalidator`] already uses.
+///
+/// It also closes over the registry URL and migrations directory, which
+/// a request handler has no business carrying around.
+///
+/// Note what is **not** here: an observer. A caller watching a run
+/// reads it back from [`super::provision_store`] instead, which is what
+/// makes a console work when the pod serving the stream is not the pod
+/// doing the work.
+pub trait TenantProvisioner: Send + Sync {
+    /// Stand up a tenant, recording the run.
+    fn provision<'a>(
+        &'a self,
+        request: &'a ProvisionRequest,
+        requested_by: Option<&'a str>,
+        idempotency_key: Option<&'a str>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<
+                        (super::provision_store::ProvisioningRun, ProvisionOutcome),
+                        TenancyError,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    >;
+
+    /// The registry pool, so a caller can read runs and events back.
+    fn registry(&self) -> crate::sql::Pool;
+}
+
+/// A [`TenantProvisioner`] over concrete pools.
+pub struct Provisioner<DB: Database> {
+    pools: std::sync::Arc<TenantPools<DB>>,
+    registry_url: String,
+    migrations_dir: std::path::PathBuf,
+}
+
+impl<DB: Database> Provisioner<DB> {
+    pub fn new(
+        pools: std::sync::Arc<TenantPools<DB>>,
+        registry_url: impl Into<String>,
+        migrations_dir: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        Self {
+            pools,
+            registry_url: registry_url.into(),
+            migrations_dir: migrations_dir.into(),
+        }
+    }
+
+    /// Type-erase for the console and anything else that does not want
+    /// `<DB>` in its state.
+    #[must_use]
+    pub fn erased(self) -> std::sync::Arc<dyn TenantProvisioner>
+    where
+        crate::sql::Pool: From<sqlx::Pool<DB>>,
+    {
+        std::sync::Arc::new(self)
+    }
+}
+
+impl<DB: Database> TenantProvisioner for Provisioner<DB>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    fn provision<'a>(
+        &'a self,
+        request: &'a ProvisionRequest,
+        requested_by: Option<&'a str>,
+        idempotency_key: Option<&'a str>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<
+                        (super::provision_store::ProvisioningRun, ProvisionOutcome),
+                        TenancyError,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            provision_tenant_recorded(
+                self.pools.as_ref(),
+                &self.registry_url,
+                &self.migrations_dir,
+                request,
+                None,
+                requested_by,
+                idempotency_key,
+            )
+            .await
+        })
+    }
+
+    fn registry(&self) -> crate::sql::Pool {
+        self.pools.registry_pool()
+    }
+}

--- a/crates/rustango/src/tenancy/templates/op_orgs_new.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_new.html
@@ -1,0 +1,132 @@
+{% extends "op_layout.html" %}
+{% block title %}New tenant — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block content %}
+<h1>New tenant</h1>
+<p>Stands the tenant up end to end: reaches its database, registers it,
+runs its migrations, and only then makes it live. Nothing is written
+until the connection check passes.</p>
+
+{% if error %}
+<div class="empty" style="border-color:var(--danger,#b3261e);color:var(--danger,#b3261e)">
+  {{ error }}
+</div>
+{% endif %}
+
+<form method="post" action="new" class="stack">
+  <label>
+    Slug
+    <input type="text" name="slug" required autofocus
+           value="{{ prefill.slug | default(value='') }}"
+           pattern="[a-z0-9][a-z0-9-]*"
+           placeholder="acme">
+    <small>Globally unique. Also the default schema name, display name
+    and subdomain label.</small>
+  </label>
+
+  <label>
+    Display name
+    <input type="text" name="display_name"
+           value="{{ prefill.display_name | default(value='') }}"
+           placeholder="defaults to the slug">
+  </label>
+
+  <label>
+    Storage mode
+    <select name="storage_mode">
+      <option value="database" {% if prefill.storage_mode | default(value="database") != "schema" %}selected{% endif %}>
+        database — its own database
+      </option>
+      {% if schema_mode_available %}
+      <option value="schema" {% if prefill.storage_mode | default(value="") == "schema" %}selected{% endif %}>
+        schema — a schema in the registry database (Postgres only)
+      </option>
+      {% endif %}
+    </select>
+    {% if not schema_mode_available %}
+    <small>Schema mode needs a Postgres registry — this one is not,
+    so only database mode is offered.</small>
+    {% endif %}
+  </label>
+
+  <label>
+    Backend
+    <select name="backend_kind">
+      {% for b in ["postgres", "mysql", "sqlite"] %}
+      <option value="{{ b }}" {% if prefill.backend_kind | default(value="postgres") == b %}selected{% endif %}>{{ b }}</option>
+      {% endfor %}
+    </select>
+  </label>
+
+  <label>
+    Database URL
+    <input type="text" name="database_url" id="database_url"
+           value="{{ prefill.database_url | default(value='') }}"
+           placeholder="postgres://user:password@host:5432/acme">
+    <small>Required in database mode. Ignored in schema mode, where the
+    tenant lives in the registry's own database.</small>
+  </label>
+
+  <p>
+    <button type="button" id="test-connection">Test connection</button>
+    <span id="probe-result"></span>
+  </p>
+
+  <label>
+    Host pattern
+    <input type="text" name="host_pattern"
+           value="{{ prefill.host_pattern | default(value='') }}"
+           placeholder="acme.example.com">
+    <small>Leave blank to derive <code>&lt;slug&gt;.&lt;RUSTANGO_APEX_DOMAIN&gt;</code>
+    when that variable is set.</small>
+  </label>
+
+  <label>
+    Path prefix
+    <input type="text" name="path_prefix"
+           value="{{ prefill.path_prefix | default(value='') }}"
+           placeholder="/acme">
+  </label>
+
+  <label>
+    Port
+    <input type="text" name="port" inputmode="numeric"
+           value="{{ prefill.port | default(value='') }}">
+  </label>
+
+  <label class="inline">
+    <input type="checkbox" name="no_migrate" value="on"
+           {% if prefill.no_migrate | default(value=false) %}checked{% endif %}>
+    Skip migrations — register the tenant without building its schema.
+    It will still go live; migrate it later.
+  </label>
+
+  <p>
+    <button type="submit" class="primary">Create tenant</button>
+    <a href="../orgs">Cancel</a>
+  </p>
+</form>
+
+<script>
+  // Posts just the URL to the probe endpoint and drops the returned
+  // fragment in place, so an operator can check a URL without losing
+  // the rest of the form to a page reload.
+  document.getElementById("test-connection").addEventListener("click", async (e) => {
+    const out = document.getElementById("probe-result");
+    const url = document.getElementById("database_url").value;
+    e.target.disabled = true;
+    out.textContent = "checking…";
+    try {
+      const res = await fetch("test-connection", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ database_url: url }),
+      });
+      out.innerHTML = await res.text();
+    } catch (err) {
+      out.textContent = "could not reach the console: " + err;
+    } finally {
+      e.target.disabled = false;
+    }
+  });
+</script>
+{% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_provision_run.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_run.html
@@ -1,0 +1,76 @@
+{% extends "op_layout.html" %}
+{% block title %}Provisioning {{ slug }} — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block content %}
+<h1>Provisioning <code>{{ slug }}</code></h1>
+
+<p>
+  Run #{{ run_id }} —
+  <strong id="run-state" data-state="{{ state }}">{{ state }}</strong>
+</p>
+
+{% if error %}
+<div class="empty" style="border-color:var(--danger,#b3261e);color:var(--danger,#b3261e)">
+  {{ error }}
+</div>
+{% endif %}
+
+<table>
+  <thead>
+    <tr><th>#</th><th>Step</th><th>Status</th><th>Detail</th></tr>
+  </thead>
+  <tbody id="events">
+    {% for e in events %}
+    <tr data-seq="{{ e.seq }}">
+      <td>{{ e.seq }}</td>
+      <td><code>{{ e.step }}</code></td>
+      <td>{{ e.status }}</td>
+      <td>{{ e.message }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<p><a href="../../orgs">Back to tenants</a></p>
+
+{% if not terminal %}
+<script>
+  // Resume from the last row already rendered, so a reload does not
+  // replay what is on screen — and a reconnect mid-run picks up
+  // exactly where it stopped. The server honours `Last-Event-ID` too;
+  // this is the explicit form for the first connection.
+  (function () {
+    const tbody = document.getElementById("events");
+    const rows = tbody.querySelectorAll("tr[data-seq]");
+    const last = rows.length ? rows[rows.length - 1].dataset.seq : 0;
+
+    const es = new EventSource("{{ run_id }}/stream?after=" + last);
+
+    es.addEventListener("step", (msg) => {
+      const e = JSON.parse(msg.data);
+      const tr = document.createElement("tr");
+      tr.dataset.seq = e.seq;
+      for (const v of [e.seq, e.step, e.status, e.message]) {
+        const td = document.createElement("td");
+        // textContent, never innerHTML: `message` carries driver text
+        // and hostnames that are not ours.
+        td.textContent = v;
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    });
+
+    es.addEventListener("done", () => {
+      es.close();
+      // Re-read rather than guess the final state: the stream says
+      // "finished", the page says what it finished as.
+      window.location.reload();
+    });
+
+    es.addEventListener("error", (msg) => {
+      const state = document.getElementById("run-state");
+      if (msg.data) { state.textContent = state.textContent + " — " + msg.data; }
+    });
+  })();
+</script>
+{% endif %}
+{% endblock %}

--- a/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
@@ -1,0 +1,514 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Creating a tenant from the operator console (#1322), end to end
+//! through the real router.
+//!
+//! SQLite, because the console is tri-dialect and this needs no server.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, Auto, FetcherPool as _};
+use rustango::tenancy::operator_console::{router_with_provisioning, SessionSecret};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::{Org, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}{}_{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    // Registry tables through the generated chain, as production does.
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein";
+    let mut op = rustango::tenancy::Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let app = router_with_provisioning(
+        registry.clone(),
+        pools.clone(),
+        provisioner,
+        SessionSecret::from_env_or_random(),
+    );
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        login.status().is_redirection(),
+        "login should redirect, got {}",
+        login.status()
+    );
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        pools,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+/// Percent-encode a form value.
+///
+/// Local rather than `urlencoding::encode`: that crate is an optional
+/// dependency not enabled by `sqlite,tenancy`, and widening a feature
+/// set to spell one test fixture is the wrong trade.
+fn form_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 3);
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    String::from_utf8_lossy(&to_bytes(resp.into_body(), 4 * 1024 * 1024).await.unwrap())
+        .into_owned()
+}
+
+#[tokio::test]
+async fn the_create_form_renders_for_an_authenticated_operator() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(html.contains("name=\"slug\""), "no slug field: {html}");
+    assert!(html.contains("Test connection"), "no probe button");
+    // Schema mode is Postgres-only; a SQLite registry must not offer
+    // a choice that can only fail.
+    assert!(
+        !html.contains("value=\"schema\""),
+        "schema mode offered on a sqlite registry"
+    );
+}
+
+/// Unauthenticated requests never reach the form.
+#[tokio::test]
+async fn the_create_routes_require_a_session() {
+    let b = boot().await;
+    for (method, uri) in [("GET", "/orgs/new"), ("POST", "/orgs/new")] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+            "{method} {uri} was reachable without a session: {}",
+            resp.status()
+        );
+    }
+}
+
+/// The probe reports the taxonomy, writes nothing, and does not leak
+/// the password back into the page.
+#[tokio::test]
+async fn test_connection_reports_why_and_creates_nothing() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/test-connection")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "database_url=postgres%3A%2F%2Fu%3Ahunter2%40127.0.0.1%3A59417%2Fnope",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(
+        html.contains("probe-bad"),
+        "an unusable URL should report as bad: {html}"
+    );
+    // The endpoint is echoed so the operator can see *what* was tried,
+    // and the password is not.
+    assert!(html.contains("127.0.0.1:59417"), "should name the endpoint");
+    assert!(!html.contains("hunter2"), "password leaked into the page");
+    // The fault taxonomy itself (unreachable / auth / no-such-database
+    // / wrong-server) is covered per dialect in `preflight_live`. This
+    // build has no `postgres` feature, so a `postgres://` URL is
+    // refused at the feature check rather than at connect — asserting
+    // a specific fault here would be asserting the build's feature
+    // set, not the console's behaviour.
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(orgs.is_empty(), "a probe must not create a tenant");
+}
+
+/// The whole path: submit the form, get redirected to the run, and
+/// find the tenant live.
+#[tokio::test]
+async fn submitting_the_form_provisions_a_tenant_and_redirects_to_its_run() {
+    let b = boot().await;
+    let tenant_db = b._tmp.path().join("acme.db");
+    let slug = unique("acme");
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url={}",
+        form_encode(&format!("sqlite://{}?mode=rwc", tenant_db.display()))
+    );
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status().is_redirection(),
+        "expected a redirect to the run, got {} — body: {}",
+        resp.status(),
+        body_of(resp).await
+    );
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("redirect target")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        location.starts_with("provision/"),
+        "should land on the run: {location}"
+    );
+
+    // The tenant exists and is live — activation is the last step.
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert_eq!(orgs.len(), 1);
+    assert_eq!(orgs[0].slug, slug);
+    assert!(orgs[0].active, "a successful run ends with the tenant live");
+
+    // The run view renders its step log.
+    let run_uri = format!("/orgs/{location}");
+    let view = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(&run_uri)
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(view.status(), StatusCode::OK);
+    let html = body_of(view).await;
+    for step in ["validate", "check_connection", "register_org", "activate"] {
+        assert!(html.contains(step), "run view missing `{step}`: {html}");
+    }
+    assert!(html.contains("succeeded"), "run should read as succeeded");
+}
+
+/// A bad submission comes back as the form with the reason, not a 500
+/// and not a half-made tenant.
+#[tokio::test]
+async fn a_bad_submission_re_renders_the_form_with_the_reason() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                // Database mode with no URL.
+                .body(Body::from("slug=nourl&storage_mode=database"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK, "re-render, not a redirect");
+    let html = body_of(resp).await;
+    assert!(html.contains("--database-url"), "should say what is wrong");
+    assert!(
+        html.contains("value=\"nourl\""),
+        "the operator's input should survive the round-trip"
+    );
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(orgs.is_empty(), "nothing should have been created");
+}
+
+/// The stream replays a finished run and **terminates**. A stream that
+/// never closes is a connection leak and leaves the browser unable to
+/// tell it is watching something already over.
+#[tokio::test]
+async fn the_stream_replays_a_finished_run_and_then_ends() {
+    let b = boot().await;
+    let tenant_db = b._tmp.path().join("streamed.db");
+    let slug = unique("streamed");
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url={}",
+        form_encode(&format!("sqlite://{}?mode=rwc", tenant_db.display()))
+    );
+    let created = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let location = created
+        .headers()
+        .get("location")
+        .expect("redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/orgs/{location}/stream"))
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+
+    // Collecting the body to completion only returns if the stream
+    // actually ends — which is the assertion.
+    let body = tokio::time::timeout(std::time::Duration::from_secs(20), body_of(resp))
+        .await
+        .expect("the stream must terminate on a finished run");
+
+    assert!(body.contains("event: step"), "no step events: {body}");
+    assert!(body.contains("event: done"), "stream did not signal done");
+    // Every event carries its `seq` as the SSE id — that is what
+    // `Last-Event-ID` resumes from.
+    assert!(body.contains("id: 1"), "events must be addressable: {body}");
+    assert!(body.contains("activate"), "the last step should be there");
+}
+
+/// `?after=` skips what the page already rendered, so a reload does
+/// not duplicate the log.
+#[tokio::test]
+async fn the_stream_resumes_from_a_given_seq() {
+    let b = boot().await;
+    let tenant_db = b._tmp.path().join("resume.db");
+    let slug = unique("resume");
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url={}",
+        form_encode(&format!("sqlite://{}?mode=rwc", tenant_db.display()))
+    );
+    let created = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let location = created
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/orgs/{location}/stream?after=3"))
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = tokio::time::timeout(std::time::Duration::from_secs(20), body_of(resp))
+        .await
+        .expect("stream terminates");
+
+    // Parse the ids rather than substring-matching them: `id: 1` is a
+    // prefix of `id: 14`, so a `contains` check passes on a stream
+    // that did replay the beginning. (It did here, and the assertion
+    // said the opposite of what it meant.)
+    let ids: Vec<i64> = body
+        .lines()
+        .filter_map(|l| l.strip_prefix("id: "))
+        .filter_map(|s| s.trim().parse().ok())
+        .collect();
+    assert!(!ids.is_empty(), "no events at all: {body}");
+    assert_eq!(
+        ids.iter().min().copied(),
+        Some(4),
+        "resume must start after the given seq, got {ids:?}"
+    );
+    assert!(
+        ids.windows(2).all(|w| w[0] < w[1]),
+        "events must arrive in order: {ids:?}"
+    );
+}
+
+/// Without a provisioner the routes are simply absent — the console
+/// built the old way cannot create tenants at all.
+#[tokio::test]
+async fn the_routes_do_not_exist_without_a_provisioner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let app = rustango::tenancy::operator_console::router_with_pools(
+        pools.registry_pool(),
+        pools.clone(),
+        SessionSecret::from_env_or_random(),
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/orgs/new")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "provisioning must be opt-in"
+    );
+}


### PR DESCRIPTION
Closes #1322. **Stacked on #1327** → #1326 → #1325 → #1324.

## Before

The console could list, edit, re-brand and impersonate. It could not **create**. An operator who needed a new tenant needed shell access to a box holding registry credentials.

## Four routes

| route | |
|---|---|
| `GET`/`POST /orgs/new` | the create form |
| `POST /orgs/test-connection` | the probe — writes nothing, creates nothing |
| `GET /orgs/provision/{id}` | the run, and its audit trail afterwards |
| `GET /orgs/provision/{id}/stream` | SSE |

## The stream reads the table, not a channel

The obvious design is an in-process broadcast: provisioning pushes, the handler subscribes. It doesn't survive two pods — the operator's stream can land on a different pod from the one doing the work — and it doesn't survive a reload, because a broadcast has no history.

So it polls the run persisted by #1327. Unglamorous, and it's what makes a reconnect resume exactly where it left off. `Last-Event-ID` is the `seq` column; the page also passes `?after=` on its first connection so a reload doesn't re-render what's already on screen. The stream **terminates** on a terminal state instead of hanging open, with a 30-minute ceiling so an abandoned tab can't hold a poll loop forever.

This is the payoff for building #1321 first — the console needed no live observer at all.

## The two questions you flagged

**`async-stream` gating.** It was optional and reachable only through `mcp`, which has nothing to do with the console. The console ships with tenancy, so `dep:async-stream` moves to the `tenancy` feature. (The handler returns `impl IntoResponse` rather than naming `Sse<impl Stream<…>>`, so no `futures-core` dependency is needed just to spell a return type.)

**Authorization — and I did *not* fully do what the issue asked.** The issue wanted its own operator permission. `Operator` has no permission model at all: every authenticated operator can already do everything the console exposes. One flag for one route would be half a system and would imply a guarantee that isn't there.

What I did instead: provisioning mounts **only** through `router_with_provisioning`, a separate constructor a deployment opts into. That's the boundary that means something today — whether the console can create tenants at all — and it's documented as exactly that rather than dressed up as the per-operator permission the issue asked for. A real operator permission model deserves its own issue; say the word and I'll file it.

## Two things found on the way

**`Dialect` is now `Send + Sync`.** The migrate runner holds a `&'static dyn Dialect` across an await, so *any* future containing a migration was silently not `Send`. That's why provisioning couldn't go behind a `dyn` trait for the console. Every implementor is a unit struct, so the bound is free — this was an accidental limitation, not a design decision.

**Template errors no longer render as an empty 200.** The console's older handlers use `.unwrap_or_default()`, so a Tera failure produces a blank page with no clue anywhere. That cost real time here: a missing key in a `{% if %}` comparison rendered nothing and looked like a routing problem. The new handlers return a 500 naming the template and the full cause chain.

## Verification

**8 end-to-end tests through the real router:**
- the form renders, and hides schema-mode on a non-PG registry rather than offering a choice that can only fail
- both create routes refuse an unauthenticated request
- the probe reports, echoes the endpoint, **leaks no password**, and creates nothing
- a submission provisions and lands on its run, with the tenant live (activation last)
- a bad submission re-renders with the reason **and the operator's input intact**
- the stream replays a finished run and **ends**
- `?after=` resumes without replaying
- the routes **404 without a provisioner** — opt-in is real

Plus 7 unit tests on form parsing (blank-is-unset, the inverted `no_migrate` checkbox, non-numeric port, schema-mode-on-sqlite, escaping).

3643 lib tests; every stack suite; preflight 15/15 tri-dialect; `manage_live` 13/13 against live Postgres. Zero warnings across seven feature combos, `--all-features --tests`, `--workspace --no-run`, `fmt --check`, clippy clean on the new module.

Note this branch also carries the CI fix from #1326 (the dead-port tests hardcoded a local container port), merged forward through the stack.