### PR TITLE
feat(tenancy): create a tenant from an inbound webhook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,17 @@ jobs:
       - run: cargo test -p rustango --all-features --test mysql_live
       - run: cargo test -p rustango --features mysql --test explain_pool_mysql_live
       - run: cargo test -p rustango --features mysql --test bulk_upsert_mysql_live
+      # A second database for tenancy to provision *into*. The service
+      # grants `rustango` rights on `rustango_test` only, so the test
+      # cannot create this itself; and provisioning refuses a tenant
+      # pointed at the registry's own database, which is what the test
+      # used to do.
+      - name: Create the tenant database
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -uroot -prustango -e "
+            CREATE DATABASE IF NOT EXISTS rustango_tenant_test;
+            GRANT ALL PRIVILEGES ON rustango_tenant_test.* TO 'rustango'@'%';
+            FLUSH PRIVILEGES;"
       - run: cargo test -p rustango --features mysql,tenancy --test tenancy_manage_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test permissions_mysql_live
       - run: cargo test -p rustango --features mysql,tenancy,testkit --test database_pools_mysql_live

--- a/crates/rustango/src/lib.rs
+++ b/crates/rustango/src/lib.rs
@@ -698,7 +698,11 @@ pub mod secrets;
 
 /// HTTP access log middleware — one tracing event per request with
 /// method / path / status / duration / IP. See [`access_log::AccessLogLayer`].
-#[cfg(feature = "admin")]
+///
+/// Available to `tenancy` as well as `admin`: it is plain axum +
+/// tracing with no dependency on either, and the operator console needs
+/// request logging for the same reasons the admin does.
+#[cfg(any(feature = "admin", feature = "tenancy"))]
 pub mod access_log;
 
 /// Test fixture loader — seed a database from JSON files.

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -75,6 +75,10 @@ pub struct Cli {
     /// Default `false` because operators sometimes want their own
     /// health endpoint shape (custom JSON, additional checks).
     health_endpoints: bool,
+    /// Migrations dir handed to the operator console so it can
+    /// create tenants (#1322). `None` = the create routes are not
+    /// mounted. See `Cli::with_tenant_provisioning`.
+    provisioning_dir: Option<std::path::PathBuf>,
     /// `(prefix, root_dir)` pairs registered via [`Cli::with_static`].
     /// Mounted at `runserver` time as
     /// `Router::nest(prefix, static_router(StaticFiles::new(root_dir)))`.
@@ -124,6 +128,7 @@ impl Cli {
             #[cfg(feature = "config")]
             settings_for_layers: None,
             health_endpoints: false,
+            provisioning_dir: None,
             #[cfg(feature = "admin")]
             static_dirs: Vec::new(),
             #[cfg(feature = "csrf")]
@@ -210,6 +215,38 @@ impl Cli {
     #[must_use]
     pub fn with_health(mut self) -> Self {
         self.health_endpoints = true;
+        self
+    }
+
+    /// Let operators create tenants from the console (#1322) —
+    /// `/orgs/new`, the connection probe, and the provisioning run
+    /// view + live stream.
+    ///
+    /// `migrations_dir` is where a new tenant's migrations come from;
+    /// the same directory `migrate` uses, usually `"migrations"`.
+    ///
+    /// ```ignore
+    /// rustango::manage::Cli::new()
+    ///     .tenancy()
+    ///     .with_tenant_provisioning("migrations")
+    ///     .run()
+    ///     .await
+    /// ```
+    ///
+    /// **Off by default.** Creating a tenant is the most dangerous
+    /// thing the console can do — it takes a database URL and
+    /// connects to it — and every authenticated operator who can
+    /// reach the console can use these routes, because `Operator` has
+    /// no permission model. Turning it on is the deployment saying
+    /// yes to that.
+    ///
+    /// Tenancy mode only; ignored without `.tenancy()`.
+    #[must_use]
+    pub fn with_tenant_provisioning(
+        mut self,
+        migrations_dir: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        self.provisioning_dir = Some(migrations_dir.into());
         self
     }
 
@@ -938,6 +975,9 @@ impl Cli {
         if self.health_endpoints {
             builder = builder.with_health();
         }
+        if let Some(dir) = self.provisioning_dir.clone() {
+            builder = builder.with_tenant_provisioning(dir);
+        }
         for (prefix, root) in self.static_dirs {
             builder = builder.with_static(prefix, root);
         }
@@ -998,6 +1038,9 @@ impl Cli {
         .api(api);
         if self.health_endpoints {
             builder = builder.with_health();
+        }
+        if let Some(dir) = self.provisioning_dir.clone() {
+            builder = builder.with_tenant_provisioning(dir);
         }
         for (prefix, root) in self.static_dirs {
             builder = builder.with_static(prefix, root);

--- a/crates/rustango/src/server/builder.rs
+++ b/crates/rustango/src/server/builder.rs
@@ -52,6 +52,11 @@ pub struct Builder<DB: Database = DefaultTenantDb> {
     /// `/ready` `SELECT 1` probe). Set via [`Builder::with_health`]
     /// so projects with custom health JSON can opt out.
     health_endpoints: bool,
+    /// Migrations directory to hand a provisioner, set by
+    /// [`Builder::with_tenant_provisioning`]. `None` means the
+    /// operator console cannot create tenants — see that method for
+    /// why this is opt-in rather than on by default.
+    provisioning_dir: Option<std::path::PathBuf>,
     /// `(prefix, root_dir)` pairs registered via [`Builder::with_static`].
     /// Mounted at `serve` time as
     /// `Router::nest(prefix, static_router(StaticFiles::new(root_dir)))`
@@ -116,6 +121,7 @@ impl<DB: Database> Builder<DB> {
             init_tenancy_fn: crate::tenancy::init_tenancy,
             routes: crate::tenancy::RouteConfig::default(),
             health_endpoints: false,
+            provisioning_dir: None,
             static_dirs: Vec::new(),
             _phantom: PhantomData,
         }
@@ -133,6 +139,29 @@ impl<DB: Database> Builder<DB> {
     #[must_use]
     pub fn with_health(mut self) -> Self {
         self.health_endpoints = true;
+        self
+    }
+
+    /// Let operators **create** tenants from the console (#1322):
+    /// `GET`/`POST /orgs/new`, the connection probe, and the
+    /// provisioning run view + SSE stream.
+    ///
+    /// `migrations_dir` is where the new tenant's migrations come
+    /// from — the same directory `migrate` uses, usually
+    /// `"migrations"`.
+    ///
+    /// **Off by default, and deliberately.** Creating a tenant is the
+    /// most dangerous thing the console can do: it takes a database
+    /// URL and connects to it. Every authenticated operator who can
+    /// reach the console can use these routes, because `Operator` has
+    /// no permission model — so the meaningful boundary today is
+    /// whether the deployment turns this on at all.
+    #[must_use]
+    pub fn with_tenant_provisioning(
+        mut self,
+        migrations_dir: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        self.provisioning_dir = Some(migrations_dir.into());
         self
     }
 
@@ -354,7 +383,21 @@ impl<DB: Database> Builder<DB> {
     /// # Errors
     /// `bind` failure, or the underlying `axum::serve` call
     /// returning an error.
-    pub async fn serve(self, addr: &str) -> Result<(), Box<dyn std::error::Error>>
+    /// Assemble the whole application — operator console, tenant
+    /// admin, the user's API, host dispatch — and hand back the
+    /// router, without binding a socket.
+    ///
+    /// Split out of [`Self::serve`] so the assembly is *testable*.
+    /// It was not, and that cost: `with_tenant_provisioning` was
+    /// added, the console constructor existed, and nothing connected
+    /// them — invisible to every test, because the only way to
+    /// exercise this code was to start a real server. A builder whose
+    /// output can only be observed by binding a port is a builder
+    /// nobody checks.
+    ///
+    /// # Errors
+    /// Pre-warm and bootstrap failures surfaced during assembly.
+    pub async fn into_router(self) -> Result<Router, Box<dyn std::error::Error>>
     where
         crate::sql::Pool: From<sqlx::Pool<DB>>,
     {
@@ -506,12 +549,24 @@ impl<DB: Database> Builder<DB> {
         // admin redeems the token + sets a host-scoped cookie. No
         // cookie is set on the operator-console origin.
         let brand_storage_for_op = crate::tenancy::branding::default_brand_storage();
-        let operator_admin = operator_console::router_with_impersonation(
+        // #1322 — only when the deployment asked for it. See
+        // `with_tenant_provisioning` for why creating tenants is not
+        // on by default.
+        let provisioner = self.provisioning_dir.map(|dir| {
+            crate::tenancy::provision::Provisioner::new(
+                self.pools.clone(),
+                self.registry_url.clone(),
+                dir,
+            )
+            .erased()
+        });
+        let operator_admin = operator_console::router_full(
             self.registry,
-            self.pools.clone().into_invalidator(),
+            Some(self.pools.clone().into_invalidator()),
+            provisioner,
             operator_secret,
             brand_storage_for_op,
-            session_secret_for_tenant.clone(),
+            Some(session_secret_for_tenant.clone()),
             // Handoff URL on the tenant admin where the token
             // gets redeemed (#88). RouteConfig holds the canonical
             // value; default `/_impersonation_handoff`. After
@@ -549,6 +604,18 @@ impl<DB: Database> Builder<DB> {
             }
         }));
 
+        Ok(app)
+    }
+
+    /// Assemble everything and bind.
+    ///
+    /// # Errors
+    /// As [`Self::into_router`], plus a bind failure on `addr`.
+    pub async fn serve(self, addr: &str) -> Result<(), Box<dyn std::error::Error>>
+    where
+        crate::sql::Pool: From<sqlx::Pool<DB>>,
+    {
+        let app = self.into_router().await?;
         let listener = tokio::net::TcpListener::bind(addr).await?;
         // v0.30.16 — `into_make_service_with_connect_info` is what
         // populates `ConnectInfo<SocketAddr>` in request extensions.

--- a/crates/rustango/src/template_views.rs
+++ b/crates/rustango/src/template_views.rs
@@ -656,6 +656,52 @@ fn mount_path(prefix: &str, suffix: &str) -> String {
     format!("{}{}", prefix.trim_end_matches('/'), suffix)
 }
 
+/// The elided page range for a pager, as template-friendly values.
+///
+/// `{"number": n}` or `{"ellipsis": true}` per entry — Tera has no enum
+/// matching, so the shape carries the discriminant as a key.
+fn page_marks(total: i64, page_size: i64, page: i64) -> Vec<serde_json::Value> {
+    let count = usize::try_from(total).unwrap_or(0);
+    let per_page = usize::try_from(page_size).unwrap_or(1).max(1);
+    let paginator = crate::pagination::Paginator::new(count, per_page);
+    let number = usize::try_from(page).unwrap_or(1);
+    paginator
+        .get_elided_page_range(number, 3, 2)
+        .into_iter()
+        .map(|mark| match mark {
+            crate::pagination::PageMark::Number(n) => serde_json::json!({"number": n}),
+            crate::pagination::PageMark::Ellipsis => serde_json::json!({"ellipsis": true}),
+        })
+        .collect()
+}
+
+/// Extra template context, supplied per request through an axum
+/// `Extension`.
+///
+/// A generic view builds its own `Context` from the model, which is
+/// everything a standalone page needs and nothing an app with a shared
+/// base template does: `{% extends "base.html" %}` fails the moment
+/// that layout reads a variable the view never inserts. Middleware puts
+/// one of these on the request — the signed-in user, branding, the
+/// active nav section — and every view here merges it.
+///
+/// Per request rather than a builder argument because the useful
+/// values are per request: who is signed in is not known when the
+/// router is assembled. View-owned keys win on collision, so a stray
+/// `object_list` cannot replace the rows.
+#[derive(Clone, Default)]
+pub struct ExtraContext(pub Context);
+
+impl ExtraContext {
+    /// Merge into `ctx` without letting it clobber what the view set.
+    fn merge_into(parts: Option<&Self>, ctx: &mut Context) {
+        let Some(extra) = parts else { return };
+        let mut merged = extra.0.clone();
+        merged.extend(ctx.clone());
+        *ctx = merged;
+    }
+}
+
 #[derive(Clone)]
 struct ListViewState {
     vs: ListView,
@@ -666,6 +712,7 @@ struct ListViewState {
 async fn handle_list(
     State(state): State<Arc<ListViewState>>,
     headers: axum::http::HeaderMap,
+    extra: Option<axum::Extension<ExtraContext>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {
     let page: i64 = params
@@ -728,6 +775,10 @@ async fn handle_list(
 
     let total_pages = ((total - 1).max(0) / page_size) + 1;
     let mut ctx = Context::new();
+    // `1 … 7 8 9 … 42` rather than one link per page, from the
+    // framework's own paginator. The scalar keys above predate it and
+    // stay as they are; this only adds the range.
+    ctx.insert("page_marks", &page_marks(total, page_size, page));
     ctx.insert("object_list", &object_list);
     // #379 — Django-shape `context_object_name`. Adds a second
     // binding so templates can read `{{ posts }}` instead of
@@ -747,6 +798,7 @@ async fn handle_list(
     insert_filter_context(&mut ctx, &state.vs.filter_fields, &params);
     insert_pagination_urls(&mut ctx, page, has_next, has_prev, &params);
     insert_bulk_actions_context(&mut ctx, &state.vs);
+    ExtraContext::merge_into(extra.as_ref().map(|e| &e.0), &mut ctx);
 
     // v0.30.17 — stamp the CSRF token into the context AND set the
     // cookie on the response. ListView's bulk-action POST is gated

--- a/crates/rustango/src/tenancy/decommission.rs
+++ b/crates/rustango/src/tenancy/decommission.rs
@@ -1,0 +1,255 @@
+//! Taking a tenant out of service, soft or hard.
+//!
+//! These steps lived inside `drop-tenant` and `purge-tenant`, welded to
+//! a CLI by a `pub(super)` visibility, an `args: &[String]` they parsed
+//! themselves, and a `W: Write` they reported through — the same shape
+//! `provision.rs` was in before it was extracted. Anything that is not
+//! a terminal had to fake an `argv`.
+//!
+//! ## Soft and hard are different operations, not a flag
+//!
+//! [`Action::Deactivate`] flips `active` and preserves everything. The
+//! resolver already filters on that column, so the tenant stops serving
+//! immediately and can be brought back.
+//!
+//! [`Action::Purge`] destroys the storage and deletes the row. It is
+//! unrecoverable, and `purge_database` has to be passed explicitly for
+//! a database-mode tenant: dropping a whole database is a bigger act
+//! than dropping a schema, and the caller should have to say so.
+
+use sqlx::Database;
+
+use super::error::TenancyError;
+use super::org::{Org, StorageMode};
+use super::pools::TenantPools;
+use crate::core::Column as _;
+use crate::sql::{FetcherPool as _, UpdaterPool as _};
+
+/// What to do to the tenant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// `active = false`. Reversible; nothing is destroyed.
+    Deactivate,
+    /// Drop the storage and the registry row. Unrecoverable.
+    Purge {
+        /// Required for a database-mode tenant, where purging means
+        /// `DROP DATABASE` rather than `DROP SCHEMA`.
+        purge_database: bool,
+    },
+}
+
+/// What happened, for a caller to render.
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    pub slug: String,
+    /// Already inactive, so a deactivate changed nothing.
+    pub no_change: bool,
+    pub deactivated: bool,
+    pub schema_dropped: Option<String>,
+    pub database_dropped: Option<String>,
+    pub row_deleted: bool,
+    /// Anything the operator still has to do by hand.
+    pub notes: Vec<String>,
+}
+
+/// Take `slug` out of service.
+///
+/// Confirmation is the caller's job — a CLI prompt, a typed slug in a
+/// form. By the time this is called the decision is made.
+///
+/// # Errors
+/// No such tenant, a schema-mode tenant on a non-Postgres registry, a
+/// database-mode purge without `purge_database`, or a driver failure.
+pub async fn decommission<DB: Database>(
+    pools: &TenantPools<DB>,
+    slug: &str,
+    action: Action,
+) -> Result<Report, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let registry = pools.registry_pool();
+    let rows: Vec<Org> = Org::objects()
+        .where_(Org::slug.eq(slug.to_owned()))
+        .fetch(&registry)
+        .await?;
+    let org = rows
+        .into_iter()
+        .next()
+        .ok_or_else(|| TenancyError::Validation(format!("no tenant with slug `{slug}`")))?;
+
+    let mut report = Report {
+        slug: slug.to_owned(),
+        ..Report::default()
+    };
+
+    match action {
+        Action::Deactivate => {
+            if !org.active {
+                report.no_change = true;
+                return Ok(report);
+            }
+            let id = org
+                .id
+                .get()
+                .copied()
+                .ok_or_else(|| TenancyError::Validation("Org row has no PK".into()))?;
+            let updated = Org::objects()
+                .where_(Org::id.eq(id))
+                .update()
+                .set("active", false)
+                .execute_pool(&registry)
+                .await?;
+            if updated == 0 {
+                return Err(TenancyError::Validation(format!(
+                    "no row updated for id {id} — race condition?"
+                )));
+            }
+            super::invalidate_org_cache();
+            report.deactivated = true;
+        }
+        Action::Purge { purge_database } => {
+            purge(pools, &registry, &org, purge_database, &mut report).await?;
+        }
+    }
+    Ok(report)
+}
+
+async fn purge<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry: &crate::sql::Pool,
+    org: &Org,
+    purge_database: bool,
+    report: &mut Report,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let slug = &org.slug;
+    let mode = StorageMode::parse(&org.storage_mode)
+        .map_err(|e| TenancyError::Validation(e.to_owned()))?;
+    match mode {
+        StorageMode::Schema => {
+            let schema = org.schema_name.clone().unwrap_or_else(|| slug.clone());
+            // Quoted: the name is an identifier, and validation only
+            // started covering it recently — older rows may hold
+            // anything.
+            let sql = format!(
+                "DROP SCHEMA IF EXISTS {} CASCADE",
+                registry.dialect().quote_ident(&schema)
+            );
+            crate::sql::raw_execute_pool(registry, &sql, Vec::new()).await?;
+            report.schema_dropped = Some(schema);
+        }
+        StorageMode::Database => {
+            if !purge_database {
+                return Err(TenancyError::Validation(format!(
+                    "tenant `{slug}` is database-mode — dropping its database is \
+                     unrecoverable. Ask for the database to be purged explicitly, or \
+                     deactivate instead."
+                )));
+            }
+            let url = pools.resolved_database_url(org).await?;
+            pools.invalidate(slug).await;
+            if org.backend_kind == "postgres" {
+                #[cfg(feature = "postgres")]
+                {
+                    drop_database_at(&url).await?;
+                    report.database_dropped = Some(crate::sql::connect_diagnosis::redact(&url));
+                }
+                #[cfg(not(feature = "postgres"))]
+                report.notes.push(format!(
+                    "the tenant database at {} was left in place — this build has no \
+                     `postgres` feature",
+                    crate::sql::connect_diagnosis::redact(&url)
+                ));
+            } else {
+                report.notes.push(format!(
+                    "delete the tenant database at {} by hand — dropping a `{}` database \
+                     is not wired up",
+                    crate::sql::connect_diagnosis::redact(&url),
+                    org.backend_kind
+                ));
+            }
+        }
+    }
+
+    let id = org
+        .id
+        .get()
+        .copied()
+        .ok_or_else(|| TenancyError::Validation("Org row has no PK".into()))?;
+    let deleted = org.clone().delete_pool(registry).await?;
+    if deleted == 0 {
+        return Err(TenancyError::Validation(format!(
+            "no Org row deleted for id {id} — race condition?"
+        )));
+    }
+    super::invalidate_org_cache();
+    report.row_deleted = true;
+    Ok(())
+}
+
+/// `DROP DATABASE` through an admin connection on the same server.
+#[cfg(feature = "postgres")]
+async fn drop_database_at(tenant_url: &str) -> Result<(), TenancyError> {
+    use crate::sql::sqlx::postgres::PgConnectOptions;
+    use crate::sql::sqlx::ConnectOptions;
+    use std::str::FromStr;
+
+    let opts = PgConnectOptions::from_str(tenant_url).map_err(|e| {
+        TenancyError::Validation(format!(
+            "cannot parse the tenant's database URL: {e} ({})",
+            crate::sql::connect_diagnosis::redact(tenant_url)
+        ))
+    })?;
+    let dbname = opts.get_database().ok_or_else(|| {
+        TenancyError::Validation(
+            "the tenant's database URL names no database — nothing to drop".into(),
+        )
+    })?;
+    if matches!(
+        dbname.to_ascii_lowercase().as_str(),
+        "postgres" | "template0" | "template1"
+    ) {
+        return Err(TenancyError::Validation(format!(
+            "refusing to drop `{dbname}` — that is a Postgres system database"
+        )));
+    }
+    let dbname = dbname.to_owned();
+    // `DROP DATABASE` cannot run from inside the database being
+    // dropped, so this connects to `postgres` on the same server.
+    let mut admin = opts.clone().database("postgres").connect().await?;
+    // Postgres by construction — the caller checks `backend_kind`.
+    let sql = format!(
+        "DROP DATABASE IF EXISTS \"{}\"",
+        dbname.replace('"', "\"\"")
+    );
+    crate::sql::sqlx::query(&sql).execute(&mut admin).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag is the whole guard for an unrecoverable act, so the two
+    /// purge shapes must not compare equal.
+    #[test]
+    fn purging_a_database_is_a_distinct_action() {
+        assert_ne!(
+            Action::Purge {
+                purge_database: false
+            },
+            Action::Purge {
+                purge_database: true
+            }
+        );
+        assert_ne!(
+            Action::Deactivate,
+            Action::Purge {
+                purge_database: false
+            }
+        );
+    }
+}

--- a/crates/rustango/src/tenancy/manage/audit.rs
+++ b/crates/rustango/src/tenancy/manage/audit.rs
@@ -1,5 +1,10 @@
 //! `audit-cleanup` management verb — runs audit-log retention across
-//! every active tenant (or a single named tenant with `--tenant`).
+//! the registry's own log and every active tenant's.
+//!
+//! The registry keeps an audit log too: every operator action the
+//! console records — tenant edits, hostname changes, operator
+//! management, purges. This verb only ever walked tenants, so nothing
+//! trimmed it and it grew with console use.
 //!
 //! Two retention modes, mutually exclusive:
 //!
@@ -25,6 +30,25 @@ use crate::tenancy::Org;
 
 use super::args::next_value;
 
+/// Whichever retention mode was asked for, against one pool.
+///
+/// The two `cleanup_*_pool` helpers are already tri-dialect; this only
+/// picks between them so the registry and each tenant cannot drift.
+async fn prune(
+    pool: &crate::sql::Pool,
+    days: Option<i64>,
+    keep_last: Option<i64>,
+) -> Result<u64, TenancyError> {
+    if let Some(n) = days {
+        Ok(crate::audit::cleanup_older_than_pool(pool, n).await?)
+    } else if let Some(n) = keep_last {
+        Ok(crate::audit::cleanup_keep_last_n_pool(pool, n).await?)
+    } else {
+        // The caller rejects "neither" before reaching here.
+        Ok(0)
+    }
+}
+
 pub(super) async fn audit_cleanup_cmd<W: Write + Send, DB: Database>(
     pools: &TenantPools<DB>,
     args: &[String],
@@ -36,6 +60,7 @@ where
     let mut days: Option<i64> = None;
     let mut keep_last: Option<i64> = None;
     let mut tenant_slug: Option<String> = None;
+    let mut registry_only = false;
 
     let mut iter = args.iter();
     while let Some(flag) = iter.next() {
@@ -55,6 +80,7 @@ where
             "--tenant" => {
                 tenant_slug = Some(next_value(&mut iter, "--tenant")?);
             }
+            "--registry" => registry_only = true,
             "--help" | "-h" => {
                 write_verb_help(w)?;
                 return Ok(());
@@ -81,50 +107,72 @@ where
         _ => {}
     }
 
+    if registry_only && tenant_slug.is_some() {
+        return Err(TenancyError::Validation(
+            "--registry and --tenant name different logs — pass one".into(),
+        ));
+    }
+
     let registry = pools.registry_pool();
-    let orgs: Vec<Org> = if let Some(ref slug) = tenant_slug {
+    let mut total_deleted: u64 = 0;
+    let mut swept = 0usize;
+    let mut failed = 0usize;
+
+    // The registry keeps an audit log of its own — every operator
+    // action the console records — and this verb only ever walked
+    // tenants, so nothing trimmed it. Swept unless a single tenant was
+    // named, which asks for that tenant and nothing else.
+    if tenant_slug.is_none() {
+        let deleted = prune(&registry, days, keep_last).await?;
+        writeln!(w, "  registry deleted={deleted}")?;
+        total_deleted += deleted;
+    }
+
+    if let Some(ref slug) = tenant_slug {
         let found: Vec<Org> = Org::objects()
             .where_(Org::slug.eq(slug.as_str()))
             .fetch(&registry)
             .await?;
-        if found.is_empty() {
-            return Err(TenancyError::Validation(format!(
-                "tenant `{slug}` not found"
-            )));
-        }
-        found
-    } else {
-        Org::objects()
-            .where_(Org::active.eq(true))
-            .fetch(&registry)
-            .await?
-    };
-
-    let total_orgs = orgs.len();
-    let mut total_deleted: u64 = 0;
-
-    for org in &orgs {
-        // v0.38 — route through scoped_pool_dyn which yields a
-        // backend-agnostic `crate::sql::Pool` enum: on PG schema-mode
-        // it builds a dedicated pool with `search_path` baked in;
-        // database-mode (any backend) just wraps the cached pool.
-        let scoped = pools.scoped_pool_dyn(org).await?;
-
-        let deleted = if let Some(n) = days {
-            crate::audit::cleanup_older_than_pool(&scoped, n).await?
-        } else if let Some(n) = keep_last {
-            crate::audit::cleanup_keep_last_n_pool(&scoped, n).await?
-        } else {
-            unreachable!()
-        };
-
-        writeln!(w, "  tenant={} deleted={}", org.slug, deleted)?;
+        let org = found
+            .into_iter()
+            .next()
+            .ok_or_else(|| TenancyError::Validation(format!("tenant `{slug}` not found")))?;
+        // One named tenant: a failure is the answer to what was asked,
+        // so it propagates rather than being collected.
+        let scoped = pools.scoped_pool_dyn(&org).await?;
+        let deleted = prune(&scoped, days, keep_last).await?;
+        writeln!(w, "  tenant={slug} deleted={deleted}")?;
         total_deleted += deleted;
+        swept = 1;
+    } else if !registry_only {
+        // `for_each_tenant` resolves each pool the right way per storage
+        // mode and — the reason for using it here — collects outcomes
+        // instead of aborting. A single tenant whose schema is missing
+        // used to end the sweep with a raw SQL error, leaving every
+        // later tenant untrimmed.
+        let sweep = super::super::sweep::for_each_tenant(pools, |_org, pool| async move {
+            prune(&pool, days, keep_last).await
+        })
+        .await?;
+
+        for outcome in &sweep.outcomes {
+            match &outcome.result {
+                Ok(deleted) => {
+                    writeln!(w, "  tenant={} deleted={}", outcome.slug, deleted)?;
+                    total_deleted += *deleted;
+                    swept += 1;
+                }
+                Err(e) => {
+                    writeln!(w, "  tenant={} FAILED: {e}", outcome.slug)?;
+                    failed += 1;
+                }
+            }
+        }
     }
 
     writeln!(
         w,
-        "audit-cleanup done: tenants={total_orgs} total_deleted={total_deleted}"
+        "audit-cleanup done: tenants={swept} failed={failed} total_deleted={total_deleted}"
     )?;
     Ok(())
 }
@@ -132,7 +180,7 @@ where
 fn write_verb_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
     writeln!(
         w,
-        "audit-cleanup — remove old entries from each tenant's audit log"
+        "audit-cleanup — remove old entries from the registry's audit log and each tenant's"
     )?;
     writeln!(w)?;
     writeln!(w, "USAGE:")?;
@@ -148,8 +196,9 @@ fn write_verb_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
     writeln!(w, "OPTIONS:")?;
     writeln!(
         w,
-        "  --tenant <slug>   scope to one tenant (default: every active tenant)"
+        "  --tenant <slug>   that tenant's log only (default: the registry and every active tenant)"
     )?;
+    writeln!(w, "  --registry        the registry's own log only")?;
     writeln!(w)?;
     writeln!(w, "EXAMPLES:")?;
     writeln!(w, "  cargo run -- audit-cleanup --days 90")?;

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -612,7 +612,7 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
     writeln!(w, "AUDIT:")?;
     writeln!(
         w,
-        "  audit-cleanup --days <N>     Delete entries older than N days (all active tenants)."
+        "  audit-cleanup --days <N>     Delete entries older than N days (registry + all active tenants)."
     )?;
     writeln!(
         w,

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -8,11 +8,9 @@ use std::path::Path;
 use sqlx::Database;
 
 use crate::core::Column as _;
-use crate::sql::{FetcherPool, UpdaterPool};
+use crate::sql::FetcherPool;
 
 use crate::tenancy::error::TenancyError;
-#[cfg(feature = "postgres")]
-use crate::tenancy::manage::args::quote_ident;
 use crate::tenancy::manage::args::{next_value, reject_leading_flag};
 use crate::tenancy::manage_interactive;
 use crate::tenancy::org::{BackendKind, Org, StorageMode};
@@ -336,46 +334,20 @@ where
         )));
     }
 
-    let registry = pools.registry_pool();
-    let existing: Vec<Org> = Org::objects()
-        .where_(Org::slug.eq(slug.clone()))
-        .fetch(&registry)
-        .await?;
-    let Some(org) = existing.into_iter().next() else {
-        return Err(TenancyError::Validation(format!(
-            "drop-tenant: no tenant with slug `{slug}`"
-        )));
-    };
-    if !org.active {
+    // The steps live in `tenancy::decommission` so the console runs
+    // exactly these; this verb keeps what is a CLI's job — argv, the
+    // confirmation prompt, and rendering.
+    let report = super::super::decommission::decommission(
+        pools,
+        &slug,
+        super::super::decommission::Action::Deactivate,
+    )
+    .await
+    .map_err(|e| TenancyError::Validation(format!("drop-tenant: {e}")))?;
+    if report.no_change {
         writeln!(w, "tenant `{slug}` already inactive — no change")?;
         return Ok(());
     }
-
-    // Soft-delete: UPDATE rustango_orgs SET active = false WHERE id = $1.
-    let id = org
-        .id
-        .get()
-        .copied()
-        .ok_or_else(|| TenancyError::Validation("dropped Org row has no PK".into()))?;
-    let updated = Org::objects()
-        .where_(Org::id.eq(id))
-        .update()
-        .set("active", false)
-        .execute_pool(&registry)
-        .await?;
-    if updated == 0 {
-        return Err(TenancyError::Validation(format!(
-            "drop-tenant: no row updated for id {id} — race condition?"
-        )));
-    }
-    // Only once the write is confirmed. Invalidating before the guard
-    // would throw away a healthy cache on a no-op, and the suspension
-    // it is clearing would not have happened.
-    //
-    // Clears the extra-hostname cache as well — that one holds `Org`
-    // rows too, so without it a suspended tenant's base host 404s while
-    // its extra hosts keep serving.
-    super::super::invalidate_org_cache();
     writeln!(
         w,
         "soft-deleted tenant `{slug}` (active=false). Data preserved."
@@ -470,6 +442,13 @@ where
         )));
     }
 
+    // Everything destructive lives in `tenancy::decommission` so the
+    // console runs exactly these steps. This verb keeps argv, the
+    // confirmation prompt, and rendering.
+    //
+    // The flag check is here rather than there because `--purge-database`
+    // is this CLI's vocabulary; the engine enforces the same rule in its
+    // own words for every other caller.
     let registry = pools.registry_pool();
     let existing: Vec<Org> = Org::objects()
         .where_(Org::slug.eq(slug.clone()))
@@ -480,154 +459,37 @@ where
             "purge-tenant: no tenant with slug `{slug}`"
         )));
     };
-
     let mode = StorageMode::parse(&org.storage_mode).map_err(|got| {
         TenancyError::Validation(format!("org `{slug}` has unknown storage_mode `{got}`"))
     })?;
-
-    match mode {
-        StorageMode::Schema => {
-            // Schema mode is PG-only by language. Downcast to grab
-            // the typed `pools.registry()` PgPool accessor.
-            #[cfg(feature = "postgres")]
-            {
-                let pg_pools = (pools as &dyn std::any::Any)
-                    .downcast_ref::<TenantPools<sqlx::Postgres>>()
-                    .ok_or_else(|| {
-                        TenancyError::Validation(
-                            "purge-tenant: schema-mode tenants require a Postgres registry".into(),
-                        )
-                    })?;
-                let schema = org.schema_name.clone().unwrap_or_else(|| slug.clone());
-                let sql = format!("DROP SCHEMA IF EXISTS {} CASCADE", quote_ident(&schema));
-                rustango::sql::sqlx::query(&sql)
-                    .execute(pg_pools.registry())
-                    .await?;
-                writeln!(w, "purged tenant `{slug}` (dropped schema `{schema}`)")?;
-            }
-            #[cfg(not(feature = "postgres"))]
-            {
-                return Err(TenancyError::Validation(
-                    "purge-tenant: schema-mode tenants require the `postgres` feature".into(),
-                ));
-            }
-        }
-        StorageMode::Database => {
-            if !purge_database {
-                return Err(TenancyError::Validation(format!(
-                    "tenant `{slug}` is database-mode — `DROP DATABASE` is unrecoverable. \
-                     Pass `--purge-database` to confirm you want the DB dropped, or use \
-                     `drop-tenant` for soft-delete."
-                )));
-            }
-            // Resolve the URL through the secrets resolver so vault-
-            // backed orgs purge correctly. Then close & drop the
-            // cached pool — DROP DATABASE refuses while connections
-            // are open.
-            let url = pools.resolved_database_url(&org).await?;
-            pools.invalidate(&slug).await;
-            // #560 — branch on the tenant's runtime `backend_kind`,
-            // NOT the cargo feature flag. On a mixed-feature build
-            // (PG + MySQL compiled in), the `cfg(postgres)` arm was
-            // unconditionally taken regardless of the tenant's
-            // actual backend; parsing a `mysql://` URL via
-            // `PgConnectOptions::from_str` then failed at runtime
-            // with a cryptic "invalid URL" error.
-            //
-            // The PG helper stays gated on the `postgres` feature
-            // (`PgConnectOptions` isn't available without it); the
-            // runtime branch decides whether the helper is reachable
-            // for THIS tenant.
-            let is_pg = org.backend_kind == "postgres";
-            #[cfg(feature = "postgres")]
-            let pg_drop_attempted = if is_pg {
-                drop_database_at(&url, w).await?;
-                true
-            } else {
-                false
-            };
-            #[cfg(not(feature = "postgres"))]
-            let pg_drop_attempted = {
-                let _ = is_pg;
-                false
-            };
-            if !pg_drop_attempted {
-                writeln!(
-                    w,
-                    "  purged tenant `{slug}` registry row; manually delete the \
-                     tenant database at `{url}` (DROP DATABASE not wired for \
-                     `{backend}` in v0.42)",
-                    backend = org.backend_kind,
-                )?;
-            }
-            writeln!(w, "purged tenant `{slug}` (dropped dedicated database)")?;
-        }
-    }
-
-    // DELETE the Org row via the ORM's bi-dialect `delete_pool`.
-    let id = org
-        .id
-        .get()
-        .copied()
-        .ok_or_else(|| TenancyError::Validation("purge-tenant: Org row has no PK".into()))?;
-    let rows_deleted = org.delete_pool(&registry).await?;
-    if rows_deleted == 0 {
+    if mode == StorageMode::Database && !purge_database {
         return Err(TenancyError::Validation(format!(
-            "purge-tenant: no Org row deleted for id {id} — race condition?"
+            "tenant `{slug}` is database-mode — `DROP DATABASE` is unrecoverable. \
+             Pass `--purge-database` to confirm you want the DB dropped, or use \
+             `drop-tenant` for soft-delete."
         )));
     }
-    // The schema or database is already gone by this point, so a cached
-    // resolution would route requests at storage that no longer exists —
-    // a 500 where the tenant should simply be unknown.
-    super::super::invalidate_org_cache();
-    writeln!(w, "  removed Org row (id {id})")?;
-    Ok(())
-}
 
-/// Connect to the same Postgres server as `tenant_url` but switch to
-/// the `postgres` admin database (DROP DATABASE can't run from a
-/// connection to the database being dropped). Issue the DROP, then
-/// close the admin connection.
-///
-/// v0.38 — PG-only. SQLite databases live in a single file (delete
-/// the file); MySQL has `DROP DATABASE` but the per-tenant URL
-/// rewrite gymnastics are different enough that lifting this helper
-/// to be tri-dialect is queued separately.
-#[cfg(feature = "postgres")]
-async fn drop_database_at<W: Write + Send>(
-    tenant_url: &str,
-    w: &mut W,
-) -> Result<(), TenancyError> {
-    use crate::sql::sqlx::postgres::PgConnectOptions;
-    use crate::sql::sqlx::ConnectOptions;
-    use std::str::FromStr;
+    let report = super::super::decommission::decommission(
+        pools,
+        &slug,
+        super::super::decommission::Action::Purge { purge_database },
+    )
+    .await
+    .map_err(|e| TenancyError::Validation(format!("purge-tenant: {e}")))?;
 
-    let opts = PgConnectOptions::from_str(tenant_url).map_err(|e| {
-        TenancyError::Validation(format!(
-            "purge-tenant: cannot parse database_url `{tenant_url}`: {e}"
-        ))
-    })?;
-    let dbname = opts.get_database().ok_or_else(|| {
-        TenancyError::Validation(
-            "purge-tenant: database_url is missing the database name — \
-             can't determine what to DROP DATABASE"
-                .into(),
-        )
-    })?;
-    if dbname.eq_ignore_ascii_case("postgres")
-        || dbname.eq_ignore_ascii_case("template0")
-        || dbname.eq_ignore_ascii_case("template1")
-    {
-        return Err(TenancyError::Validation(format!(
-            "purge-tenant: refusing to DROP DATABASE `{dbname}` (Postgres system database)"
-        )));
+    if let Some(schema) = &report.schema_dropped {
+        writeln!(w, "purged tenant `{slug}` (dropped schema `{schema}`)")?;
     }
-    let dbname = dbname.to_owned();
-    let admin_opts = opts.clone().database("postgres");
-    let mut admin = admin_opts.connect().await?;
-    let sql = format!("DROP DATABASE IF EXISTS {}", quote_ident(&dbname));
-    writeln!(w, "  issuing {sql}")?;
-    rustango::sql::sqlx::query(&sql).execute(&mut admin).await?;
+    if report.database_dropped.is_some() {
+        writeln!(w, "purged tenant `{slug}` (dropped dedicated database)")?;
+    }
+    for note in &report.notes {
+        writeln!(w, "  {note}")?;
+    }
+    if report.row_deleted {
+        writeln!(w, "  removed Org row")?;
+    }
     Ok(())
 }
 

--- a/crates/rustango/src/tenancy/migrate_run.rs
+++ b/crates/rustango/src/tenancy/migrate_run.rs
@@ -1,0 +1,210 @@
+//! Running tenant migrations against a recorded, streamable run.
+//!
+//! The migrate seams report through a synchronous observer called
+//! inside the migrate lock, so it cannot await a write. Provisioning
+//! solved that by buffering and flushing at the end, which is fine for
+//! a run measured in seconds and useless for a batch across hundreds of
+//! tenants — nobody watching would see anything until it finished.
+//!
+//! Here the observer sends down a channel and a task drains it, so
+//! events land while the migration is still going and the run's SSE
+//! stream shows them.
+
+use std::path::Path;
+
+use sqlx::Database;
+
+use super::error::TenancyError;
+use super::migrate::{self as tenant_migrate, TenantMigrationEvent};
+use super::org::Org;
+use super::pools::TenantPools;
+use super::provision_store::{self as store, RunState};
+use crate::core::Column as _;
+use crate::sql::FetcherPool as _;
+
+/// One event, flattened for the run's event table.
+struct Row {
+    step: String,
+    status: String,
+    message: String,
+}
+
+fn flatten(event: &TenantMigrationEvent) -> Row {
+    match event {
+        TenantMigrationEvent::Planned { tenants } => Row {
+            step: "plan".into(),
+            status: "info".into(),
+            message: format!("{tenants} tenant(s) to migrate"),
+        },
+        TenantMigrationEvent::TenantStarted { slug, index, total } => Row {
+            step: "tenant".into(),
+            status: "started".into(),
+            message: format!("{slug} ({index}/{total})"),
+        },
+        TenantMigrationEvent::Migration { slug, chain, event } => Row {
+            step: "migration".into(),
+            status: "info".into(),
+            message: format!("{slug} {}: {}", chain_name(*chain), describe(event)),
+        },
+        TenantMigrationEvent::TenantFinished {
+            slug,
+            applied,
+            error,
+            ..
+        } => error.as_ref().map_or_else(
+            || Row {
+                step: "tenant".into(),
+                status: "ok".into(),
+                message: format!("{slug}: {applied} applied"),
+            },
+            |e| Row {
+                step: "tenant".into(),
+                status: "failed".into(),
+                message: format!("{slug}: {e}"),
+            },
+        ),
+    }
+}
+
+const fn chain_name(chain: tenant_migrate::Chain) -> &'static str {
+    match chain {
+        tenant_migrate::Chain::System => "system",
+        tenant_migrate::Chain::Project => "app",
+    }
+}
+
+fn describe(event: &crate::migrate::MigrationEvent) -> String {
+    use crate::migrate::MigrationEvent as E;
+    match event {
+        E::Planned { total } => format!("{total} pending"),
+        E::Started { name, .. } => format!("{name} started"),
+        E::Finished { name, outcome, .. } => format!("applied {name} ({outcome:?})"),
+        E::Failed { name, error, .. } => format!("{name} failed: {error}"),
+    }
+}
+
+/// Migrate one tenant, or every active one, recording into `run_id`.
+///
+/// `slug` picks a single tenant; `None` migrates the active batch.
+/// Errors are recorded on the run and returned — the caller is usually
+/// a spawned task with nowhere to report them.
+///
+/// # Errors
+/// An unreachable tenant database, a failing migration, or a storage
+/// mode this build cannot serve.
+pub async fn migrate_in_run<DB: Database>(
+    pools: &TenantPools<DB>,
+    dir: &Path,
+    registry_url: &str,
+    run_id: i64,
+    slug: Option<&str>,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let registry = pools.registry_pool();
+
+    // The observer is synchronous and runs inside the migrate lock, so
+    // it hands events off rather than writing them.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Row>();
+    let writer_registry = registry.clone();
+    let writer = tokio::spawn(async move {
+        let mut seq = 1i64;
+        while let Some(row) = rx.recv().await {
+            if let Err(e) = store::append_event(
+                &writer_registry,
+                run_id,
+                seq,
+                &row.step,
+                &row.status,
+                &row.message,
+            )
+            .await
+            {
+                tracing::warn!(
+                    target: "rustango::tenancy::migrate_run",
+                    run_id, error = %e,
+                    "could not record a migration event; the run continues"
+                );
+            }
+            seq += 1;
+        }
+    });
+
+    let observer = move |event: TenantMigrationEvent| {
+        // A closed receiver means the writer died; the migration is
+        // still worth finishing.
+        let _ = tx.send(flatten(&event));
+    };
+
+    let result = match slug {
+        Some(slug) => migrate_one(pools, &registry, dir, registry_url, slug, &observer).await,
+        None => tenant_migrate::migrate_tenants_dyn_with_progress(
+            pools,
+            dir,
+            registry_url,
+            Some(&observer),
+        )
+        .await
+        .map(|_| ()),
+    };
+
+    // Dropping the observer closes the channel, which ends the writer.
+    drop(observer);
+    let _ = writer.await;
+
+    let state = if result.is_ok() {
+        RunState::Succeeded
+    } else {
+        RunState::Failed
+    };
+    let error = result.as_ref().err().map(ToString::to_string);
+    if let Err(e) = store::finish_run(&registry, run_id, state, error.as_deref()).await {
+        tracing::warn!(
+            target: "rustango::tenancy::migrate_run",
+            run_id, error = %e,
+            "could not close the run"
+        );
+    }
+    result
+}
+
+async fn migrate_one<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry: &crate::sql::Pool,
+    dir: &Path,
+    registry_url: &str,
+    slug: &str,
+    observer: &dyn tenant_migrate::TenantMigrationObserver,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let rows: Vec<Org> = Org::objects()
+        .where_(Org::slug.eq(slug.to_owned()))
+        .fetch(registry)
+        .await?;
+    let org = rows
+        .into_iter()
+        .next()
+        .ok_or_else(|| TenancyError::Validation(format!("no tenant `{slug}`")))?;
+
+    // The batch seam frames each tenant; a single run should read the
+    // same way rather than starting mid-narrative.
+    observer.on_event(TenantMigrationEvent::Planned { tenants: 1 });
+    observer.on_event(TenantMigrationEvent::TenantStarted {
+        slug: org.slug.clone(),
+        index: 1,
+        total: 1,
+    });
+    let applied =
+        tenant_migrate::migrate_one_tenant(pools, &org, dir, registry_url, Some(observer)).await;
+    observer.on_event(TenantMigrationEvent::TenantFinished {
+        slug: org.slug.clone(),
+        index: 1,
+        total: 1,
+        applied: applied.as_ref().map(Vec::len).unwrap_or(0),
+        error: applied.as_ref().err().map(ToString::to_string),
+    });
+    applied.map(|_| ())
+}

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -90,6 +90,8 @@ pub mod member_auth;
 pub(crate) use crate::manage_interactive;
 pub mod middleware;
 pub mod migrate;
+/// Tenant migrations against a recorded, streamable run.
+pub mod migrate_run;
 pub mod operator_console;
 mod org;
 pub mod org_host;

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -108,6 +108,13 @@ pub mod provision;
 /// Durable record of provisioning runs and their events, so a run
 /// survives a reconnect and is readable from a second pod.
 pub mod provision_store;
+/// Inbound webhook that creates a tenant from a billing event.
+///
+/// Gated on `webhook`, which is where HMAC verification lives: a
+/// tenancy deployment that does not expose this endpoint has no reason
+/// to compile signature machinery for it.
+#[cfg(feature = "webhook")]
+pub mod provision_webhook;
 mod resolver;
 mod resolver_cache;
 pub mod routes;

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -73,6 +73,9 @@ pub mod auth_routes;
 pub mod bootstrap;
 pub mod branding;
 pub mod database_pools;
+/// Taking a tenant out of service — the steps `drop-tenant` and
+/// `purge-tenant` run, callable from anything that is not a terminal.
+pub mod decommission;
 mod error;
 pub mod impersonation_handoff;
 pub mod jwt_lifecycle;

--- a/crates/rustango/src/tenancy/operator_console/audit.rs
+++ b/crates/rustango/src/tenancy/operator_console/audit.rs
@@ -32,11 +32,7 @@ use serde::Deserialize;
 use tera::Context;
 
 use super::super::auth;
-use super::{inject_op_brand, render, ConsoleState};
-
-/// A screenful. The table grows with every console action, so the page
-/// pages rather than pretending the history is small.
-const PAGE_SIZE: i64 = 50;
+use super::{inject_op_brand, render, ConsoleState, Paged};
 
 #[derive(Deserialize)]
 pub(super) struct AuditQuery {
@@ -55,17 +51,6 @@ pub(super) async fn audit_list(
     Extension(op): Extension<auth::Operator>,
     Query(q): Query<AuditQuery>,
 ) -> Response<Body> {
-    // 1-based in the URL, 0-based in the query: a `?page=0` or a
-    // negative should read as the first page rather than as an offset
-    // the database has to reject.
-    //
-    // Saturating, not plain arithmetic: `?page=1000000000000000000`
-    // parses into an `i64` happily and then overflows when multiplied,
-    // which panicked the worker in debug and wrapped to a negative
-    // offset in release. Clamped, an absurd page is simply an empty one.
-    let page = q.page.unwrap_or(1).max(1);
-    let offset = page.saturating_sub(1).saturating_mul(PAGE_SIZE);
-
     let filter = crate::audit::AuditFilter {
         entity_table: blank_to_none(q.entity_table.as_deref()),
         entity_pk: blank_to_none(q.entity_pk.as_deref()),
@@ -73,10 +58,22 @@ pub(super) async fn audit_list(
         source: None,
     };
 
-    // One extra row, so "is there a next page?" is answered without a
-    // second COUNT over a table that only grows.
-    let mut entries =
-        match crate::audit::list(&state.registry, &filter, PAGE_SIZE + 1, offset).await {
+    // Counted through the same filter, or page 2 of a filtered view
+    // would be sized by the unfiltered total.
+    let total = match crate::audit::count(&state.registry, &filter).await {
+        Ok(n) => n,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not count the audit log: {e}"),
+            )
+                .into_response();
+        }
+    };
+    let paged = Paged::from_total(total, q.page);
+
+    let entries =
+        match crate::audit::list(&state.registry, &filter, paged.limit, paged.offset).await {
             Ok(e) => e,
             Err(e) => {
                 return (
@@ -86,9 +83,6 @@ pub(super) async fn audit_list(
                     .into_response();
             }
         };
-    let page_len = usize::try_from(PAGE_SIZE).unwrap_or(usize::MAX);
-    let has_next = entries.len() > page_len;
-    entries.truncate(page_len);
 
     let view: Vec<_> = entries
         .iter()
@@ -116,12 +110,10 @@ pub(super) async fn audit_list(
     ctx.insert("section", "audit");
     ctx.insert("operator_username", &op.username);
     ctx.insert("entries", &view);
-    ctx.insert("page", &page);
-    ctx.insert("has_next", &has_next);
     ctx.insert("filter_entity_table", &q.entity_table.unwrap_or_default());
     ctx.insert("filter_entity_pk", &q.entity_pk.unwrap_or_default());
     ctx.insert("filter_operation", &q.operation.unwrap_or_default());
-    ctx.insert("query_suffix", &filter_suffix(&filter));
+    paged.inject(&mut ctx, "/audit", &filter_suffix(&filter));
 
     render(&state, "op_audit.html", &ctx)
 }

--- a/crates/rustango/src/tenancy/operator_console/audit.rs
+++ b/crates/rustango/src/tenancy/operator_console/audit.rs
@@ -1,0 +1,220 @@
+//! Reading the registry's audit trail from the console.
+//!
+//! Every console mutation already writes here — `emit_op_audit` on
+//! tenant edits, branding, impersonation, and now operator and hostname
+//! changes. Nothing read it back. The record an operator would want
+//! during an incident ("who deactivated this tenant, and when?") existed
+//! and was reachable only with a SQL client on the registry.
+//!
+//! ## Registry only
+//!
+//! `rustango_audit_log` exists in the registry *and* in every tenant's
+//! storage, and this page reads the registry's. Tenant-side rows are the
+//! tenant's own history — a tenant admin's edits to tenant data — and
+//! belong to the tenant admin, which already has a viewer. Mixing them
+//! would mean fanning out a query over every tenant pool to render one
+//! page.
+//!
+//! ## Read-only, and mounted for every console
+//!
+//! There is no write path, so this is not behind the edit gate: a
+//! read-only console is exactly the deployment where "what happened?"
+//! still needs answering. Any authenticated operator can already see and
+//! change everything the log describes, so showing them the log grants
+//! nothing new.
+
+use axum::body::Body;
+use axum::extract::{Query, State};
+use axum::http::{Response, StatusCode};
+use axum::response::IntoResponse;
+use axum::Extension;
+use serde::Deserialize;
+use tera::Context;
+
+use super::super::auth;
+use super::{inject_op_brand, render, ConsoleState};
+
+/// A screenful. The table grows with every console action, so the page
+/// pages rather than pretending the history is small.
+const PAGE_SIZE: i64 = 50;
+
+#[derive(Deserialize)]
+pub(super) struct AuditQuery {
+    #[serde(default)]
+    entity_table: Option<String>,
+    #[serde(default)]
+    entity_pk: Option<String>,
+    #[serde(default)]
+    operation: Option<String>,
+    #[serde(default)]
+    page: Option<i64>,
+}
+
+pub(super) async fn audit_list(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Query(q): Query<AuditQuery>,
+) -> Response<Body> {
+    // 1-based in the URL, 0-based in the query: a `?page=0` or a
+    // negative should read as the first page rather than as an offset
+    // the database has to reject.
+    //
+    // Saturating, not plain arithmetic: `?page=1000000000000000000`
+    // parses into an `i64` happily and then overflows when multiplied,
+    // which panicked the worker in debug and wrapped to a negative
+    // offset in release. Clamped, an absurd page is simply an empty one.
+    let page = q.page.unwrap_or(1).max(1);
+    let offset = page.saturating_sub(1).saturating_mul(PAGE_SIZE);
+
+    let filter = crate::audit::AuditFilter {
+        entity_table: blank_to_none(q.entity_table.as_deref()),
+        entity_pk: blank_to_none(q.entity_pk.as_deref()),
+        operation: blank_to_none(q.operation.as_deref()),
+        source: None,
+    };
+
+    // One extra row, so "is there a next page?" is answered without a
+    // second COUNT over a table that only grows.
+    let mut entries =
+        match crate::audit::list(&state.registry, &filter, PAGE_SIZE + 1, offset).await {
+            Ok(e) => e,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("could not read the audit log: {e}"),
+                )
+                    .into_response();
+            }
+        };
+    let page_len = usize::try_from(PAGE_SIZE).unwrap_or(usize::MAX);
+    let has_next = entries.len() > page_len;
+    entries.truncate(page_len);
+
+    let view: Vec<_> = entries
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "id": e.id,
+                "occurred_at": e.occurred_at.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+                "entity_table": e.entity_table,
+                "entity_pk": e.entity_pk,
+                "operation": e.operation,
+                "source": e.source,
+                "who": who(&e.source),
+                "what": what(&e.source),
+                // Pretty-printed: `changes` is the column that actually
+                // answers "what changed", and one long line of JSON is
+                // not an answer anybody reads.
+                "changes": serde_json::to_string_pretty(&e.changes)
+                    .unwrap_or_else(|_| e.changes.to_string()),
+            })
+        })
+        .collect();
+
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "audit");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("entries", &view);
+    ctx.insert("page", &page);
+    ctx.insert("has_next", &has_next);
+    ctx.insert("filter_entity_table", &q.entity_table.unwrap_or_default());
+    ctx.insert("filter_entity_pk", &q.entity_pk.unwrap_or_default());
+    ctx.insert("filter_operation", &q.operation.unwrap_or_default());
+    ctx.insert("query_suffix", &filter_suffix(&filter));
+
+    render(&state, "op_audit.html", &ctx)
+}
+
+fn blank_to_none(v: Option<&str>) -> Option<String> {
+    v.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// The filters, re-encoded for the paging links so moving to page 2
+/// does not silently drop what the operator filtered by.
+fn filter_suffix(filter: &crate::audit::AuditFilter) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    for (key, value) in [
+        ("entity_table", filter.entity_table.as_deref()),
+        ("entity_pk", filter.entity_pk.as_deref()),
+        ("operation", filter.operation.as_deref()),
+    ] {
+        if let Some(v) = value {
+            let _ = write!(out, "&{key}={}", super::urlencoding_lite(v));
+        }
+    }
+    out
+}
+
+/// The actor in `operator:<id>:<verb>`, or the raw source.
+///
+/// `AuditSource::Custom` renders that shape for every console action —
+/// see `emit_registry_audit` — and a column of `operator:1:host_add`
+/// makes the reader parse the same string on every row.
+fn who(source: &str) -> String {
+    match source.strip_prefix("operator:") {
+        Some(rest) => match rest.split_once(':') {
+            Some((id, _)) => format!("operator {id}"),
+            None => format!("operator {rest}"),
+        },
+        None => source.to_owned(),
+    }
+}
+
+/// The verb half of the same shape.
+fn what(source: &str) -> String {
+    source
+        .strip_prefix("operator:")
+        .and_then(|rest| rest.split_once(':'))
+        .map_or_else(|| source.to_owned(), |(_, verb)| verb.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_operator_source_shape_splits_into_who_and_what() {
+        assert_eq!(who("operator:1:host_add"), "operator 1");
+        assert_eq!(what("operator:1:host_add"), "host_add");
+        // The verb may itself contain a colon (`operator:1:impersonating`
+        // is the two-part case, but nothing forbids more).
+        assert_eq!(what("operator:7:a:b"), "a:b");
+    }
+
+    /// Anything not written by the console — a tenant-side source, a
+    /// system one — has to render as itself rather than as a mangled
+    /// "operator".
+    #[test]
+    fn a_source_that_is_not_an_operator_is_left_alone() {
+        assert_eq!(who("system"), "system");
+        assert_eq!(what("system"), "system");
+        assert_eq!(who("user:42"), "user:42");
+    }
+
+    #[test]
+    fn blank_filters_do_not_become_empty_string_matches() {
+        assert_eq!(blank_to_none(Some("   ")), None);
+        assert_eq!(blank_to_none(Some("")), None);
+        assert_eq!(blank_to_none(None), None);
+        assert_eq!(blank_to_none(Some(" orgs ")).as_deref(), Some("orgs"));
+    }
+
+    #[test]
+    fn paging_links_keep_the_filters() {
+        let f = crate::audit::AuditFilter {
+            entity_table: Some("rustango_orgs".into()),
+            entity_pk: Some("acme".into()),
+            operation: None,
+            source: None,
+        };
+        let suffix = filter_suffix(&f);
+        assert!(suffix.contains("entity_table=rustango_orgs"), "{suffix}");
+        assert!(suffix.contains("entity_pk=acme"), "{suffix}");
+        assert!(!suffix.contains("operation="), "unset filters stay out");
+    }
+}

--- a/crates/rustango/src/tenancy/operator_console/decommission.rs
+++ b/crates/rustango/src/tenancy/operator_console/decommission.rs
@@ -1,0 +1,136 @@
+//! Taking a tenant out of service from the console.
+//!
+//! Two actions with very different consequences, so the page keeps them
+//! visibly apart: deactivating is one click and reversible, purging
+//! requires typing the slug and destroys the storage.
+//!
+//! The typed slug is the same guard `purge-tenant --confirm` uses on the
+//! command line. It is not security — an operator who can reach this page
+//! can already do the damage — it is a pause between intent and an
+//! unrecoverable act.
+
+use axum::body::Body;
+use axum::extract::{Form, Path, State};
+use axum::http::{Response, StatusCode};
+use axum::response::{IntoResponse, Redirect};
+use axum::Extension;
+use serde::Deserialize;
+
+use super::super::auth;
+use super::super::decommission::Action;
+use super::{urlencoding_lite, ConsoleState};
+
+#[derive(Deserialize)]
+pub(super) struct PurgeForm {
+    /// Must repeat the slug verbatim.
+    #[serde(default)]
+    confirm: String,
+    /// Present for a database-mode tenant, whose purge is a
+    /// `DROP DATABASE` rather than a `DROP SCHEMA`.
+    #[serde(default)]
+    purge_database: Option<String>,
+}
+
+/// Soft-delete: `active = false`, nothing destroyed.
+pub(super) async fn deactivate(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(slug): Path<String>,
+) -> Response<Body> {
+    let Some(pools) = state.pools.clone() else {
+        return not_available();
+    };
+    match pools.decommission(&slug, Action::Deactivate).await {
+        Ok(report) => {
+            audit(&state, &op, &slug, "tenant_deactivate").await;
+            let msg = if report.no_change {
+                format!("`{slug}` was already inactive")
+            } else {
+                format!("deactivated `{slug}` — its data is untouched")
+            };
+            back_to_orgs(Some(&msg), None)
+        }
+        Err(e) => back_to_orgs(None, Some(&e.to_string())),
+    }
+}
+
+/// Hard-delete: drop the storage, remove the row.
+pub(super) async fn purge(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(slug): Path<String>,
+    Form(form): Form<PurgeForm>,
+) -> Response<Body> {
+    use std::fmt::Write as _;
+
+    let Some(pools) = state.pools.clone() else {
+        return not_available();
+    };
+    if form.confirm != slug {
+        return back_to_tenant(
+            &slug,
+            &format!("Type `{slug}` exactly to confirm. Nothing was destroyed."),
+        );
+    }
+
+    let action = Action::Purge {
+        purge_database: form.purge_database.is_some(),
+    };
+    match pools.decommission(&slug, action).await {
+        Ok(report) => {
+            audit(&state, &op, &slug, "tenant_purge").await;
+            let mut msg = format!("purged `{slug}`");
+            if let Some(schema) = &report.schema_dropped {
+                let _ = write!(msg, " — dropped schema `{schema}`");
+            }
+            if report.database_dropped.is_some() {
+                msg.push_str(" — dropped its database");
+            }
+            for note in &report.notes {
+                let _ = write!(msg, " — {note}");
+            }
+            back_to_orgs(Some(&msg), None)
+        }
+        // Back to the tenant, not the list: it still exists, and the
+        // reason usually names something to change.
+        Err(e) => back_to_tenant(&slug, &e.to_string()),
+    }
+}
+
+fn not_available() -> Response<Body> {
+    (
+        StatusCode::NOT_FOUND,
+        "this console is read-only".to_owned(),
+    )
+        .into_response()
+}
+
+fn back_to_orgs(notice: Option<&str>, error: Option<&str>) -> Response<Body> {
+    let query = match (notice, error) {
+        (Some(n), _) => format!("?notice={}", urlencoding_lite(n)),
+        (_, Some(e)) => format!("?error={}", urlencoding_lite(e)),
+        _ => String::new(),
+    };
+    Redirect::to(&format!("/orgs{query}")).into_response()
+}
+
+fn back_to_tenant(slug: &str, error: &str) -> Response<Body> {
+    Redirect::to(&format!(
+        "/orgs/{}/edit?error={}",
+        urlencoding_lite(slug),
+        urlencoding_lite(error)
+    ))
+    .into_response()
+}
+
+async fn audit(state: &ConsoleState, op: &auth::Operator, slug: &str, verb: &str) {
+    let operator_id = op.id.get().copied().unwrap_or_default();
+    super::emit_op_audit(
+        &state.registry,
+        slug,
+        operator_id,
+        verb,
+        serde_json::Map::new(),
+    )
+    .await;
+}

--- a/crates/rustango/src/tenancy/operator_console/hosts.rs
+++ b/crates/rustango/src/tenancy/operator_console/hosts.rs
@@ -1,0 +1,211 @@
+//! Managing the extra hostnames a tenant answers on, from the console.
+//!
+//! [`super::super::org_host`] shipped the model, the resolver and the
+//! whole `add` / `remove` / `enable` API — reachable only from Rust.
+//! An operator adding a customer's vanity domain had to write a program
+//! or hand-edit `rustango_org_hosts`, which is the kind of task a
+//! console exists for. `TenantHost::is_base` was even documented as
+//! being "for the UI to explain why the row has no delete button", for
+//! a UI that did not exist.
+//!
+//! ## Why its own page rather than a section of the edit form
+//!
+//! The edit form is one `POST` that writes one `Org` row. Hostnames are
+//! a collection with three verbs (add, remove, enable/disable) acting on
+//! individual members, and folding them into that form would mean either
+//! a submit that does several unrelated things at once, or per-row
+//! forms nested inside the outer one — which HTML does not allow.
+//!
+//! ## What this page may not do
+//!
+//! Remove the base host. It has no row in `rustango_org_hosts` to
+//! remove — that is [`org_host`](super::super::org_host)'s deliberate
+//! design, not an oversight — so the page renders it without controls
+//! and the engine refuses it anyway. Both, because an operator who
+//! guesses the `POST` should get the same answer as one who reads the
+//! page.
+
+use axum::body::Body;
+use axum::extract::{Form, Path, Query, State};
+use axum::http::{Response, StatusCode};
+use axum::response::{IntoResponse, Redirect};
+use axum::Extension;
+use serde::Deserialize;
+use tera::Context;
+
+use super::super::auth;
+use super::super::org_host::{self, HostError};
+use super::{inject_op_brand, render, urlencoding_lite, ConsoleState};
+use crate::core::Column as _;
+use crate::sql::FetcherPool as _;
+
+#[derive(Deserialize)]
+pub(super) struct HostsQuery {
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    notice: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AddForm {
+    #[serde(default)]
+    hostname: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct HostActionForm {
+    #[serde(default)]
+    hostname: String,
+    /// Present and `"on"` for the enable action; absent means disable.
+    /// A checkbox posts nothing when unchecked, which is exactly the
+    /// shape this needs.
+    #[serde(default)]
+    enabled: Option<String>,
+}
+
+/// The page: base host first, then every extra, with its controls.
+pub(super) async fn org_hosts_view(
+    State(state): State<ConsoleState>,
+    Path(slug): Path<String>,
+    Extension(op): Extension<auth::Operator>,
+    Query(q): Query<HostsQuery>,
+) -> Response<Body> {
+    // 404 before listing, so an unknown slug reads as "no such tenant"
+    // rather than "a tenant with no hosts".
+    if !org_exists(&state, &slug).await {
+        return (StatusCode::NOT_FOUND, format!("org `{slug}` not found")).into_response();
+    }
+
+    let hosts = match org_host::list_for_org(&state.registry, &slug).await {
+        Ok(h) => h,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "orgs");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("slug", &slug);
+    ctx.insert("hosts", &hosts);
+    ctx.insert("error", &q.error);
+    ctx.insert("notice", &q.notice);
+
+    render(&state, "op_org_hosts.html", &ctx)
+}
+
+/// Bind one more hostname to this tenant.
+pub(super) async fn org_hosts_add(
+    State(state): State<ConsoleState>,
+    Path(slug): Path<String>,
+    Extension(op): Extension<auth::Operator>,
+    Form(form): Form<AddForm>,
+) -> Response<Body> {
+    match org_host::add_host(&state.registry, &slug, &form.hostname).await {
+        Ok(row) => {
+            audit(&state, &slug, &op, "host_add", &row.hostname).await;
+            back(&slug, None, Some(&format!("added `{}`", row.hostname)))
+        }
+        Err(e) => back(&slug, Some(&explain(&e, &slug)), None),
+    }
+}
+
+/// Unbind a hostname. Refused for the base host.
+pub(super) async fn org_hosts_remove(
+    State(state): State<ConsoleState>,
+    Path(slug): Path<String>,
+    Extension(op): Extension<auth::Operator>,
+    Form(form): Form<HostActionForm>,
+) -> Response<Body> {
+    match org_host::remove_host(&state.registry, &slug, &form.hostname).await {
+        Ok(()) => {
+            audit(&state, &slug, &op, "host_remove", &form.hostname).await;
+            back(&slug, None, Some(&format!("removed `{}`", form.hostname)))
+        }
+        Err(e) => back(&slug, Some(&explain(&e, &slug)), None),
+    }
+}
+
+/// Park or un-park a hostname without losing the record.
+pub(super) async fn org_hosts_toggle(
+    State(state): State<ConsoleState>,
+    Path(slug): Path<String>,
+    Extension(op): Extension<auth::Operator>,
+    Form(form): Form<HostActionForm>,
+) -> Response<Body> {
+    let enable = form.enabled.is_some();
+    match org_host::set_host_enabled(&state.registry, &slug, &form.hostname, enable).await {
+        Ok(()) => {
+            let verb = if enable {
+                "host_enable"
+            } else {
+                "host_disable"
+            };
+            audit(&state, &slug, &op, verb, &form.hostname).await;
+            let word = if enable { "enabled" } else { "disabled" };
+            back(&slug, None, Some(&format!("{word} `{}`", form.hostname)))
+        }
+        Err(e) => back(&slug, Some(&explain(&e, &slug)), None),
+    }
+}
+
+// ------------------------------------------------------------- helpers
+
+async fn org_exists(state: &ConsoleState, slug: &str) -> bool {
+    super::super::Org::objects()
+        .where_(super::super::Org::slug.eq(slug.to_owned()))
+        .fetch(&state.registry)
+        .await
+        .is_ok_and(|rows: Vec<super::super::Org>| !rows.is_empty())
+}
+
+/// Post/Redirect/Get back to the page, carrying the outcome.
+///
+/// A redirect rather than a render so a reload does not repost the
+/// action — these are writes that change how traffic routes.
+fn back(slug: &str, error: Option<&str>, notice: Option<&str>) -> Response<Body> {
+    use std::fmt::Write as _;
+
+    let mut url = format!("/orgs/{}/hosts", urlencoding_lite(slug));
+    if let Some(e) = error {
+        let _ = write!(url, "?error={}", urlencoding_lite(e));
+    } else if let Some(n) = notice {
+        let _ = write!(url, "?notice={}", urlencoding_lite(n));
+    }
+    Redirect::to(&url).into_response()
+}
+
+/// The engine's message, plus what the operator should do about it.
+///
+/// `HostError`'s own `Display` is written for a log line. On a page
+/// where someone is about to retype the value, "is already registered"
+/// without "to which tenant, and what to do" just invites a second
+/// attempt at the same thing.
+fn explain(e: &HostError, slug: &str) -> String {
+    match e {
+        HostError::Invalid(h) => format!(
+            "`{h}` is not a bare hostname — no scheme, no port, no path, no trailing dot. \
+             Use `shop.example.com`"
+        ),
+        HostError::Taken(h) => format!(
+            "`{h}` is already registered. A hostname resolves to exactly one tenant, so \
+             remove it from the tenant that holds it first"
+        ),
+        HostError::IsBaseHost(h) => format!(
+            "`{h}` is `{slug}`'s base host and has no row to remove. Change it on the edit \
+             page instead"
+        ),
+        HostError::NotFound => "no such host on this tenant".to_owned(),
+        HostError::Driver(d) => format!("the registry rejected the change: {d}"),
+    }
+}
+
+async fn audit(state: &ConsoleState, slug: &str, op: &auth::Operator, verb: &str, host: &str) {
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "hostname".into(),
+        serde_json::Value::String(host.to_owned()),
+    );
+    let operator_id = op.id.get().copied().unwrap_or_default();
+    super::emit_op_audit(&state.registry, slug, operator_id, verb, extra).await;
+}

--- a/crates/rustango/src/tenancy/operator_console/migrate.rs
+++ b/crates/rustango/src/tenancy/operator_console/migrate.rs
@@ -1,0 +1,69 @@
+//! Running tenant migrations from the console.
+//!
+//! After a deploy every tenant needs migrating, and that meant a shell
+//! on the production host. The run is recorded and streamed like a
+//! provisioning run, so it survives a reload and a second pod.
+//!
+//! Unlike provisioning, the work is spawned rather than awaited: a
+//! batch across hundreds of tenants is minutes, not the seconds an
+//! operator can watch a form for. The run is opened first so the
+//! redirect has somewhere to point.
+
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{Response, StatusCode};
+use axum::response::{IntoResponse, Redirect};
+use axum::Extension;
+
+use super::super::auth;
+use super::super::provision_store as store;
+use super::ConsoleState;
+
+/// Migrate every active tenant.
+pub(super) async fn migrate_all(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+) -> Response<Body> {
+    start(&state, &op, None).await
+}
+
+/// Migrate one tenant.
+pub(super) async fn migrate_one(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(slug): Path<String>,
+) -> Response<Body> {
+    start(&state, &op, Some(slug)).await
+}
+
+async fn start(state: &ConsoleState, op: &auth::Operator, slug: Option<String>) -> Response<Body> {
+    let Some(provisioner) = state.provisioner.clone() else {
+        return (
+            StatusCode::NOT_FOUND,
+            "this console cannot run migrations".to_owned(),
+        )
+            .into_response();
+    };
+
+    let run =
+        match store::open_migrate_run(&state.registry, slug.as_deref(), Some(&op.username)).await {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("could not open a run: {e}"),
+                )
+                    .into_response();
+            }
+        };
+    let run_id = run.id.get().copied().unwrap_or_default();
+
+    // Detached: the response is a link to the run, not the result.
+    // Failures are recorded on the run, which is the only place anyone
+    // will look for them.
+    tokio::spawn(async move {
+        let _ = provisioner.migrate_in_run(run_id, slug.as_deref()).await;
+    });
+
+    Redirect::to(&format!("/orgs/provision/{run_id}")).into_response()
+}

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -408,6 +408,39 @@ fn default_tenant_handoff_url() -> String {
     super::routes::RouteConfig::default().impersonation_handoff_url
 }
 
+/// Every knob at once.
+///
+/// The named constructors above are thin wrappers over this, each
+/// fixing some arguments — which is fine until a caller wants a
+/// combination none of them covers (the tenancy `Builder` wants
+/// impersonation **and** provisioning). Rather than add a seventh
+/// positional constructor for each new pairing, this is the one that
+/// takes everything and the others stay as the convenient shorthands.
+///
+/// `pools` unlocks the edit routes, `provisioner` the create routes,
+/// `tenant_session_secret` impersonation. `None` for any of them
+/// simply does not mount those routes.
+#[must_use]
+pub fn router_full(
+    registry: impl Into<crate::sql::Pool>,
+    pools: Option<Arc<dyn crate::tenancy::TenantPoolInvalidator>>,
+    provisioner: Option<Arc<dyn crate::tenancy::provision::TenantProvisioner>>,
+    secret: SessionSecret,
+    brand_storage: BoxedStorage,
+    tenant_session_secret: Option<SessionSecret>,
+    tenant_handoff_url: String,
+) -> Router {
+    router_inner(
+        registry.into(),
+        pools,
+        provisioner,
+        secret,
+        brand_storage,
+        tenant_session_secret,
+        tenant_handoff_url,
+    )
+}
+
 fn router_inner(
     registry: crate::sql::Pool,
     pools: Option<Arc<dyn crate::tenancy::TenantPoolInvalidator>>,
@@ -1074,6 +1107,10 @@ async fn orgs_list(
     ctx.insert("operator_username", &op.username);
     ctx.insert("orgs", &view);
     ctx.insert("edit_enabled", &state.pools.is_some());
+    // Drives the "New tenant" button. Without this the create page
+    // exists but nothing links to it — which is exactly the state
+    // this shipped in first.
+    ctx.insert("provisioning_enabled", &state.provisioner.is_some());
     Html(state.tera.render("op_orgs.html", &ctx).unwrap_or_default()).into_response()
 }
 

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -42,6 +42,7 @@
 /// Mounted only by [`router_with_provisioning`].
 mod audit;
 mod hosts;
+mod migrate;
 mod operators;
 mod provisioning;
 
@@ -624,6 +625,16 @@ fn router_inner(
                 get(provisioning::org_new_form).post(provisioning::org_new_submit),
             )
             .route("/orgs/test-connection", post(provisioning::test_connection))
+            // Migrations ride with provisioning: both need the
+            // provisioner's migrations directory and its registry URL.
+            .route(
+                "/orgs/migrate",
+                get(op_post_only_redirect).post(migrate::migrate_all),
+            )
+            .route(
+                "/orgs/{slug}/migrate",
+                get(org_post_only_redirect).post(migrate::migrate_one),
+            )
             // The index has to come before the `{run_id}` route it
             // shares a prefix with, and be a distinct path: a run id is
             // numeric, so `/orgs/provision` cannot be confused for one.
@@ -1588,6 +1599,9 @@ async fn org_edit_form(
     ctx.insert("section", "orgs");
     ctx.insert("operator_username", &op.username);
     ctx.insert("slug", &slug);
+    // Drives the "Run migrations" button: migrations ride with the
+    // provisioner, which owns the migrations directory.
+    ctx.insert("provisioning_enabled", &state.provisioner.is_some());
     ctx.insert("editable_rows", &editable_rows);
     ctx.insert("locked_rows", &locked_rows);
     ctx.insert("logo_url", &logo_url);

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -40,6 +40,7 @@
 
 /// Creating a tenant from the console, and watching it happen (#1322).
 /// Mounted only by [`router_with_provisioning`].
+mod hosts;
 mod provisioning;
 
 use crate::core::Column as _;
@@ -483,6 +484,10 @@ fn router_inner(
             include_str!("../templates/op_orgs_edit.html"),
         ),
         (
+            "op_org_hosts.html",
+            include_str!("../templates/op_org_hosts.html"),
+        ),
+        (
             "op_change_password.html",
             include_str!("../templates/op_change_password.html"),
         ),
@@ -555,6 +560,24 @@ fn router_inner(
             .route(
                 "/orgs/{slug}/edit/branding",
                 get(org_post_only_redirect).post(org_edit_branding),
+            )
+            // The extra hostnames a tenant answers on. Behind the same
+            // gate as `/edit`: binding a hostname changes which tenant
+            // serves that traffic, which is an edit in every sense that
+            // matters. The three writes are separate routes rather than
+            // one submit because they act on individual rows.
+            .route("/orgs/{slug}/hosts", get(hosts::org_hosts_view))
+            .route(
+                "/orgs/{slug}/hosts/add",
+                get(org_post_only_redirect).post(hosts::org_hosts_add),
+            )
+            .route(
+                "/orgs/{slug}/hosts/remove",
+                get(org_post_only_redirect).post(hosts::org_hosts_remove),
+            )
+            .route(
+                "/orgs/{slug}/hosts/toggle",
+                get(org_post_only_redirect).post(hosts::org_hosts_toggle),
             );
     }
     if provisioning_enabled {
@@ -601,6 +624,40 @@ fn router_inner(
 /// Stamp the operator-console branding fields onto every render
 /// context. Centralizing the keys keeps op_layout.html and op_login.html
 /// in sync without each handler remembering the four template names.
+/// Render, or say why not.
+///
+/// The console's older handlers use `.unwrap_or_default()`, which turns
+/// a template error into an empty `200` — a blank page with no clue
+/// anywhere. That cost real time: a missing key in a Tera comparison
+/// rendered nothing and looked like a routing problem. A 500 naming the
+/// template is worth far more than a page that lies about having
+/// worked.
+fn render(state: &ConsoleState, template: &str, ctx: &Context) -> Response<Body> {
+    match state.tera.render(template, ctx) {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            let mut detail = e.to_string();
+            let mut source = std::error::Error::source(&e);
+            while let Some(s) = source {
+                detail.push_str(": ");
+                detail.push_str(&s.to_string());
+                source = s.source();
+            }
+            tracing::error!(
+                target: "rustango::tenancy::operator_console",
+                template,
+                error = %detail,
+                "operator console template failed to render"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not render {template}: {detail}"),
+            )
+                .into_response()
+        }
+    }
+}
+
 fn inject_op_brand(ctx: &mut Context, brand: &OpBrand) {
     // Show the "Shared SSO" nav entry only when the admin-sso feature is
     // compiled in (its routes exist only then).

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -41,6 +41,7 @@
 /// Creating a tenant from the console, and watching it happen (#1322).
 /// Mounted only by [`router_with_provisioning`].
 mod audit;
+mod decommission;
 mod hosts;
 mod migrate;
 mod operators;
@@ -599,6 +600,17 @@ fn router_inner(
             // serves that traffic, which is an edit in every sense that
             // matters. The three writes are separate routes rather than
             // one submit because they act on individual rows.
+            // Taking a tenant out of service. Behind the edit gate
+            // like the rest: `purge` is the most destructive thing this
+            // console can do, and a read-only one must not offer it.
+            .route(
+                "/orgs/{slug}/deactivate",
+                get(org_post_only_redirect).post(decommission::deactivate),
+            )
+            .route(
+                "/orgs/{slug}/purge",
+                get(org_post_only_redirect).post(decommission::purge),
+            )
             .route("/orgs/{slug}/hosts", get(hosts::org_hosts_view))
             .route(
                 "/orgs/{slug}/hosts/add",
@@ -799,6 +811,17 @@ pub(super) async fn count_where(
 pub(super) struct PageQuery {
     #[serde(default)]
     pub(super) page: Option<i64>,
+}
+
+/// A page plus the outcome of whatever redirected here.
+#[derive(Deserialize)]
+pub(super) struct ListQuery {
+    #[serde(default)]
+    pub(super) page: Option<i64>,
+    #[serde(default)]
+    pub(super) error: Option<String>,
+    #[serde(default)]
+    pub(super) notice: Option<String>,
 }
 
 /// Render, or say why not.
@@ -1304,7 +1327,7 @@ async fn welcome(
 async fn orgs_list(
     State(state): State<ConsoleState>,
     Extension(op): Extension<auth::Operator>,
-    Query(q): Query<PageQuery>,
+    Query(q): Query<ListQuery>,
 ) -> Response<Body> {
     // Paged: this fetched every tenant, which is fine for the three a
     // demo has and not for the thousands a real registry holds.
@@ -1349,6 +1372,8 @@ async fn orgs_list(
     // exists but nothing links to it — which is exactly the state
     // this shipped in first.
     ctx.insert("provisioning_enabled", &state.provisioner.is_some());
+    ctx.insert("error", &q.error);
+    ctx.insert("notice", &q.notice);
     paged.inject(&mut ctx, "/orgs", "");
     render(&state, "op_orgs.html", &ctx)
 }

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -6,6 +6,56 @@
 //! at the apex (`localhost:8080`); production deployments mount it
 //! the same way.
 //!
+//! ## Logging
+//!
+//! Two streams, both plain `tracing` events, so whatever subscriber the
+//! app installs decides the shape.
+//!
+//! **Actions** — one event per mutation, on target
+//! [`ACTION_TARGET`]:
+//!
+//! ```text
+//! event=operator_action action=host_add operator_id=1
+//!   entity=rustango_orgs entity_id=acme fields=hostname,tenant_slug
+//! ```
+//!
+//! Emitted from the same function that writes the audit row, so the log
+//! stream and the durable trail describe the same set of actions. A
+//! failure to write that row is an `ERROR` with
+//! `event=operator_action_unrecorded` — the action happened and the
+//! record did not, which is the one case worth paging on.
+//!
+//! `fields` carries the *names* of what changed, never the values: an
+//! audit blob is one careless caller away from holding a credential,
+//! and logs travel further than the database does.
+//!
+//! **Requests** — one event per request from [`crate::access_log`]
+//! (method, path, status, duration, IP), with `next` and `token`
+//! redacted out of query strings.
+//!
+//! ### Choosing the shape
+//!
+//! Format is the subscriber's job, not this module's. JSON for a
+//! collector, pretty for a terminal, either driven by settings:
+//!
+//! ```ignore
+//! rustango::logging::Setup::new().json().install();
+//! // or [logging] format = "json" in settings
+//! ```
+//!
+//! Route or silence console activity without touching the rest of
+//! tenancy by filtering on the target:
+//!
+//! ```text
+//! RUST_LOG=warn,rustango::tenancy::operator_console::action=info
+//! ```
+//!
+//! For a different field set or destination — a collector wanting its
+//! own envelope, or events fanned to an external sink — add a
+//! `tracing_subscriber::Layer` and match on the target. The events are
+//! structured fields rather than formatted strings precisely so a layer
+//! can re-shape them without parsing.
+//!
 //! ## What it ships
 //!
 //! * `GET  /login`               — form HTML
@@ -79,6 +129,16 @@ use super::branding::{self, BrandAssetKind};
 use super::pools::TenantPools;
 
 const RUSTANGO_PNG: &[u8] = include_bytes!("../static/rustango.png");
+
+/// Tracing target for operator actions.
+///
+/// Its own target so a deployment can route or silence console activity
+/// without touching the rest of tenancy —
+/// `RUST_LOG=rustango::tenancy::operator_console::action=info`.
+/// Request logging is not here — it comes from
+/// [`crate::access_log`] under its own `rustango::access_log` target,
+/// the same middleware the admin uses.
+pub const ACTION_TARGET: &str = "rustango::tenancy::operator_console::action";
 
 #[derive(Clone)]
 struct ConsoleState {
@@ -683,7 +743,20 @@ fn router_inner(
         require_session,
     ));
 
-    public.merge(private).with_state(state)
+    // One event per request — method, path, status, duration, IP —
+    // from the middleware the admin already uses, rather than a second
+    // one written here. Without it a console 500 left nothing behind
+    // but the operator's screen.
+    //
+    // `next` is redacted because the login bounce carries the whole
+    // attempted URL, and `token` because impersonation handoff puts one
+    // in a query string.
+    use crate::access_log::AccessLogRouterExt as _;
+    public.merge(private).with_state(state).access_log(
+        crate::access_log::AccessLogLayer::new()
+            .redact_additional("next")
+            .redact_additional("token"),
+    )
 }
 
 /// Stamp the operator-console branding fields onto every render
@@ -1860,6 +1933,31 @@ async fn emit_registry_audit(
 ) {
     let mut changes = extra;
     changes.insert("operator_id".into(), serde_json::json!(operator_id));
+
+    // The same action, to the log stream. Emitted here rather than at
+    // each call site so the trail and the logs cannot describe
+    // different sets of actions — every console mutation already comes
+    // through this function.
+    //
+    // Field *names* only, never the blob: today's callers put column
+    // names in `changes` rather than values, and logging it whole would
+    // make the next caller's habit a credential leak.
+    let fields: Vec<&str> = changes
+        .keys()
+        .filter(|k| k.as_str() != "operator_id")
+        .map(String::as_str)
+        .collect();
+    tracing::info!(
+        target: ACTION_TARGET,
+        event = "operator_action",
+        action = verb,
+        operator_id,
+        entity = entity_table,
+        entity_id = entity_pk,
+        fields = fields.join(","),
+        "operator action",
+    );
+
     let entry = crate::audit::PendingEntry {
         entity_table,
         entity_pk: entity_pk.to_owned(),
@@ -1868,14 +1966,18 @@ async fn emit_registry_audit(
         changes: serde_json::Value::Object(changes),
     };
     if let Err(e) = crate::audit::emit_one_pool(registry, &entry).await {
-        tracing::warn!(
-            target: "rustango::tenancy::operator_console",
-            error = %e,
-            entity_table,
-            entity_pk,
+        // The action happened; only its durable record did not. Loud,
+        // because an audit trail with a hole in it is worse than one
+        // that is merely incomplete.
+        tracing::error!(
+            target: ACTION_TARGET,
+            event = "operator_action_unrecorded",
+            action = verb,
             operator_id,
-            verb,
-            "failed to record operator action in audit log",
+            entity = entity_table,
+            entity_id = entity_pk,
+            error = %e,
+            "operator action was NOT written to the audit log",
         );
     }
 }

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -611,6 +611,12 @@ fn router_inner(
                 "/orgs/{slug}/purge",
                 get(org_post_only_redirect).post(decommission::purge),
             )
+            // Probing an existing tenant, as opposed to the create
+            // form's probe of a URL being typed.
+            .route(
+                "/orgs/{slug}/test-connection",
+                post(provisioning::test_tenant_connection),
+            )
             .route("/orgs/{slug}/hosts", get(hosts::org_hosts_view))
             .route(
                 "/orgs/{slug}/hosts/add",

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -276,11 +276,11 @@ impl OpBrand {
 /// ## Authorization
 ///
 /// Every authenticated operator who can reach the console can use
-/// these routes. That is not an oversight to work around with a
-/// wrapper — `Operator` has no permission model at all today, so a
-/// single flag for a single route would be half a system. Mounting is
-/// the boundary that currently means something. A real operator
-/// permission model is tracked separately.
+/// these routes, by design (#1342): operators are uniformly fully
+/// capable, and there is no per-operator permission model to add one
+/// to. Authorization lives in which router a deployment assembles —
+/// [`router`] is read-only, [`router_with_pools`] can edit, this one
+/// can create tenants.
 #[must_use]
 pub fn router_with_provisioning(
     registry: impl Into<crate::sql::Pool>,

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -40,6 +40,7 @@
 
 /// Creating a tenant from the console, and watching it happen (#1322).
 /// Mounted only by [`router_with_provisioning`].
+mod audit;
 mod hosts;
 mod operators;
 mod provisioning;
@@ -504,6 +505,11 @@ fn router_inner(
             "op_provision_run.html",
             include_str!("../templates/op_provision_run.html"),
         ),
+        (
+            "op_provision_runs.html",
+            include_str!("../templates/op_provision_runs.html"),
+        ),
+        ("op_audit.html", include_str!("../templates/op_audit.html")),
     ])
     .expect("operator-console templates parse");
     let edit_enabled = pools.is_some();
@@ -535,6 +541,11 @@ fn router_inner(
         .route("/", get(welcome))
         .route("/operators", get(operators::operators_list))
         .route("/orgs", get(orgs_list))
+        // Read-only, so it is not behind the edit gate: a read-only
+        // console is exactly where "what happened?" still needs
+        // answering, and every operator can already see everything the
+        // log describes.
+        .route("/audit", get(audit::audit_list))
         .route(
             "/change-password",
             get(change_password_form).post(change_password_submit),
@@ -609,6 +620,10 @@ fn router_inner(
                 get(provisioning::org_new_form).post(provisioning::org_new_submit),
             )
             .route("/orgs/test-connection", post(provisioning::test_connection))
+            // The index has to come before the `{run_id}` route it
+            // shares a prefix with, and be a distinct path: a run id is
+            // numeric, so `/orgs/provision` cannot be confused for one.
+            .route("/orgs/provision", get(provisioning::provision_runs_index))
             .route(
                 "/orgs/provision/{run_id}",
                 get(provisioning::provision_run_view),

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -464,6 +464,10 @@ fn router_inner(
             include_str!("../templates/_op_styles.html"),
         ),
         (
+            "_op_pager.html",
+            include_str!("../templates/_op_pager.html"),
+        ),
+        (
             "_theme_toggle.html",
             include_str!("../../admin/templates/_theme_toggle.html"),
         ),
@@ -656,6 +660,136 @@ fn router_inner(
 /// Stamp the operator-console branding fields onto every render
 /// context. Centralizing the keys keeps op_layout.html and op_login.html
 /// in sync without each handler remembering the four template names.
+/// A screenful, for every list the console renders.
+///
+/// One number rather than one per page, so a deployment with thousands
+/// of tenants and one with three behave the same way and nobody has to
+/// remember which list was the unbounded one.
+pub(super) const PAGE_SIZE: usize = 50;
+
+/// One page of a console list.
+///
+/// A thin adapter over [`crate::pagination::Paginator`] — the
+/// framework's own page-number paginator, which is built for exactly
+/// this (server-rendered list views: `offset()`, `limit()`, and an
+/// elided `1 … 7 8 9 … 42` range). This type only counts the rows,
+/// hands the paginator the number, and flattens the result into
+/// template context.
+///
+/// Shared rather than written per view because the arithmetic has a
+/// trap in it: `?page=<huge>` parses into an `i64` and then overflows a
+/// naive `(page - 1) * size`, which panicked a worker thread in debug
+/// and wrapped to a negative offset in release. `Paginator::get_page`
+/// clamps instead, so no list view can reintroduce that and none can
+/// disagree about what page 1 means.
+pub(super) struct Paged {
+    pub(super) offset: i64,
+    pub(super) limit: i64,
+    number: usize,
+    total: usize,
+    num_pages: usize,
+    has_previous: bool,
+    has_next: bool,
+    marks: Vec<serde_json::Value>,
+}
+
+impl Paged {
+    /// From a total the caller already knows — a filtered count, say.
+    pub(super) fn from_total(total: i64, requested: Option<i64>) -> Self {
+        let total = usize::try_from(total).unwrap_or(0);
+        let paginator = crate::pagination::Paginator::new(total, PAGE_SIZE);
+        // `get_page` clamps rather than erroring: a page number out of
+        // range is a stale link, not something to show a 500 for.
+        let page = paginator.get_page(requested.unwrap_or(1));
+        let marks = paginator
+            .get_elided_page_range(page.number, 3, 2)
+            .into_iter()
+            .map(|mark| match mark {
+                crate::pagination::PageMark::Number(n) => serde_json::json!({"number": n}),
+                crate::pagination::PageMark::Ellipsis => serde_json::json!({"ellipsis": true}),
+            })
+            .collect();
+        Self {
+            offset: i64::try_from(page.offset()).unwrap_or(i64::MAX),
+            limit: i64::try_from(page.limit()).unwrap_or(i64::MAX),
+            number: page.number,
+            total,
+            num_pages: paginator.num_pages(),
+            has_previous: page.has_previous(),
+            has_next: page.has_next(),
+            marks,
+        }
+    }
+
+    /// Counting the model's rows first, for the lists with no filter.
+    pub(super) async fn of_model(
+        pool: &crate::sql::Pool,
+        model: &'static crate::core::ModelSchema,
+        requested: Option<i64>,
+    ) -> Result<Self, crate::sql::ExecError> {
+        let total = count_where(pool, model, crate::core::WhereExpr::default()).await?;
+        Ok(Self::from_total(total, requested))
+    }
+
+    /// What `_op_pager.html` needs.
+    ///
+    /// Key names match `template_views::ListView`'s so one partial
+    /// renders both. `base` is the path the links point at; `suffix`
+    /// carries active filters so paging does not drop them.
+    pub(super) fn inject(&self, ctx: &mut Context, base: &str, suffix: &str) {
+        ctx.insert("page", &self.number);
+        ctx.insert("total_pages", &self.num_pages);
+        ctx.insert("total", &self.total);
+        ctx.insert("has_prev", &self.has_previous);
+        ctx.insert("has_next", &self.has_next);
+        ctx.insert("page_marks", &self.marks);
+        ctx.insert("pager_base", base);
+        ctx.insert("query_suffix", suffix);
+    }
+}
+
+/// Which nav entry to highlight for a path.
+///
+/// Only the generic-view path needs this; the hand-written handlers
+/// set `section` themselves.
+#[cfg(feature = "template_views")]
+fn nav_section(path: &str) -> &'static str {
+    match path.split('/').nth(1).unwrap_or("") {
+        "orgs" => "orgs",
+        "operators" => "operators",
+        "audit" => "audit",
+        "sso-shared" => "sso",
+        "change-password" => "change_password",
+        _ => "home",
+    }
+}
+
+/// `SELECT COUNT(*)` over one model, optionally filtered.
+///
+/// Separate from [`Paged`] because a list view sometimes needs a count
+/// that is *not* its page count — the operator list pages its rows but
+/// still has to know how many operators are active in total, which a
+/// page of rows cannot tell it.
+pub(super) async fn count_where(
+    pool: &crate::sql::Pool,
+    model: &'static crate::core::ModelSchema,
+    where_clause: crate::core::WhereExpr,
+) -> Result<i64, crate::sql::ExecError> {
+    let count = crate::core::CountQuery {
+        model,
+        where_clause,
+        search: None,
+    };
+    crate::sql::count_rows_pool(pool, &count).await
+}
+
+/// The `?page=` parameter, for the list views that take nothing else.
+#[derive(Deserialize)]
+pub(super) struct PageQuery {
+    #[serde(default)]
+    pub(super) page: Option<i64>,
+}
+
 /// Render, or say why not.
 ///
 /// The console's older handlers use `.unwrap_or_default()`, which turns
@@ -748,6 +882,21 @@ async fn require_session(
                 if payload.iat < ts.timestamp() {
                     return redirect_to_login(&safe_next).into_response();
                 }
+            }
+            // The chrome `op_layout.html` needs, for any generic view
+            // an app mounts here: those build their context from the
+            // model and know nothing about this layout. Gated because
+            // `tenancy` does not depend on `template_views`.
+            #[cfg(feature = "template_views")]
+            {
+                let mut chrome = Context::new();
+                inject_op_brand(&mut chrome, &state.op_brand);
+                chrome.insert("operator_username", &op.username);
+                chrome.insert("section", &nav_section(uri.path()));
+                chrome.insert("edit_enabled", &state.pools.is_some());
+                chrome.insert("provisioning_enabled", &state.provisioner.is_some());
+                req.extensions_mut()
+                    .insert(crate::template_views::ExtraContext(chrome));
             }
             req.extensions_mut().insert(op);
             next.run(req).await
@@ -1144,8 +1293,24 @@ async fn welcome(
 async fn orgs_list(
     State(state): State<ConsoleState>,
     Extension(op): Extension<auth::Operator>,
+    Query(q): Query<PageQuery>,
 ) -> Response<Body> {
-    let rows: Vec<super::Org> = match super::Org::objects().fetch(&state.registry).await {
+    // Paged: this fetched every tenant, which is fine for the three a
+    // demo has and not for the thousands a real registry holds.
+    // Ordered so the page boundaries are stable between requests — an
+    // unordered `LIMIT` may hand back the same row on two pages.
+    use crate::core::Model as _;
+    let paged = match Paged::of_model(&state.registry, super::Org::SCHEMA, q.page).await {
+        Ok(p) => p,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
+    };
+    let rows: Vec<super::Org> = match super::Org::objects()
+        .order_by(&[("slug", false)])
+        .limit(paged.limit)
+        .offset(paged.offset)
+        .fetch(&state.registry)
+        .await
+    {
         Ok(r) => r,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
     };
@@ -1173,7 +1338,8 @@ async fn orgs_list(
     // exists but nothing links to it — which is exactly the state
     // this shipped in first.
     ctx.insert("provisioning_enabled", &state.provisioner.is_some());
-    Html(state.tera.render("op_orgs.html", &ctx).unwrap_or_default()).into_response()
+    paged.inject(&mut ctx, "/orgs", "");
+    render(&state, "op_orgs.html", &ctx)
 }
 
 // ---- Shared SSO providers (registry-wide, `admin-sso`) --------------

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -41,6 +41,7 @@
 /// Creating a tenant from the console, and watching it happen (#1322).
 /// Mounted only by [`router_with_provisioning`].
 mod hosts;
+mod operators;
 mod provisioning;
 
 use crate::core::Column as _;
@@ -532,7 +533,7 @@ fn router_inner(
     // Authenticated routes: the middleware injects an `Extension<auth::Operator>`.
     let mut private = Router::new()
         .route("/", get(welcome))
-        .route("/operators", get(operators_list))
+        .route("/operators", get(operators::operators_list))
         .route("/orgs", get(orgs_list))
         .route(
             "/change-password",
@@ -549,6 +550,22 @@ fn router_inner(
     }
     if edit_enabled {
         private = private
+            // Who can sign in to this console. Behind the same gate as
+            // the tenant writes: `edit_enabled` is named for its first
+            // use (dropping a cached pool when a `database_url`
+            // rotates) but is in practice the switch between the
+            // read-only `router()` and a console that can change
+            // things, and creating an operator is emphatically the
+            // latter.
+            .route("/operators", post(operators::operator_create))
+            .route(
+                "/operators/{id}/active",
+                get(op_post_only_redirect).post(operators::operator_set_active),
+            )
+            .route(
+                "/operators/{id}/reset-password",
+                get(op_post_only_redirect).post(operators::operator_reset_password),
+            )
             .route(
                 "/orgs/{slug}/edit",
                 get(org_edit_form).post(org_edit_submit),
@@ -736,6 +753,12 @@ async fn org_post_only_redirect(
     axum::extract::Path(slug): axum::extract::Path<String>,
 ) -> Redirect {
     Redirect::to(&format!("/orgs/{slug}/edit"))
+}
+
+/// The same bounce for the operator routes, which are keyed by id
+/// rather than slug and land back on the one list page.
+async fn op_post_only_redirect() -> Redirect {
+    Redirect::to("/operators")
 }
 
 /// v0.27.10 (#68) — when an unauthenticated non-GET request
@@ -1101,39 +1124,6 @@ async fn welcome(
             .render("op_welcome.html", &ctx)
             .unwrap_or_default(),
     )
-}
-
-async fn operators_list(
-    State(state): State<ConsoleState>,
-    Extension(op): Extension<auth::Operator>,
-) -> Response<Body> {
-    let rows: Vec<auth::Operator> = match auth::Operator::objects().fetch(&state.registry).await {
-        Ok(r) => r,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")).into_response(),
-    };
-    let view: Vec<_> = rows
-        .into_iter()
-        .map(|o| {
-            serde_json::json!({
-                "id": o.id.get().copied().unwrap_or_default(),
-                "username": o.username,
-                "active": o.active,
-                "created_at": o.created_at.format("%Y-%m-%d %H:%M UTC").to_string(),
-            })
-        })
-        .collect();
-    let mut ctx = Context::new();
-    inject_op_brand(&mut ctx, &state.op_brand);
-    ctx.insert("section", "operators");
-    ctx.insert("operator_username", &op.username);
-    ctx.insert("operators", &view);
-    Html(
-        state
-            .tera
-            .render("op_operators.html", &ctx)
-            .unwrap_or_default(),
-    )
-    .into_response()
 }
 
 async fn orgs_list(
@@ -1620,18 +1610,33 @@ async fn emit_op_audit(
     verb: &str,
     extra: serde_json::Map<String, serde_json::Value>,
 ) {
-    let mut changes = serde_json::Map::new();
+    let mut changes = extra;
     changes.insert(
         "tenant_slug".into(),
         serde_json::Value::String(slug.to_owned()),
     );
+    emit_registry_audit(registry, "rustango_orgs", slug, operator_id, verb, changes).await;
+}
+
+/// The same trail for an action whose subject is not a tenant.
+///
+/// `emit_op_audit` above hardcodes `rustango_orgs`, which is right for
+/// everything that acts on a tenant and wrong for everything else —
+/// operator management acts on `rustango_operators`, and recording that
+/// under the orgs table would make the entity column a lie.
+async fn emit_registry_audit(
+    registry: &crate::sql::Pool,
+    entity_table: &'static str,
+    entity_pk: &str,
+    operator_id: i64,
+    verb: &str,
+    extra: serde_json::Map<String, serde_json::Value>,
+) {
+    let mut changes = extra;
     changes.insert("operator_id".into(), serde_json::json!(operator_id));
-    for (k, v) in extra {
-        changes.insert(k, v);
-    }
     let entry = crate::audit::PendingEntry {
-        entity_table: "rustango_orgs",
-        entity_pk: slug.to_owned(),
+        entity_table,
+        entity_pk: entity_pk.to_owned(),
         operation: crate::audit::AuditOp::Action,
         source: crate::audit::AuditSource::Custom(format!("operator:{operator_id}:{verb}")),
         changes: serde_json::Value::Object(changes),
@@ -1640,7 +1645,8 @@ async fn emit_op_audit(
         tracing::warn!(
             target: "rustango::tenancy::operator_console",
             error = %e,
-            slug = slug,
+            entity_table,
+            entity_pk,
             operator_id,
             verb,
             "failed to record operator action in audit log",

--- a/crates/rustango/src/tenancy/operator_console/operators.rs
+++ b/crates/rustango/src/tenancy/operator_console/operators.rs
@@ -47,7 +47,7 @@ use tera::Context;
 use super::super::auth;
 use super::super::password;
 use super::{inject_op_brand, render, ConsoleState};
-use crate::core::Column as _;
+use crate::core::{Column as _, Model as _};
 use crate::sql::{Auto, FetcherPool as _};
 
 /// The column's limit. A longer username is truncated by some backends
@@ -65,6 +65,8 @@ pub(super) struct OperatorsQuery {
     error: Option<String>,
     #[serde(default)]
     notice: Option<String>,
+    #[serde(default)]
+    page: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -106,7 +108,15 @@ pub(super) async fn operators_list(
     Extension(op): Extension<auth::Operator>,
     Query(q): Query<OperatorsQuery>,
 ) -> Response<Body> {
-    page(&state, &op, q.error.as_deref(), q.notice.as_deref(), None).await
+    page(
+        &state,
+        &op,
+        q.error.as_deref(),
+        q.notice.as_deref(),
+        None,
+        q.page,
+    )
+    .await
 }
 
 /// Render the list, optionally with a freshly generated password to
@@ -117,13 +127,48 @@ async fn page(
     error: Option<&str>,
     notice: Option<&str>,
     secret: Option<(&str, &str)>,
+    requested_page: Option<i64>,
 ) -> Response<Body> {
-    let rows: Vec<auth::Operator> = match all_operators(state).await {
+    use crate::core::Model as _;
+
+    let paged =
+        match super::Paged::of_model(&state.registry, auth::Operator::SCHEMA, requested_page).await
+        {
+            Ok(p) => p,
+            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        };
+    let rows: Vec<auth::Operator> = match auth::Operator::objects()
+        .order_by(&[("username", false)])
+        .limit(paged.limit)
+        .offset(paged.offset)
+        .fetch(&state.registry)
+        .await
+    {
         Ok(r) => r,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not read the operator list: {e}"),
+            )
+                .into_response();
+        }
     };
     let me = id_of(op);
-    let active_count = rows.iter().filter(|o| o.active).count();
+
+    // Counted across the whole table, not this page. "Is this the last
+    // active operator?" is a question about the registry, and a page of
+    // rows cannot answer it — on page 2 of a long list every row would
+    // have looked like the last one.
+    let active_count = match super::count_where(
+        &state.registry,
+        auth::Operator::SCHEMA,
+        auth::Operator::active.eq(true).into(),
+    )
+    .await
+    {
+        Ok(n) => usize::try_from(n).unwrap_or(usize::MAX),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
 
     let view: Vec<_> = rows
         .iter()
@@ -150,6 +195,7 @@ async fn page(
     ctx.insert("operator_username", &op.username);
     ctx.insert("operators", &view);
     ctx.insert("manage_enabled", &state.pools.is_some());
+    paged.inject(&mut ctx, "/operators", "");
     ctx.insert("error", &error);
     ctx.insert("notice", &notice);
     if let Some((username, plain)) = secret {
@@ -236,7 +282,7 @@ pub(super) async fn operator_create(
 
     if generated {
         // Rendered here, not redirected to — see the module docs.
-        page(&state, &op, None, None, Some((&username, &plain))).await
+        page(&state, &op, None, None, Some((&username, &plain)), None).await
     } else {
         back_ok(&format!("created operator `{username}`"))
     }
@@ -279,33 +325,31 @@ pub(super) async fn operator_set_active(
             )
             .await;
         }
-        // Everyone active *except* the one being deactivated. Counting
-        // the target too would refuse the last legitimate deactivation
-        // and permit nothing extra.
-        //
-        // With the self-check above, this is unreachable single-handed:
-        // the session owner is active by definition, so deactivating
-        // somebody else always leaves at least them. It is here for two
-        // operators acting at once, where both read "two active" and
-        // both deactivate — the window is narrow rather than closed,
-        // which is the honest description of a check-then-act.
-        match all_operators(&state).await {
-            Ok(rows) => {
-                let others = rows
-                    .iter()
-                    .filter(|o| o.active && o.id.get().copied().unwrap_or_default() != id)
-                    .count();
-                if others == 0 {
-                    return back_err(
-                        &state,
-                        &op,
-                        "This is the last active operator. Deactivating it would lock everyone \
-                         out of the console, and only a shell on the registry could undo it.",
-                    )
-                    .await;
-                }
+        // Everyone active *except* the target. With the self-check
+        // above this is unreachable single-handed; it covers two
+        // operators deactivating each other at once, where both read
+        // "two active". A narrow window, not a closed one.
+        let others = super::count_where(
+            &state.registry,
+            auth::Operator::SCHEMA,
+            auth::Operator::active
+                .eq(true)
+                .and(auth::Operator::id.ne(id))
+                .into(),
+        )
+        .await;
+        match others {
+            Ok(0) => {
+                return back_err(
+                    &state,
+                    &op,
+                    "This is the last active operator. Deactivating it would lock everyone out \
+                     of the console, and only a shell on the registry could undo it.",
+                )
+                .await;
             }
-            Err(e) => return back_err(&state, &op, &e).await,
+            Ok(_) => {}
+            Err(e) => return back_err(&state, &op, &e.to_string()).await,
         }
     }
 
@@ -363,7 +407,7 @@ pub(super) async fn operator_reset_password(
 
     if generated {
         let username = target.username.clone();
-        page(&state, &op, None, None, Some((&username, &plain))).await
+        page(&state, &op, None, None, Some((&username, &plain)), None).await
     } else {
         back_ok(&format!(
             "reset the password for `{}` — they are now signed out everywhere",
@@ -396,13 +440,6 @@ fn chosen_password(generate: bool, typed: &str, confirm: &str) -> Result<String,
     Ok(typed.to_owned())
 }
 
-async fn all_operators(state: &ConsoleState) -> Result<Vec<auth::Operator>, String> {
-    auth::Operator::objects()
-        .fetch(&state.registry)
-        .await
-        .map_err(|e| format!("could not read the operator list: {e}"))
-}
-
 async fn one_operator(state: &ConsoleState, id: i64) -> Result<Option<auth::Operator>, String> {
     auth::Operator::objects()
         .where_(auth::Operator::id.eq(id))
@@ -426,9 +463,9 @@ fn back_ok(notice: &str) -> Response<Body> {
 }
 
 /// Re-render with the reason rather than redirecting, so a long message
-/// does not have to survive a URL.
+/// need not survive a URL.
 async fn back_err(state: &ConsoleState, op: &auth::Operator, msg: &str) -> Response<Body> {
-    page(state, op, Some(msg), None, None).await
+    page(state, op, Some(msg), None, None, None).await
 }
 
 async fn audit(

--- a/crates/rustango/src/tenancy/operator_console/operators.rs
+++ b/crates/rustango/src/tenancy/operator_console/operators.rs
@@ -1,0 +1,494 @@
+//! Managing who can sign in to the operator console, from the console.
+//!
+//! The page used to be a table with a paragraph telling the reader to
+//! leave: *"Mutations go through `cargo run -- create-operator`"*. So
+//! onboarding a colleague, locking out someone who left, or rescuing an
+//! operator who forgot their password all required shell access to the
+//! production host — for the one surface whose entire job is
+//! administering the deployment.
+//!
+//! ## Deactivate, never delete
+//!
+//! `active = false` is what the CLI offers and what the audit trail
+//! wants: the row stays, so a later "who was this?" still resolves.
+//! [`super::require_session`] re-reads the row on **every** request and
+//! filters on `active`, so a deactivation takes effect on the target's
+//! next click rather than whenever their cookie happens to expire.
+//!
+//! ## The two locks this page must not let you turn
+//!
+//! Deactivating **yourself** ends your own session on the next request.
+//! Deactivating the **last active operator** ends everyone's, and there
+//! is no console path back — recovery means a shell on the registry.
+//! Both are refused here, for the same reason the base host has no
+//! delete button: an action whose only outcome is losing access to the
+//! thing you are using should not be one click away.
+//!
+//! ## Passwords
+//!
+//! A reset rotates `password_changed_at`, and `require_session` rejects
+//! any session issued before it, so a reset signs that operator out
+//! everywhere. The page says so, because an operator resetting a
+//! colleague's password should know it will interrupt them.
+//!
+//! A generated password is rendered **directly in the POST response**
+//! rather than carried through a redirect. It is a secret, and a
+//! redirect would put it in the URL bar, the history, the referrer and
+//! every access log between here and the browser.
+
+use axum::body::Body;
+use axum::extract::{Form, Path, Query, State};
+use axum::http::{header, Response, StatusCode};
+use axum::response::{IntoResponse, Redirect};
+use axum::Extension;
+use serde::Deserialize;
+use tera::Context;
+
+use super::super::auth;
+use super::super::password;
+use super::{inject_op_brand, render, ConsoleState};
+use crate::core::Column as _;
+use crate::sql::{Auto, FetcherPool as _};
+
+/// The column's limit. A longer username is truncated by some backends
+/// and rejected by others; neither is a good way to find out.
+const USERNAME_MAX: usize = 64;
+
+/// Matches the console's own change-password rule, so the two places
+/// that set an operator password cannot disagree about what is
+/// acceptable.
+const PASSWORD_MIN: usize = 8;
+
+#[derive(Deserialize)]
+pub(super) struct OperatorsQuery {
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    notice: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct CreateForm {
+    #[serde(default)]
+    username: String,
+    #[serde(default)]
+    password: String,
+    #[serde(default)]
+    confirm_password: String,
+    /// Present when the operator asked for a random password instead of
+    /// typing one.
+    #[serde(default)]
+    generate: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ResetForm {
+    #[serde(default)]
+    password: String,
+    #[serde(default)]
+    confirm_password: String,
+    #[serde(default)]
+    generate: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ActiveForm {
+    /// Present and `"on"` to activate; absent to deactivate — the shape
+    /// a checkbox posts.
+    #[serde(default)]
+    active: Option<String>,
+}
+
+// ------------------------------------------------------------- listing
+
+pub(super) async fn operators_list(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Query(q): Query<OperatorsQuery>,
+) -> Response<Body> {
+    page(&state, &op, q.error.as_deref(), q.notice.as_deref(), None).await
+}
+
+/// Render the list, optionally with a freshly generated password to
+/// show once.
+async fn page(
+    state: &ConsoleState,
+    op: &auth::Operator,
+    error: Option<&str>,
+    notice: Option<&str>,
+    secret: Option<(&str, &str)>,
+) -> Response<Body> {
+    let rows: Vec<auth::Operator> = match all_operators(state).await {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    };
+    let me = id_of(op);
+    let active_count = rows.iter().filter(|o| o.active).count();
+
+    let view: Vec<_> = rows
+        .iter()
+        .map(|o| {
+            let id = o.id.get().copied().unwrap_or_default();
+            serde_json::json!({
+                "id": id,
+                "username": o.username,
+                "active": o.active,
+                "created_at": o.created_at.format("%Y-%m-%d %H:%M UTC").to_string(),
+                "password_changed_at": o.password_changed_at
+                    .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string()),
+                "is_self": id == me,
+                // Why the control is absent, so the page can say it
+                // rather than just omit a button.
+                "last_active": o.active && active_count <= 1,
+            })
+        })
+        .collect();
+
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "operators");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("operators", &view);
+    ctx.insert("manage_enabled", &state.pools.is_some());
+    ctx.insert("error", &error);
+    ctx.insert("notice", &notice);
+    if let Some((username, plain)) = secret {
+        ctx.insert("new_username", username);
+        ctx.insert("new_password", plain);
+    }
+
+    let mut resp = render(state, "op_operators.html", &ctx);
+    if secret.is_some() {
+        // A page body holding a plaintext password must not sit in a
+        // disk cache or come back on a Back-button replay.
+        resp.headers_mut().insert(
+            header::CACHE_CONTROL,
+            header::HeaderValue::from_static("no-store, max-age=0"),
+        );
+    }
+    resp
+}
+
+// -------------------------------------------------------------- create
+
+pub(super) async fn operator_create(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Form(form): Form<CreateForm>,
+) -> Response<Body> {
+    let username = form.username.trim().to_owned();
+    if username.is_empty() {
+        return back_err(&state, &op, "A username is required.").await;
+    }
+    if username.chars().count() > USERNAME_MAX {
+        return back_err(
+            &state,
+            &op,
+            &format!("A username may be at most {USERNAME_MAX} characters."),
+        )
+        .await;
+    }
+
+    // Up front, so a duplicate reads as a duplicate rather than as
+    // whatever the unique index says.
+    match auth::Operator::objects()
+        .where_(auth::Operator::username.eq(username.clone()))
+        .fetch(&state.registry)
+        .await
+    {
+        Ok(existing) => {
+            if !existing.is_empty() {
+                return back_err(
+                    &state,
+                    &op,
+                    &format!("An operator named `{username}` already exists."),
+                )
+                .await;
+            }
+        }
+        Err(e) => return back_err(&state, &op, &format!("Registry lookup failed: {e}")).await,
+    }
+
+    let generated = form.generate.is_some();
+    let plain = match chosen_password(generated, &form.password, &form.confirm_password) {
+        Ok(p) => p,
+        Err(msg) => return back_err(&state, &op, &msg).await,
+    };
+
+    let hash = match password::hash(&plain) {
+        Ok(h) => h,
+        Err(e) => return back_err(&state, &op, &format!("Could not hash password: {e}")).await,
+    };
+
+    let mut row = auth::Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: hash,
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    if let Err(e) = row.insert_pool(&state.registry).await {
+        return back_err(&state, &op, &format!("Could not create the operator: {e}")).await;
+    }
+
+    audit(&state, &op, id_of(&row), "operator_create", &username).await;
+
+    if generated {
+        // Rendered here, not redirected to — see the module docs.
+        page(&state, &op, None, None, Some((&username, &plain))).await
+    } else {
+        back_ok(&format!("created operator `{username}`"))
+    }
+}
+
+// ------------------------------------------------------ activate / not
+
+pub(super) async fn operator_set_active(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(id): Path<i64>,
+    Form(form): Form<ActiveForm>,
+) -> Response<Body> {
+    let activate = form.active.is_some();
+    let mut target = match one_operator(&state, id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return back_err(&state, &op, "No such operator.").await,
+        Err(e) => return back_err(&state, &op, &e).await,
+    };
+
+    // Before the guards, not after: deactivating an already-inactive
+    // operator changes nothing, and running the lockout check on it
+    // answered "this is the last active operator" about an operator who
+    // was not active at all.
+    if target.active == activate {
+        return back_ok(&format!(
+            "`{}` was already {}",
+            target.username,
+            if activate { "active" } else { "inactive" }
+        ));
+    }
+
+    if !activate {
+        if id == id_of(&op) {
+            return back_err(
+                &state,
+                &op,
+                "You cannot deactivate yourself — your next request would be rejected. Ask \
+                 another operator to do it.",
+            )
+            .await;
+        }
+        // Everyone active *except* the one being deactivated. Counting
+        // the target too would refuse the last legitimate deactivation
+        // and permit nothing extra.
+        //
+        // With the self-check above, this is unreachable single-handed:
+        // the session owner is active by definition, so deactivating
+        // somebody else always leaves at least them. It is here for two
+        // operators acting at once, where both read "two active" and
+        // both deactivate — the window is narrow rather than closed,
+        // which is the honest description of a check-then-act.
+        match all_operators(&state).await {
+            Ok(rows) => {
+                let others = rows
+                    .iter()
+                    .filter(|o| o.active && o.id.get().copied().unwrap_or_default() != id)
+                    .count();
+                if others == 0 {
+                    return back_err(
+                        &state,
+                        &op,
+                        "This is the last active operator. Deactivating it would lock everyone \
+                         out of the console, and only a shell on the registry could undo it.",
+                    )
+                    .await;
+                }
+            }
+            Err(e) => return back_err(&state, &op, &e).await,
+        }
+    }
+
+    target.active = activate;
+    if let Err(e) = target.save_pool(&state.registry).await {
+        return back_err(&state, &op, &format!("Could not save: {e}")).await;
+    }
+
+    let verb = if activate {
+        "operator_activate"
+    } else {
+        "operator_deactivate"
+    };
+    audit(&state, &op, id, verb, &target.username).await;
+    back_ok(&format!(
+        "{} `{}`",
+        if activate { "activated" } else { "deactivated" },
+        target.username
+    ))
+}
+
+// ------------------------------------------------------ reset password
+
+pub(super) async fn operator_reset_password(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Path(id): Path<i64>,
+    Form(form): Form<ResetForm>,
+) -> Response<Body> {
+    let mut target = match one_operator(&state, id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return back_err(&state, &op, "No such operator.").await,
+        Err(e) => return back_err(&state, &op, &e).await,
+    };
+
+    let generated = form.generate.is_some();
+    let plain = match chosen_password(generated, &form.password, &form.confirm_password) {
+        Ok(p) => p,
+        Err(msg) => return back_err(&state, &op, &msg).await,
+    };
+    let hash = match password::hash(&plain) {
+        Ok(h) => h,
+        Err(e) => return back_err(&state, &op, &format!("Could not hash password: {e}")).await,
+    };
+
+    target.password_hash = hash;
+    // What actually signs them out: `require_session` rejects any
+    // session whose `iat` predates this.
+    target.password_changed_at = Some(chrono::Utc::now());
+    if let Err(e) = target.save_pool(&state.registry).await {
+        return back_err(&state, &op, &format!("Could not save: {e}")).await;
+    }
+
+    audit(&state, &op, id, "operator_reset_password", &target.username).await;
+
+    if generated {
+        let username = target.username.clone();
+        page(&state, &op, None, None, Some((&username, &plain))).await
+    } else {
+        back_ok(&format!(
+            "reset the password for `{}` — they are now signed out everywhere",
+            target.username
+        ))
+    }
+}
+
+// ------------------------------------------------------------- helpers
+
+/// The password to store, or why neither route produced one.
+fn chosen_password(generate: bool, typed: &str, confirm: &str) -> Result<String, String> {
+    if generate {
+        if !typed.is_empty() {
+            return Err("Choose one: generate a password, or type one. Both were supplied.".into());
+        }
+        return Ok(password::generate(20));
+    }
+    if typed.is_empty() {
+        return Err("A password is required.".into());
+    }
+    if typed != confirm {
+        return Err("The password and its confirmation did not match.".into());
+    }
+    if typed.chars().count() < PASSWORD_MIN {
+        return Err(format!(
+            "A password must be at least {PASSWORD_MIN} characters."
+        ));
+    }
+    Ok(typed.to_owned())
+}
+
+async fn all_operators(state: &ConsoleState) -> Result<Vec<auth::Operator>, String> {
+    auth::Operator::objects()
+        .fetch(&state.registry)
+        .await
+        .map_err(|e| format!("could not read the operator list: {e}"))
+}
+
+async fn one_operator(state: &ConsoleState, id: i64) -> Result<Option<auth::Operator>, String> {
+    auth::Operator::objects()
+        .where_(auth::Operator::id.eq(id))
+        .fetch(&state.registry)
+        .await
+        .map(|rows: Vec<auth::Operator>| rows.into_iter().next())
+        .map_err(|e| format!("could not read the operator: {e}"))
+}
+
+fn id_of(op: &auth::Operator) -> i64 {
+    op.id.get().copied().unwrap_or_default()
+}
+
+/// Post/Redirect/Get on success, so a reload does not repeat the write.
+fn back_ok(notice: &str) -> Response<Body> {
+    Redirect::to(&format!(
+        "/operators?notice={}",
+        crate::url_codec::url_encode(notice)
+    ))
+    .into_response()
+}
+
+/// Re-render with the reason rather than redirecting, so a long message
+/// does not have to survive a URL.
+async fn back_err(state: &ConsoleState, op: &auth::Operator, msg: &str) -> Response<Body> {
+    page(state, op, Some(msg), None, None).await
+}
+
+async fn audit(
+    state: &ConsoleState,
+    actor: &auth::Operator,
+    subject_id: i64,
+    verb: &str,
+    subject_username: &str,
+) {
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "target_username".into(),
+        serde_json::Value::String(subject_username.to_owned()),
+    );
+    super::emit_registry_audit(
+        &state.registry,
+        "rustango_operators",
+        &subject_id.to_string(),
+        id_of(actor),
+        verb,
+        extra,
+    )
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_generated_password_needs_no_typing_and_refuses_both() {
+        let p = chosen_password(true, "", "").expect("generate");
+        assert!(p.chars().count() >= 20, "should be long: {p}");
+        assert!(
+            chosen_password(true, "typed", "typed").is_err(),
+            "supplying both is ambiguous and should be refused"
+        );
+    }
+
+    #[test]
+    fn a_typed_password_must_be_confirmed_and_long_enough() {
+        assert!(chosen_password(false, "", "").is_err(), "empty");
+        assert!(
+            chosen_password(false, "longenough", "different").is_err(),
+            "mismatched confirmation"
+        );
+        assert!(
+            chosen_password(false, "short", "short").is_err(),
+            "too short"
+        );
+        assert_eq!(
+            chosen_password(false, "longenough", "longenough").as_deref(),
+            Ok("longenough")
+        );
+    }
+
+    /// The console's own change-password form refuses anything under 8,
+    /// and two places that set the same field must not disagree.
+    #[test]
+    fn the_minimum_matches_the_change_password_form() {
+        assert_eq!(PASSWORD_MIN, 8);
+    }
+}

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -331,6 +331,69 @@ pub(super) async fn test_connection(
 
 // ------------------------------------------------------------ run view
 
+/// Probe an *existing* tenant's database.
+///
+/// The create form's probe takes a URL from the form, which an existing
+/// tenant cannot use: its URL carries a password and may be a secret
+/// reference. This resolves server-side from the slug, so the URL never
+/// reaches the browser.
+///
+/// Without it, testing a tenant whose database moved meant starting to
+/// create a different tenant and borrowing that button.
+pub(super) async fn test_tenant_connection(
+    State(state): State<ConsoleState>,
+    Extension(_op): Extension<auth::Operator>,
+    Path(slug): Path<String>,
+) -> Response<Body> {
+    use crate::core::Column as _;
+    use crate::sql::FetcherPool as _;
+
+    let Some(pools) = state.pools.clone() else {
+        return probe_bad("This console is read-only.");
+    };
+    let rows: Vec<super::super::Org> = match super::super::Org::objects()
+        .where_(super::super::Org::slug.eq(slug.clone()))
+        .fetch(&state.registry)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return probe_bad(&format!("could not read the tenant: {e}")),
+    };
+    let Some(org) = rows.into_iter().next() else {
+        return probe_bad(&format!("No tenant `{slug}`."));
+    };
+
+    if org.database_url.is_none() {
+        return Html(
+            "<p class=\"probe probe-ok\">Schema-mode: this tenant lives in the registry's own \
+             database, which is already connected. There is no separate connection to test.</p>"
+                .to_owned(),
+        )
+        .into_response();
+    }
+
+    let url = match pools.resolved_database_url(&org).await {
+        Ok(u) => u,
+        Err(e) => return probe_bad(&e.to_string()),
+    };
+    match preflight::check(&url, &Preflight::default()).await {
+        Ok(ok) => Html(format!(
+            "<p class=\"probe probe-ok\">Reached <code>{}</code>. This role can create tables.</p>",
+            html_escape(&ok.endpoint)
+        ))
+        .into_response(),
+        Err(d) => probe_bad(&d.to_string()),
+    }
+}
+
+fn probe_bad(message: &str) -> Response<Body> {
+    Html(format!(
+        "<p class=\"probe probe-bad\">{}</p>",
+        html_escape(message)
+    ))
+    .into_response()
+}
+
 /// Every provisioning run, newest first.
 ///
 /// A run was reachable only by its id — in practice only from the

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -21,13 +21,10 @@
 //!
 //! Provisioning routes are mounted **only** when the deployment builds
 //! the console through [`super::router_with_provisioning`]. That is a
-//! deliberate deployment-level gate rather than a per-operator
-//! permission, because `Operator` has no permission model at all
-//! today — every authenticated operator can already do everything the
-//! console exposes. Adding one flag for one route would be half a
-//! permission system; the gate that actually means something right now
-//! is whether the console can create tenants *at all*. A real operator
-//! permission model is worth its own issue.
+//! deployment-level gate, and it is the only one: operators are
+//! uniformly fully capable by design (#1342), so there is no
+//! per-operator permission to check here and none is coming. What a
+//! console can do is decided when it is assembled, not per request.
 
 use std::collections::HashMap;
 use std::time::Duration;

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -38,7 +38,6 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::Form;
-use serde::Deserialize;
 use tera::Context;
 
 use super::{inject_op_brand, ConsoleState};
@@ -332,37 +331,30 @@ pub(super) async fn test_connection(
 
 // ------------------------------------------------------------ run view
 
-/// How many runs a page of the index shows.
-const RUNS_PAGE_SIZE: i64 = 50;
-
-#[derive(Deserialize)]
-pub(super) struct RunsQuery {
-    #[serde(default)]
-    page: Option<i64>,
-}
-
 /// Every provisioning run, newest first.
 ///
-/// A run was reachable only by its id, which meant only from the
-/// redirect that created it: navigate away and the record survived in
-/// the table but not in anybody's reach. The runs are persisted so they
-/// outlive the request, and this is what makes that worth anything —
-/// including for the runs that failed, which are the ones somebody
-/// comes back to.
+/// A run was reachable only by its id — in practice only from the
+/// redirect that created it, so navigating away stranded the record.
 pub(super) async fn provision_runs_index(
     State(state): State<ConsoleState>,
     Extension(op): Extension<auth::Operator>,
-    Query(q): Query<RunsQuery>,
+    Query(q): Query<super::PageQuery>,
 ) -> Response<Body> {
-    // Saturating: a page number large enough to overflow the multiply
-    // parses into an `i64` fine and then panicked the worker. Clamped,
-    // an absurd page is just an empty one.
-    let page = q.page.unwrap_or(1).max(1);
-    let offset = page.saturating_sub(1).saturating_mul(RUNS_PAGE_SIZE);
+    use crate::core::Model as _;
 
-    // One more than a page, so "is there an older page?" costs no
-    // second query.
-    let mut runs = match store::recent_runs(&state.registry, RUNS_PAGE_SIZE + 1, offset).await {
+    let paged =
+        match super::Paged::of_model(&state.registry, store::ProvisioningRun::SCHEMA, q.page).await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("could not count the runs: {e}"),
+                )
+                    .into_response();
+            }
+        };
+    let runs = match store::recent_runs(&state.registry, paged.limit, paged.offset).await {
         Ok(r) => r,
         Err(e) => {
             return (
@@ -372,9 +364,6 @@ pub(super) async fn provision_runs_index(
                 .into_response();
         }
     };
-    let page_len = usize::try_from(RUNS_PAGE_SIZE).unwrap_or(usize::MAX);
-    let has_next = runs.len() > page_len;
-    runs.truncate(page_len);
 
     let view: Vec<_> = runs
         .iter()
@@ -405,8 +394,7 @@ pub(super) async fn provision_runs_index(
     ctx.insert("section", "orgs");
     ctx.insert("operator_username", &op.username);
     ctx.insert("runs", &view);
-    ctx.insert("page", &page);
-    ctx.insert("has_next", &has_next);
+    paged.inject(&mut ctx, "/orgs/provision", "");
     render(&state, "op_provision_runs.html", &ctx)
 }
 

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -327,6 +327,23 @@ pub(super) async fn test_connection(
     };
     let url = url.as_str();
 
+    // Answer the same question the submit will, including the one
+    // refusal that has nothing to do with reachability. The registry's
+    // own database is reachable and this role *can* create tables in
+    // it, so the probe used to report "migrations will run" for the
+    // single target provisioning refuses outright — blessing, in its
+    // most confident wording, the mistake that ran the tenant
+    // migration chain over the registry.
+    if let Some(p) = state.provisioner.as_ref() {
+        if let Err(msg) = provision::refuse_registry_url(url, &p.registry_url()) {
+            return Html(format!(
+                "<p class=\"probe probe-bad\">{}</p>",
+                html_escape(&msg)
+            ))
+            .into_response();
+        }
+    }
+
     match preflight::check(url, &Preflight::default()).await {
         Ok(ok) => Html(format!(
             "<p class=\"probe probe-ok\">Reached <code>{}</code>. \

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -41,10 +41,11 @@ use axum::Form;
 use tera::Context;
 
 use super::{inject_op_brand, ConsoleState};
+use crate::sql::connect_diagnosis::redact;
 use crate::tenancy::auth;
 use crate::tenancy::org::{BackendKind, StorageMode};
 use crate::tenancy::preflight::{self, Preflight};
-use crate::tenancy::provision::ProvisionRequest;
+use crate::tenancy::provision::{self, ProvisionRequest};
 use crate::tenancy::provision_store::{self as store, RunState};
 
 /// How often the stream looks for new events.
@@ -89,7 +90,46 @@ fn render_form(
         "schema_mode_available",
         &(state.registry.dialect().name() == "postgres"),
     );
+    // Only backends this binary can actually speak. Listing all three
+    // unconditionally meant an operator could pick `sqlite` on a
+    // Postgres-only build and be told to edit `Cargo.toml` — advice
+    // aimed at a developer, for a choice the form itself offered.
+    ctx.insert("backends", &compiled_backends());
+    // What a derived URL will look like, with the password removed.
+    // The real one is built server-side at submit time; the browser
+    // never sees the registry's credentials.
+    ctx.insert(
+        "derived_url_example",
+        &state
+            .provisioner
+            .as_ref()
+            .and_then(|p| {
+                provision::tenant_url_on_registry_server(&p.registry_url(), "tenant_<slug>")
+            })
+            .map(|u| redact(&u)),
+    );
     render(state, "op_orgs_new.html", &ctx)
+}
+
+/// The backends this binary was built with.
+///
+/// Compile-time truth, not a hardcoded list: a form must not offer a
+/// choice the binary cannot honour.
+fn compiled_backends() -> Vec<&'static str> {
+    // Written as pushes rather than one `vec![]` because each entry is
+    // independently `#[cfg]`-gated; clippy's `vec![]` suggestion does
+    // not apply to a conditionally-built list.
+    #[allow(clippy::vec_init_then_push)]
+    {
+        let mut out = Vec::new();
+        #[cfg(feature = "postgres")]
+        out.push("postgres");
+        #[cfg(feature = "mysql")]
+        out.push("mysql");
+        #[cfg(feature = "sqlite")]
+        out.push("sqlite");
+        out
+    }
 }
 
 /// Render, or say why not.
@@ -127,7 +167,14 @@ fn render(state: &ConsoleState, template: &str, ctx: &Context) -> Response<Body>
 }
 
 /// Turn the submitted form into a request, or say what is wrong with it.
-fn request_from_form(form: &HashMap<String, String>) -> Result<ProvisionRequest, String> {
+///
+/// `registry_url` is used to derive the tenant's URL when the operator
+/// supplied a database *name* rather than a full URL — see
+/// [`provision::tenant_url_on_registry_server`]. It is never rendered.
+fn request_from_form(
+    form: &HashMap<String, String>,
+    registry_url: Option<&str>,
+) -> Result<ProvisionRequest, String> {
     let field = |k: &str| form.get(k).map(|v| v.trim()).filter(|v| !v.is_empty());
 
     let slug = field("slug")
@@ -152,12 +199,46 @@ fn request_from_form(form: &HashMap<String, String>) -> Result<ProvisionRequest,
         None => None,
     };
 
+    // Where the tenant's database URL comes from, in order of
+    // deference to what the operator actually said:
+    //
+    // 1. an explicit URL (the advanced escape hatch — another server);
+    // 2. a database *name* on the registry's server, derived here so
+    //    the registry password never reaches the browser and never
+    //    travels back in a form post;
+    // 3. nothing, for schema-mode, which has no separate database.
+    let database_url = match (mode, field("database_url")) {
+        (StorageMode::Schema, _) => None,
+        (_, Some(explicit)) => Some(explicit.to_owned()),
+        (_, None) => {
+            // A blank database name means the default the form shows:
+            // `tenant_<slug>`. Applying it here and not only in the
+            // helper text matters — the page promises it, and a
+            // promise the submit does not honour is worse than having
+            // no default at all. (It was: the form said "blank uses
+            // tenant_globex" and the submit answered "database mode
+            // needs a database URL".)
+            let name =
+                field("database_name").map_or_else(|| format!("tenant_{slug}"), ToOwned::to_owned);
+            let registry = registry_url
+                .ok_or("This console cannot derive a database URL — supply a full URL instead.")?;
+            Some(
+                provision::tenant_url_on_registry_server(registry, &name).ok_or_else(|| {
+                    format!(
+                        "Could not derive a URL for database `{name}` from the registry's own \
+                         connection. Supply a full URL instead."
+                    )
+                })?,
+            )
+        }
+    };
+
     Ok(ProvisionRequest {
         slug,
         mode,
         backend,
         display_name: field("display_name").map(ToOwned::to_owned),
-        database_url: field("database_url").map(ToOwned::to_owned),
+        database_url,
         schema_name: field("schema_name").map(ToOwned::to_owned),
         host_pattern: field("host_pattern").map(ToOwned::to_owned),
         port,
@@ -178,7 +259,8 @@ pub(super) async fn org_new_submit(
         .as_ref()
         .expect("provisioning routes are only mounted when a provisioner is supplied");
 
-    let request = match request_from_form(&form) {
+    let registry_url = provisioner.registry_url();
+    let request = match request_from_form(&form, Some(&registry_url)) {
         Ok(r) => r,
         Err(msg) => return render_form(&state, &op, &form, Some(&msg)),
     };
@@ -211,18 +293,39 @@ pub(super) async fn org_new_submit(
 /// Writes nothing, creates nothing. Returns a fragment the form drops
 /// in place, so this is usable from a button without a page reload.
 pub(super) async fn test_connection(
-    State(_state): State<ConsoleState>,
+    State(state): State<ConsoleState>,
     Extension(_op): Extension<auth::Operator>,
     Form(form): Form<HashMap<String, String>>,
 ) -> Response<Body> {
-    let Some(url) = form
-        .get("database_url")
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-    else {
-        return Html("<p class=\"probe probe-bad\">Enter a database URL first.</p>".to_owned())
-            .into_response();
+    let field = |k: &str| form.get(k).map(|s| s.trim()).filter(|s| !s.is_empty());
+
+    // Probe exactly what a submit would use — an explicit URL, or the
+    // one derived from the database name. Probing a different target
+    // from the one about to be provisioned is worse than not probing
+    // at all, because it reports confidence in the wrong thing.
+    let target = if let Some(explicit) = field("database_url") {
+        Some(explicit.to_owned())
+    } else {
+        {
+            let db = field("database_name")
+                .map(ToOwned::to_owned)
+                .or_else(|| field("slug").map(|s| format!("tenant_{s}")));
+            match (state.provisioner.as_ref(), db) {
+                (Some(p), Some(db)) => {
+                    provision::tenant_url_on_registry_server(&p.registry_url(), &db)
+                }
+                _ => None,
+            }
+        }
     };
+    let Some(url) = target else {
+        return Html(
+            "<p class=\"probe probe-bad\">Enter a slug, a database name, or a full URL first.</p>"
+                .to_owned(),
+        )
+        .into_response();
+    };
+    let url = url.as_str();
 
     match preflight::check(url, &Preflight::default()).await {
         Ok(ok) => Html(format!(
@@ -314,6 +417,12 @@ pub(super) async fn provision_run_stream(
     // transitively but not a declared dependency. Not worth adding one
     // to spell a return type.
 ) -> impl IntoResponse {
+    // The error type is pinned once: nothing in this stream can fail
+    // in a way axum has to render — a store read that errors is
+    // reported *as an event* and closes the stream, which is what a
+    // watcher can actually act on.
+    type Item = Result<Event, std::convert::Infallible>;
+
     // `Last-Event-ID` is how the browser's own EventSource resumes
     // after a dropped connection — it replays the header without being
     // asked. Honouring it is what makes a reconnect seamless rather
@@ -326,11 +435,6 @@ pub(super) async fn provision_run_stream(
     });
 
     let registry = state.registry.clone();
-    // The error type is pinned once here: nothing in this stream can
-    // fail in a way axum has to render — a store read that errors is
-    // reported *as an event* and closes the stream, which is what a
-    // watcher can actually act on.
-    type Item = Result<Event, std::convert::Infallible>;
     let stream = async_stream::stream! {
         let mut last = resume.unwrap_or(0);
         let started = std::time::Instant::now();
@@ -401,6 +505,9 @@ fn html_escape(s: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Stands in for a deployment's registry connection.
+    const TEST_REGISTRY: &str = "postgres://app:pw@db.internal:5432/registry_db";
+
     fn form(pairs: &[(&str, &str)]) -> HashMap<String, String> {
         pairs
             .iter()
@@ -410,10 +517,10 @@ mod tests {
 
     #[test]
     fn a_minimal_form_becomes_a_database_mode_request() {
-        let r = request_from_form(&form(&[
-            ("slug", "acme"),
-            ("database_url", "postgres://u:p@h/acme"),
-        ]))
+        let r = request_from_form(
+            &form(&[("slug", "acme"), ("database_url", "postgres://u:p@h/acme")]),
+            Some(TEST_REGISTRY),
+        )
         .expect("valid");
         assert_eq!(r.slug, "acme");
         assert_eq!(r.mode, StorageMode::Database);
@@ -425,12 +532,15 @@ mod tests {
     /// into columns that mean something by being NULL.
     #[test]
     fn blank_fields_are_treated_as_unset() {
-        let r = request_from_form(&form(&[
-            ("slug", "acme"),
-            ("database_url", "postgres://u:p@h/acme"),
-            ("display_name", "   "),
-            ("host_pattern", ""),
-        ]))
+        let r = request_from_form(
+            &form(&[
+                ("slug", "acme"),
+                ("database_url", "postgres://u:p@h/acme"),
+                ("display_name", "   "),
+                ("host_pattern", ""),
+            ]),
+            Some(TEST_REGISTRY),
+        )
         .expect("valid");
         assert_eq!(r.display_name, None);
         assert_eq!(r.host_pattern, None);
@@ -438,14 +548,18 @@ mod tests {
 
     #[test]
     fn a_missing_slug_is_refused_with_a_useful_message() {
-        let err = request_from_form(&form(&[("database_url", "x")])).expect_err("no slug");
+        let err = request_from_form(&form(&[("database_url", "x")]), Some(TEST_REGISTRY))
+            .expect_err("no slug");
         assert!(err.contains("slug"), "{err}");
     }
 
     #[test]
     fn a_non_numeric_port_is_refused() {
-        let err =
-            request_from_form(&form(&[("slug", "a"), ("port", "eighty")])).expect_err("bad port");
+        let err = request_from_form(
+            &form(&[("slug", "a"), ("port", "eighty")]),
+            Some(TEST_REGISTRY),
+        )
+        .expect_err("bad port");
         assert!(err.contains("whole number"), "{err}");
     }
 
@@ -453,9 +567,13 @@ mod tests {
     /// work — so its *presence* is what turns migrations off.
     #[test]
     fn the_no_migrate_checkbox_inverts_correctly() {
-        let on = request_from_form(&form(&[("slug", "a"), ("no_migrate", "on")])).unwrap();
+        let on = request_from_form(
+            &form(&[("slug", "a"), ("no_migrate", "on")]),
+            Some(TEST_REGISTRY),
+        )
+        .unwrap();
         assert!(!on.run_migrations);
-        let off = request_from_form(&form(&[("slug", "a")])).unwrap();
+        let off = request_from_form(&form(&[("slug", "a")]), Some(TEST_REGISTRY)).unwrap();
         assert!(off.run_migrations);
     }
 
@@ -463,11 +581,14 @@ mod tests {
     /// deep in the pool layer.
     #[test]
     fn schema_mode_on_a_non_pg_backend_is_refused_early() {
-        let err = request_from_form(&form(&[
-            ("slug", "a"),
-            ("storage_mode", "schema"),
-            ("backend_kind", "sqlite"),
-        ]))
+        let err = request_from_form(
+            &form(&[
+                ("slug", "a"),
+                ("storage_mode", "schema"),
+                ("backend_kind", "sqlite"),
+            ]),
+            Some(TEST_REGISTRY),
+        )
         .expect_err("sqlite cannot do schema mode");
         assert!(!err.is_empty());
     }
@@ -478,5 +599,93 @@ mod tests {
             html_escape(r#"<script>"&"</script>"#),
             "&lt;script&gt;&quot;&amp;&quot;&lt;/script&gt;"
         );
+    }
+}
+
+#[cfg(test)]
+mod derivation_tests {
+    use super::*;
+
+    const REGISTRY: &str = "postgres://app:pw@db.internal:5432/registry_db";
+
+    fn form(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    /// A slug alone is enough. This is the whole point: an operator
+    /// should not retype a host, a port and a password they already
+    /// configured once.
+    #[test]
+    fn a_slug_alone_derives_a_url_on_the_registry_server() {
+        let r = request_from_form(&form(&[("slug", "globex")]), Some(REGISTRY)).expect("valid");
+        assert_eq!(
+            r.database_url.as_deref(),
+            Some("postgres://app:pw@db.internal:5432/tenant_globex")
+        );
+    }
+
+    /// The default the form *advertises* must be the default the
+    /// submit *applies*. It was not: the page said "blank uses
+    /// tenant_globex" and the submit answered "database mode needs a
+    /// database URL".
+    #[test]
+    fn a_blank_database_name_uses_the_advertised_default() {
+        let r = request_from_form(
+            &form(&[("slug", "globex"), ("database_name", "   ")]),
+            Some(REGISTRY),
+        )
+        .expect("valid");
+        assert!(r
+            .database_url
+            .as_deref()
+            .unwrap()
+            .ends_with("/tenant_globex"));
+    }
+
+    #[test]
+    fn an_explicit_database_name_wins_over_the_default() {
+        let r = request_from_form(
+            &form(&[("slug", "globex"), ("database_name", "acme_prod")]),
+            Some(REGISTRY),
+        )
+        .unwrap();
+        assert!(r.database_url.as_deref().unwrap().ends_with("/acme_prod"));
+    }
+
+    /// The escape hatch: a tenant on another server entirely.
+    #[test]
+    fn an_explicit_url_overrides_the_derivation() {
+        let r = request_from_form(
+            &form(&[
+                ("slug", "globex"),
+                ("database_name", "ignored"),
+                ("database_url", "postgres://u:p@elsewhere:5432/own"),
+            ]),
+            Some(REGISTRY),
+        )
+        .unwrap();
+        assert_eq!(
+            r.database_url.as_deref(),
+            Some("postgres://u:p@elsewhere:5432/own")
+        );
+    }
+
+    /// Schema mode has no separate database, so nothing is derived —
+    /// and a URL is not silently carried along either.
+    #[test]
+    fn schema_mode_derives_nothing() {
+        let r = request_from_form(
+            &form(&[
+                ("slug", "globex"),
+                ("storage_mode", "schema"),
+                ("database_name", "would_be_ignored"),
+            ]),
+            Some(REGISTRY),
+        )
+        .unwrap();
+        assert_eq!(r.database_url, None);
     }
 }

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -132,39 +132,7 @@ fn compiled_backends() -> Vec<&'static str> {
     }
 }
 
-/// Render, or say why not.
-///
-/// The console's older handlers use `.unwrap_or_default()`, which turns
-/// a template error into an empty `200` — a blank page with no clue
-/// anywhere. That cost real time on this very module: a missing key in
-/// a Tera comparison rendered nothing and looked like a routing
-/// problem. A 500 naming the template is worth far more than a page
-/// that lies about having worked.
-fn render(state: &ConsoleState, template: &str, ctx: &Context) -> Response<Body> {
-    match state.tera.render(template, ctx) {
-        Ok(html) => Html(html).into_response(),
-        Err(e) => {
-            let mut detail = e.to_string();
-            let mut source = std::error::Error::source(&e);
-            while let Some(s) = source {
-                detail.push_str(": ");
-                detail.push_str(&s.to_string());
-                source = s.source();
-            }
-            tracing::error!(
-                target: "rustango::tenancy::operator_console",
-                template,
-                error = %detail,
-                "operator console template failed to render"
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("could not render {template}: {detail}"),
-            )
-                .into_response()
-        }
-    }
-}
+use super::render;
 
 /// Turn the submitted form into a request, or say what is wrong with it.
 ///

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -38,6 +38,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::Form;
+use serde::Deserialize;
 use tera::Context;
 
 use super::{inject_op_brand, ConsoleState};
@@ -331,6 +332,104 @@ pub(super) async fn test_connection(
 
 // ------------------------------------------------------------ run view
 
+/// How many runs a page of the index shows.
+const RUNS_PAGE_SIZE: i64 = 50;
+
+#[derive(Deserialize)]
+pub(super) struct RunsQuery {
+    #[serde(default)]
+    page: Option<i64>,
+}
+
+/// Every provisioning run, newest first.
+///
+/// A run was reachable only by its id, which meant only from the
+/// redirect that created it: navigate away and the record survived in
+/// the table but not in anybody's reach. The runs are persisted so they
+/// outlive the request, and this is what makes that worth anything —
+/// including for the runs that failed, which are the ones somebody
+/// comes back to.
+pub(super) async fn provision_runs_index(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+    Query(q): Query<RunsQuery>,
+) -> Response<Body> {
+    // Saturating: a page number large enough to overflow the multiply
+    // parses into an `i64` fine and then panicked the worker. Clamped,
+    // an absurd page is just an empty one.
+    let page = q.page.unwrap_or(1).max(1);
+    let offset = page.saturating_sub(1).saturating_mul(RUNS_PAGE_SIZE);
+
+    // One more than a page, so "is there an older page?" costs no
+    // second query.
+    let mut runs = match store::recent_runs(&state.registry, RUNS_PAGE_SIZE + 1, offset).await {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("could not read the run list: {e}"),
+            )
+                .into_response();
+        }
+    };
+    let page_len = usize::try_from(RUNS_PAGE_SIZE).unwrap_or(usize::MAX);
+    let has_next = runs.len() > page_len;
+    runs.truncate(page_len);
+
+    let view: Vec<_> = runs
+        .iter()
+        .map(|r| {
+            let state_str = r.state.clone();
+            serde_json::json!({
+                "id": r.id.get().copied().unwrap_or_default(),
+                "slug": r.slug,
+                "state": state_str,
+                "failed": RunState::parse(&r.state) == RunState::Failed,
+                "running": !RunState::parse(&r.state).is_terminal(),
+                "storage_mode": r.storage_mode,
+                "backend_kind": r.backend_kind,
+                "requested_by": r.requested_by,
+                "error": r.error,
+                "started_at": r.started_at.get()
+                    .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string()),
+                // How long it took, rather than a second wide timestamp
+                // column: the finish time on its own says little that
+                // the start time and a duration do not.
+                "took": took(r),
+            })
+        })
+        .collect();
+
+    let mut ctx = Context::new();
+    inject_op_brand(&mut ctx, &state.op_brand);
+    ctx.insert("section", "orgs");
+    ctx.insert("operator_username", &op.username);
+    ctx.insert("runs", &view);
+    ctx.insert("page", &page);
+    ctx.insert("has_next", &has_next);
+    render(&state, "op_provision_runs.html", &ctx)
+}
+
+/// How long a finished run took, or `None` while it is still going.
+fn took(run: &store::ProvisioningRun) -> Option<String> {
+    let started = run.started_at.get()?;
+    let finished = run.finished_at?;
+    let ms = (finished - *started).num_milliseconds();
+    if ms < 0 {
+        // Clocks on two pods can disagree; a negative duration is not
+        // information worth rendering.
+        return None;
+    }
+    // Integer arithmetic rather than a float divide: one decimal place
+    // of a millisecond count needs no `f64`, and `i64 as f64` loses
+    // precision for large values.
+    Some(if ms < 1000 {
+        format!("{ms}ms")
+    } else {
+        format!("{}.{}s", ms / 1000, (ms % 1000) / 100)
+    })
+}
+
 /// The non-streaming view of a run: what it did, whether it finished.
 ///
 /// Also the page a finished run settles into, and the audit trail
@@ -614,7 +713,7 @@ mod derivation_tests {
 
     /// The default the form *advertises* must be the default the
     /// submit *applies*. It was not: the page said "blank uses
-    /// tenant_globex" and the submit answered "database mode needs a
+    /// `tenant_globex`" and the submit answered "database mode needs a
     /// database URL".
     #[test]
     fn a_blank_database_name_uses_the_advertised_default() {

--- a/crates/rustango/src/tenancy/operator_console/provisioning.rs
+++ b/crates/rustango/src/tenancy/operator_console/provisioning.rs
@@ -369,9 +369,14 @@ pub(super) async fn provision_runs_index(
         .iter()
         .map(|r| {
             let state_str = r.state.clone();
+            let kind = store::RunKind::parse(&r.kind);
             serde_json::json!({
                 "id": r.id.get().copied().unwrap_or_default(),
-                "slug": r.slug,
+                "kind": kind.as_str(),
+                "is_migrate": kind == store::RunKind::Migrate,
+                // A batch migrate spans every tenant, so it stores no
+                // slug; the events name them as they go.
+                "slug": if r.slug.is_empty() { "all tenants".to_owned() } else { r.slug.clone() },
                 "state": state_str,
                 "failed": RunState::parse(&r.state) == RunState::Failed,
                 "running": !RunState::parse(&r.state).is_terminal(),
@@ -444,7 +449,27 @@ pub(super) async fn provision_run_view(
     ctx.insert("section", "orgs");
     ctx.insert("operator_username", &op.username);
     ctx.insert("run_id", &run_id);
-    ctx.insert("slug", &run.slug);
+    let kind = store::RunKind::parse(&run.kind);
+    let is_migrate = kind == store::RunKind::Migrate;
+    ctx.insert("is_migrate", &is_migrate);
+    // Chosen here rather than in the template: Tera has no ternary, and
+    // the alternative is the same word in four `{% if %}` blocks.
+    ctx.insert(
+        "verb",
+        if is_migrate {
+            "Migrating"
+        } else {
+            "Provisioning"
+        },
+    );
+    ctx.insert(
+        "slug",
+        &if run.slug.is_empty() {
+            "all tenants".to_owned()
+        } else {
+            run.slug.clone()
+        },
+    );
     ctx.insert("state", &state_str);
     ctx.insert("terminal", &parsed.is_terminal());
     ctx.insert("error", &run.error);

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -526,6 +526,22 @@ pub trait TenantPoolInvalidator: Send + Sync {
         slug: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>;
 
+    /// The tenant's literal connection URL, secret references resolved.
+    ///
+    /// Resolved here rather than handed to a caller's form: the URL
+    /// carries a password, and the console must be able to act on it
+    /// without it ever reaching a browser.
+    fn resolved_database_url<'a>(
+        &'a self,
+        org: &'a super::org::Org,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<String, super::error::TenancyError>>
+                + Send
+                + 'a,
+        >,
+    >;
+
     /// Take a tenant out of service — see
     /// [`crate::tenancy::decommission`].
     ///
@@ -555,6 +571,19 @@ where
         slug: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
         Box::pin(async move { TenantPools::<DB>::invalidate(self, slug).await })
+    }
+
+    fn resolved_database_url<'a>(
+        &'a self,
+        org: &'a super::org::Org,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<String, super::error::TenancyError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move { TenantPools::<DB>::resolved_database_url(self, org).await })
     }
 
     fn decommission<'a>(

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -525,14 +525,51 @@ pub trait TenantPoolInvalidator: Send + Sync {
         &'a self,
         slug: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>;
+
+    /// Take a tenant out of service — see
+    /// [`crate::tenancy::decommission`].
+    ///
+    /// Here because it is the same erasure and the same capability: a
+    /// surface holding this handle is one allowed to change tenants,
+    /// and decommissioning invalidates the pool anyway.
+    fn decommission<'a>(
+        &'a self,
+        slug: &'a str,
+        action: super::decommission::Action,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<super::decommission::Report, super::error::TenancyError>,
+                > + Send
+                + 'a,
+        >,
+    >;
 }
 
-impl<DB: Database> TenantPoolInvalidator for TenantPools<DB> {
+impl<DB: Database> TenantPoolInvalidator for TenantPools<DB>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
     fn invalidate<'a>(
         &'a self,
         slug: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
         Box::pin(async move { TenantPools::<DB>::invalidate(self, slug).await })
+    }
+
+    fn decommission<'a>(
+        &'a self,
+        slug: &'a str,
+        action: super::decommission::Action,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<super::decommission::Report, super::error::TenancyError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move { super::decommission::decommission(self, slug, action).await })
     }
 }
 
@@ -544,7 +581,10 @@ impl<DB: Database> TenantPools<DB> {
     /// rotate config). Avoids cascading `<DB>` generics through
     /// non-query layers.
     #[must_use]
-    pub fn into_invalidator(self: Arc<Self>) -> Arc<dyn TenantPoolInvalidator> {
+    pub fn into_invalidator(self: Arc<Self>) -> Arc<dyn TenantPoolInvalidator>
+    where
+        crate::sql::Pool: From<sqlx::Pool<DB>>,
+    {
         self
     }
 

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -492,7 +492,7 @@ pub async fn provision_tenant_recorded<DB: Database>(
 where
     crate::sql::Pool: From<sqlx::Pool<DB>>,
 {
-    use super::provision_store::{self as store, RunState};
+    use super::provision_store as store;
 
     let registry = pools.registry_pool();
     let run = store::open_run(
@@ -507,6 +507,42 @@ where
     .await?;
     let run_id = run.id.get().copied().unwrap_or_default();
 
+    let outcome = provision_tenant_in_run(pools, registry_url, dir, request, observer, run_id)
+        .await
+        // A pre-row failure still closed the run inside
+        // `provision_tenant_in_run`; propagate the reason unchanged.
+        ?;
+    // Re-read so the caller sees the closed run, not the one that was
+    // handed back at `open_run` time.
+    let refreshed = store::run_by_id(&registry, run_id).await?.unwrap_or(run);
+    Ok((refreshed, outcome))
+}
+
+/// [`provision_tenant_recorded`] against a run somebody else already
+/// opened.
+///
+/// The inbound webhook needs this: it opens the run **synchronously**
+/// so the caller gets an id back and so the `idempotency_key` unique
+/// constraint fires where a response can carry it, then hands the slow
+/// part to a task. Without this entry point that task would open a
+/// *second* run for the same tenant.
+///
+/// # Errors
+/// As [`provision_tenant`]. The run is closed either way.
+pub async fn provision_tenant_in_run<DB: Database>(
+    pools: &TenantPools<DB>,
+    registry_url: &str,
+    dir: &Path,
+    request: &ProvisionRequest,
+    observer: Option<&dyn ProvisionObserver>,
+    run_id: i64,
+) -> Result<ProvisionOutcome, TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    use super::provision_store::{self as store, RunState};
+
+    let registry = pools.registry_pool();
     let rep = Reporter::new(observer).persisting(&registry, run_id);
     let result = provision_reported(pools, registry_url, dir, request, &rep).await;
 
@@ -529,8 +565,7 @@ where
         tracing::warn!(target: "rustango::tenancy::provision", error = %e, "could not close provisioning run");
     }
 
-    let refreshed = store::run_by_id(&registry, run_id).await?.unwrap_or(run);
-    result.map(|outcome| (refreshed, outcome))
+    result
 }
 
 async fn provision_reported<DB: Database>(
@@ -919,21 +954,31 @@ pub trait TenantProvisioner: Send + Sync {
         request: &'a ProvisionRequest,
         requested_by: Option<&'a str>,
         idempotency_key: Option<&'a str>,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<
-                        (super::provision_store::ProvisioningRun, ProvisionOutcome),
-                        TenancyError,
-                    >,
-                > + Send
-                + 'a,
-        >,
-    >;
+    ) -> BoxFuture<'a, (super::provision_store::ProvisioningRun, ProvisionOutcome)>;
+
+    /// Stand up a tenant into a run the caller already opened.
+    ///
+    /// The inbound webhook opens its run synchronously — so the
+    /// response can carry an id, and so the `idempotency_key` unique
+    /// constraint fires where an HTTP status can report it — and then
+    /// hands the slow part to a task. Without this the task would open
+    /// a *second* run for the same tenant.
+    fn provision_in_run<'a>(
+        &'a self,
+        run_id: i64,
+        request: &'a ProvisionRequest,
+    ) -> BoxFuture<'a, ProvisionOutcome>;
 
     /// The registry pool, so a caller can read runs and events back.
     fn registry(&self) -> crate::sql::Pool;
 }
+
+/// The boxed-future shape an object-safe async method has to return.
+///
+/// Spelled once: written out inline it is four lines of angle brackets
+/// per method, which buries what each one actually does.
+pub type BoxFuture<'a, T> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<T, TenancyError>> + Send + 'a>>;
 
 /// A [`TenantProvisioner`] over concrete pools.
 pub struct Provisioner<DB: Database> {
@@ -975,17 +1020,7 @@ where
         request: &'a ProvisionRequest,
         requested_by: Option<&'a str>,
         idempotency_key: Option<&'a str>,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<
-                        (super::provision_store::ProvisioningRun, ProvisionOutcome),
-                        TenancyError,
-                    >,
-                > + Send
-                + 'a,
-        >,
-    > {
+    ) -> BoxFuture<'a, (super::provision_store::ProvisioningRun, ProvisionOutcome)> {
         Box::pin(async move {
             provision_tenant_recorded(
                 self.pools.as_ref(),
@@ -995,6 +1030,24 @@ where
                 None,
                 requested_by,
                 idempotency_key,
+            )
+            .await
+        })
+    }
+
+    fn provision_in_run<'a>(
+        &'a self,
+        run_id: i64,
+        request: &'a ProvisionRequest,
+    ) -> BoxFuture<'a, ProvisionOutcome> {
+        Box::pin(async move {
+            provision_tenant_in_run(
+                self.pools.as_ref(),
+                &self.registry_url,
+                &self.migrations_dir,
+                request,
+                None,
+                run_id,
             )
             .await
         })

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -601,15 +601,27 @@ where
             .await;
     }
 
+    if let Err(msg) = validate_slug(&request.slug) {
+        return rep
+            .fail(ProvisionStep::Validate, TenancyError::Validation(msg))
+            .await;
+    }
+
     if request.mode == StorageMode::Database && request.database_url.is_none() {
         return rep
             .fail(
                 ProvisionStep::Validate,
-                TenancyError::Validation(
-                    "create-tenant --mode database requires --database-url".into(),
-                ),
+                TenancyError::Validation("database mode needs a database URL".into()),
             )
             .await;
+    }
+
+    if let Some(url) = &request.database_url {
+        if let Err(msg) = refuse_registry_url(url, registry_url) {
+            return rep
+                .fail(ProvisionStep::Validate, TenancyError::Validation(msg))
+                .await;
+        }
     }
     rep.step(ProvisionStep::Validate, StepStatus::Ok).await;
 
@@ -771,6 +783,128 @@ async fn provision_storage<DB: Database>(
     rep.step(ProvisionStep::ProvisionStorage, StepStatus::Ok)
         .await;
     Ok(())
+}
+
+/// A slug becomes three things, and has to be legal in all of them.
+///
+/// It is a **database name**, a **schema name**, and a **hostname
+/// label** (`<slug>.<apex>`). The last is the strictest: RFC 1123
+/// allows only lowercase letters, digits and hyphens, not leading or
+/// trailing.
+///
+/// This lived only in the inbound webhook, so the console — the path a
+/// human uses — was the laxer of the two. `tennant 1`, with a space,
+/// produced a **live tenant** whose `host_pattern` was
+/// `tennant 1.localhost`: a hostname that cannot resolve, so the
+/// tenant could never be reached, discovered only by someone
+/// wondering why their new customer 404s.
+fn validate_slug(slug: &str) -> Result<(), String> {
+    if slug.is_empty() {
+        return Err("a slug is required".into());
+    }
+    if slug.len() > 63 {
+        // The hostname-label limit; the database-name limits are
+        // higher, so this is the binding one.
+        return Err(format!(
+            "slug `{slug}` is {} characters; a hostname label allows at most 63",
+            slug.len()
+        ));
+    }
+    let legal = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-';
+    if let Some(bad) = slug.bytes().find(|b| !legal(*b)) {
+        return Err(format!(
+            "slug `{slug}` contains `{}` — only lowercase letters, digits and hyphens are \
+             allowed, because the slug becomes a database name, a schema name and a \
+             hostname label",
+            bad as char
+        ));
+    }
+    if slug.starts_with('-') || slug.ends_with('-') {
+        return Err(format!(
+            "slug `{slug}` may not start or end with a hyphen — a hostname label cannot"
+        ));
+    }
+    Ok(())
+}
+
+/// Refuse a tenant URL that points at the registry's own database.
+///
+/// Nothing stopped this, and the consequence is not cosmetic:
+/// provisioning ran the **tenant** migration chain into the
+/// **registry**, creating `rustango_users`, `rustango_admin_users`,
+/// the media tables and the project's own models there — and writing
+/// `0001_initial` into the registry's project ledger, so a later
+/// legitimate migration run reads a ledger that lies about what has
+/// been applied. A project whose tenant migrations contain any
+/// destructive operation would have had it run against the registry.
+///
+/// Compared on endpoint identity — scheme, host, port, database —
+/// because the *credentials* may legitimately differ while still
+/// naming the same database.
+fn refuse_registry_url(tenant_url: &str, registry_url: &str) -> Result<(), String> {
+    if endpoint_identity(tenant_url) == endpoint_identity(registry_url) {
+        return Err(format!(
+            "this is the registry's own database ({}). A tenant needs its own — pointing one \
+             here would run the tenant migrations over the registry",
+            crate::sql::connect_diagnosis::redact(tenant_url)
+        ));
+    }
+    Ok(())
+}
+
+/// Build a tenant URL on the same server as the registry, naming
+/// `database`.
+///
+/// The overwhelmingly common deployment is "one Postgres, one database
+/// per tenant". Without this, an operator retypes the host, the port
+/// **and the password** into a web form for every tenant — which is
+/// both tedious and the single most likely way for a credential to end
+/// up somewhere it should not be.
+///
+/// Derived server-side on purpose: the caller supplies a database
+/// *name*, never a URL, so the registry password is never rendered into
+/// a page and never travels back in a form post.
+///
+/// Returns `None` when the registry URL has no database segment to
+/// replace — a shape this cannot reason about, where the operator
+/// should supply a URL themselves.
+#[must_use]
+pub fn tenant_url_on_registry_server(registry_url: &str, database: &str) -> Option<String> {
+    // sqlite is a file path, not a server: "same server, other
+    // database" means a sibling file.
+    if let Some(path) = registry_url.strip_prefix("sqlite://") {
+        let path = path.split('?').next().unwrap_or(path);
+        let (dir, _) = path.rsplit_once('/')?;
+        return Some(format!("sqlite://{dir}/{database}.db?mode=rwc"));
+    }
+
+    let (scheme, rest) = registry_url.split_once("://")?;
+    // Keep userinfo and authority; replace only the path segment.
+    let (authority, _old_db) = rest.rsplit_once('/')?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{authority}/{database}"))
+}
+
+/// Scheme + host + port + database, lowercased, credentials and query
+/// dropped. Two URLs naming the same database compare equal even when
+/// they authenticate differently.
+fn endpoint_identity(url: &str) -> String {
+    let (scheme, rest) = url.split_once("://").unwrap_or_else(|| {
+        // `sqlite:path` has no authority — the whole tail is the file.
+        url.split_once(':').unwrap_or(("", url))
+    });
+    // Drop userinfo (everything before the last `@` of the authority).
+    let rest = rest.rsplit_once('@').map_or(rest, |(_, after)| after);
+    // Drop the query string: `?mode=rwc` does not change which database
+    // this is.
+    let rest = rest.split_once('?').map_or(rest, |(before, _)| before);
+    format!(
+        "{}://{}",
+        scheme.to_ascii_lowercase(),
+        rest.to_ascii_lowercase()
+    )
 }
 
 /// The schema a schema-mode tenant lives in: whatever the request
@@ -969,6 +1103,14 @@ pub trait TenantProvisioner: Send + Sync {
         request: &'a ProvisionRequest,
     ) -> BoxFuture<'a, ProvisionOutcome>;
 
+    /// The registry's own connection URL.
+    ///
+    /// Used to derive a tenant URL on the same server — the common
+    /// case, and the one that otherwise has an operator retyping a
+    /// password into a form field. **Never render this**: it carries
+    /// credentials. Derive, then redact for display.
+    fn registry_url(&self) -> String;
+
     /// The registry pool, so a caller can read runs and events back.
     fn registry(&self) -> crate::sql::Pool;
 }
@@ -1053,7 +1195,107 @@ where
         })
     }
 
+    fn registry_url(&self) -> String {
+        self.registry_url.clone()
+    }
+
     fn registry(&self) -> crate::sql::Pool {
         self.pools.registry_pool()
+    }
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+
+    /// The exact input that created a live, unreachable tenant during
+    /// QA: a space in the slug, accepted by the console, producing
+    /// `host_pattern = "tennant 1.localhost"`.
+    #[test]
+    fn a_slug_with_a_space_is_refused() {
+        let err = validate_slug("tennant 1").expect_err("a space is not a hostname character");
+        assert!(err.contains("tennant 1"), "{err}");
+        assert!(err.contains("hostname"), "should say why: {err}");
+    }
+
+    #[test]
+    fn a_slug_is_restricted_to_what_is_legal_in_all_three_uses() {
+        for bad in [
+            "",          // empty
+            "Acme",      // uppercase — not a hostname label
+            "ac me",     // space
+            "acme_corp", // underscore is legal in a DB name, not a hostname
+            "acme.corp", // dot would make it two labels
+            "acme;DROP", // punctuation
+            "../etc",    // traversal
+            "-acme",     // leading hyphen
+            "acme-",     // trailing hyphen
+        ] {
+            assert!(
+                validate_slug(bad).is_err(),
+                "slug `{bad}` should have been refused"
+            );
+        }
+        for good in ["acme", "acme-2", "a", "tenant-42"] {
+            assert!(
+                validate_slug(good).is_ok(),
+                "slug `{good}` should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn an_over_long_slug_is_refused_at_the_hostname_limit() {
+        assert!(validate_slug(&"a".repeat(63)).is_ok());
+        let err = validate_slug(&"a".repeat(64)).expect_err("too long for a hostname label");
+        assert!(err.contains("63"), "{err}");
+    }
+
+    /// The critical QA finding: a tenant pointed at the registry's own
+    /// database ran the tenant migration chain over the registry.
+    #[test]
+    fn a_tenant_url_naming_the_registry_database_is_refused() {
+        let registry = "postgres://rustango:rustango@localhost:5432/orgdemo_dev";
+        let err = refuse_registry_url(registry, registry).expect_err("same database");
+        assert!(err.contains("registry's own database"), "{err}");
+        // And it must not echo the password while saying so.
+        assert!(!err.contains("rustango:rustango"), "password leaked: {err}");
+    }
+
+    /// Different credentials, same database, is still the same
+    /// database — which is the case a naive string compare misses.
+    #[test]
+    fn different_credentials_for_the_same_database_are_still_refused() {
+        assert!(refuse_registry_url(
+            "postgres://someone_else:other@localhost:5432/orgdemo_dev",
+            "postgres://rustango:rustango@localhost:5432/orgdemo_dev",
+        )
+        .is_err());
+    }
+
+    /// And a query string does not make it a different database —
+    /// sqlite's `?mode=rwc` in particular.
+    #[test]
+    fn a_query_string_does_not_disguise_the_same_database() {
+        assert!(refuse_registry_url(
+            "sqlite:///var/app/reg.db?mode=rwc",
+            "sqlite:///var/app/reg.db",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn a_genuinely_separate_database_is_allowed() {
+        let registry = "postgres://rustango:rustango@localhost:5432/orgdemo_dev";
+        for ok in [
+            "postgres://rustango:rustango@localhost:5432/acme_tenant", // other db
+            "postgres://rustango:rustango@otherhost:5432/orgdemo_dev", // other host
+            "postgres://rustango:rustango@localhost:5433/orgdemo_dev", // other port
+        ] {
+            assert!(
+                refuse_registry_url(ok, registry).is_ok(),
+                "`{ok}` is a different database and should be allowed"
+            );
+        }
     }
 }

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -1318,6 +1318,14 @@ pub trait TenantProvisioner: Send + Sync {
     /// case, and the one that otherwise has an operator retyping a
     /// password into a form field. **Never render this**: it carries
     /// credentials. Derive, then redact for display.
+    /// Migrate one tenant (`slug`) or every active one (`None`),
+    /// recording into an already-open run.
+    ///
+    /// Here rather than on a trait of its own because this is the same
+    /// type erasure: the console holds `Arc<dyn TenantProvisioner>` and
+    /// has no `DB` to name.
+    fn migrate_in_run<'a>(&'a self, run_id: i64, slug: Option<&'a str>) -> BoxFuture<'a, ()>;
+
     fn registry_url(&self) -> String;
 
     /// The registry pool, so a caller can read runs and events back.
@@ -1399,6 +1407,19 @@ where
                 request,
                 None,
                 run_id,
+            )
+            .await
+        })
+    }
+
+    fn migrate_in_run<'a>(&'a self, run_id: i64, slug: Option<&'a str>) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            super::migrate_run::migrate_in_run(
+                self.pools.as_ref(),
+                &self.migrations_dir,
+                &self.registry_url,
+                run_id,
+                slug,
             )
             .await
         })

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -601,11 +601,17 @@ where
             .await;
     }
 
-    if let Err(msg) = validate_slug(&request.slug) {
-        return rep
-            .fail(ProvisionStep::Validate, TenancyError::Validation(msg))
-            .await;
-    }
+    // Every free-text field, not just the slug. Returns the request
+    // back with `host_pattern` normalized — see `validate_fields`.
+    let normalized = match validate_fields(request) {
+        Ok(r) => r,
+        Err(msg) => {
+            return rep
+                .fail(ProvisionStep::Validate, TenancyError::Validation(msg))
+                .await;
+        }
+    };
+    let request = &normalized;
 
     if request.mode == StorageMode::Database && request.database_url.is_none() {
         return rep
@@ -827,6 +833,209 @@ fn validate_slug(slug: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Check every operator-supplied field, and hand back the request with
+/// the one field that is normalized rather than refused.
+///
+/// One function, called from the `Validate` step, so the console, the
+/// webhook and `manage create-tenant` cannot disagree about what a
+/// legal tenant is. They did: the slug rule lived in the webhook alone
+/// until a space in a console slug produced an unreachable tenant, and
+/// these four fields had no rule anywhere at all.
+///
+/// The shared thread is that all four feed a matcher or an identifier
+/// that is *exact*. A value that cannot be produced by the thing it is
+/// compared against is not a configuration choice with an unusual
+/// consequence — it is a tenant that is registered, active, and
+/// unreachable, discovered by whoever eventually wonders why the new
+/// customer 404s.
+fn validate_fields(request: &ProvisionRequest) -> Result<ProvisionRequest, String> {
+    validate_slug(&request.slug)?;
+
+    // The effective name, so the slug-derived default is checked by the
+    // same rule as an explicit one.
+    if let Some(schema) = schema_name_for(request) {
+        validate_schema_name(&schema)?;
+    }
+    if let Some(prefix) = &request.path_prefix {
+        validate_path_prefix(prefix)?;
+    }
+    if let Some(port) = request.port {
+        validate_port(port)?;
+    }
+
+    let mut out = request.clone();
+    if let Some(pattern) = &request.host_pattern {
+        out.host_pattern = Some(validate_host_pattern(pattern)?);
+    }
+    Ok(out)
+}
+
+/// The schema a schema-mode tenant is created in.
+///
+/// This reaches `CREATE SCHEMA` and `SET search_path` as an
+/// identifier. [`crate::sql::Dialect::quote_ident`] quotes it, so a
+/// name carrying a quote and a semicolon does **not** execute — that
+/// held when it was tried. What did not hold is everything after:
+/// nothing rejected the name, so
+/// `x"; CREATE TABLE public.pwned(i int); --` became a real schema and
+/// a live, active tenant. An identifier nobody can type again without
+/// quoting is not a tenant anybody can operate.
+///
+/// The rule is the slug's, plus underscores: a schema name is not a
+/// hostname label, so `_` — which Postgres and every naming convention
+/// allow — has no reason to be refused here.
+fn validate_schema_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("a schema name is required".into());
+    }
+    if name.len() > 63 {
+        // Postgres truncates identifiers at NAMEDATALEN-1 silently,
+        // which would make the stored name and the real schema differ.
+        return Err(format!(
+            "schema name `{name}` is {} characters; Postgres allows at most 63",
+            name.len()
+        ));
+    }
+    let legal = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_' || b == b'-';
+    if let Some(bad) = name.bytes().find(|b| !legal(*b)) {
+        return Err(format!(
+            "schema name `{name}` contains `{}` — only lowercase letters, digits, underscores \
+             and hyphens are allowed",
+            bad as char
+        ));
+    }
+    // Not "must start with a letter": the *default* schema name is the
+    // slug, and a slug may start with a digit. Only the hyphen is
+    // refused, being the one leading character that reads as a flag.
+    if name.starts_with('-') {
+        return Err(format!("schema name `{name}` may not start with a hyphen"));
+    }
+    // `pg_*` is reserved for system schemas; `CREATE SCHEMA pg_x` is
+    // refused by the server with a message about the reservation, which
+    // would surface here as a failed run rather than a validation error.
+    if name.starts_with("pg_") || name == "information_schema" {
+        return Err(format!(
+            "schema name `{name}` is reserved by Postgres — choose another"
+        ));
+    }
+    Ok(())
+}
+
+/// The `Host` header this tenant answers to.
+///
+/// Matched **exactly**, against a header the resolver has already
+/// lowercased and stripped of its `:port` (see
+/// `resolver::host_from_parts`). Three things therefore produce a
+/// tenant that is registered, active, and unreachable forever:
+/// uppercase, a `:port` suffix, and a wildcard — none of which can ever
+/// equal the normalized header.
+///
+/// Uppercase is normalized rather than refused, because lowercasing it
+/// is exactly what the resolver does and the operator's intent is not
+/// in doubt. The other two are refused: they mean the operator wants
+/// something this matcher does not do, and quietly storing a value that
+/// cannot match would be the worse answer.
+fn validate_host_pattern(pattern: &str) -> Result<String, String> {
+    if pattern.contains(':') {
+        return Err(format!(
+            "host pattern `{pattern}` carries a port — the `Host` header is matched with the \
+             port stripped, so this could never match. Put the port in the port field"
+        ));
+    }
+    if pattern.contains('*') {
+        return Err(format!(
+            "host pattern `{pattern}` uses a wildcard — patterns are matched exactly, so this \
+             could never match. Register one tenant per hostname"
+        ));
+    }
+    if pattern.len() > 253 {
+        return Err(format!(
+            "host pattern `{pattern}` is {} characters; a hostname allows at most 253",
+            pattern.len()
+        ));
+    }
+    let normalized = pattern.to_ascii_lowercase();
+    for label in normalized.split('.') {
+        if label.is_empty() {
+            return Err(format!(
+                "host pattern `{pattern}` has an empty label — check for a doubled or trailing dot"
+            ));
+        }
+        if label.len() > 63 {
+            return Err(format!(
+                "host pattern `{pattern}` has a label longer than the 63 characters a hostname \
+                 allows"
+            ));
+        }
+        let legal = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-';
+        if let Some(bad) = label.bytes().find(|b| !legal(*b)) {
+            return Err(format!(
+                "host pattern `{pattern}` contains `{}` — a hostname allows only letters, \
+                 digits, hyphens and dots",
+                bad as char
+            ));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!(
+                "host pattern `{pattern}` has a label starting or ending with a hyphen, which a \
+                 hostname cannot"
+            ));
+        }
+    }
+    Ok(normalized)
+}
+
+/// The URL path segment this tenant answers to.
+///
+/// `PathPrefixResolver` takes the **first** path segment and looks up
+/// `"/<segment>"`. So a stored prefix that is not exactly one
+/// leading-slash segment — no slash, a second segment, a trailing slash
+/// — cannot be produced by that lookup and never matches.
+fn validate_path_prefix(prefix: &str) -> Result<(), String> {
+    let Some(segment) = prefix.strip_prefix('/') else {
+        return Err(format!(
+            "path prefix `{prefix}` must start with `/` — the resolver looks up `/<segment>`"
+        ));
+    };
+    if segment.is_empty() {
+        return Err("path prefix `/` is the apex, which resolves to no tenant".into());
+    }
+    if segment.contains('/') {
+        return Err(format!(
+            "path prefix `{prefix}` has more than one segment — only the first segment of the \
+             URL is matched, so this could never match"
+        ));
+    }
+    if segment.bytes().all(|b| b == b'.') {
+        return Err(format!(
+            "path prefix `{prefix}` is a relative-path segment, not a tenant prefix"
+        ));
+    }
+    let legal = |b: u8| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~');
+    if let Some(bad) = segment.bytes().find(|b| !legal(*b)) {
+        return Err(format!(
+            "path prefix `{prefix}` contains `{}` — a path segment that needs escaping would \
+             not match the decoded path",
+            bad as char
+        ));
+    }
+    Ok(())
+}
+
+/// The TCP port this tenant answers on.
+///
+/// `i32` is the column's type, not the range of a port. `-1` and
+/// `999999` both parsed and both stored, producing a tenant matched
+/// against a port no listener can ever have.
+fn validate_port(port: i32) -> Result<(), String> {
+    if !(1..=65535).contains(&port) {
+        return Err(format!(
+            "port {port} is outside the 1–65535 a TCP port can be"
+        ));
+    }
+    Ok(())
+}
+
 /// Refuse a tenant URL that points at the registry's own database.
 ///
 /// Nothing stopped this, and the consequence is not cosmetic:
@@ -841,7 +1050,7 @@ fn validate_slug(slug: &str) -> Result<(), String> {
 /// Compared on endpoint identity — scheme, host, port, database —
 /// because the *credentials* may legitimately differ while still
 /// naming the same database.
-fn refuse_registry_url(tenant_url: &str, registry_url: &str) -> Result<(), String> {
+pub(crate) fn refuse_registry_url(tenant_url: &str, registry_url: &str) -> Result<(), String> {
     if endpoint_identity(tenant_url) == endpoint_identity(registry_url) {
         return Err(format!(
             "this is the registry's own database ({}). A tenant needs its own — pointing one \
@@ -1242,6 +1451,163 @@ mod validation_tests {
                 "slug `{good}` should be allowed"
             );
         }
+    }
+
+    /// The two schema names that were actually posted through the
+    /// console during QA. Both were accepted, and both became real
+    /// Postgres schemas behind live, active tenants.
+    ///
+    /// `quote_ident` did hold — no `pwned_a` table was created and
+    /// `rustango_operators` was still there — so this is not a fix for
+    /// an injection that worked. It is a fix for the schema name being
+    /// unchecked, which is how an operator ends up with a tenant whose
+    /// identifier they cannot type again.
+    #[test]
+    fn the_schema_names_that_got_through_qa_are_refused() {
+        for injected in [
+            r#"x"; CREATE TABLE public.pwned_a(i int); --"#,
+            r#"y"; DROP TABLE public.rustango_operators; --"#,
+        ] {
+            let err =
+                validate_schema_name(injected).expect_err("an SQL fragment is not a schema name");
+            assert!(err.contains("only lowercase"), "{err}");
+        }
+    }
+
+    #[test]
+    fn a_schema_name_is_a_postgres_identifier() {
+        for bad in [
+            "",                   // empty
+            "Acme",               // uppercase would be a *different* schema
+            "ac me",              // space
+            "acme;DROP",          // punctuation
+            "acme.other",         // a dot is schema-qualification
+            "-acme",              // leading hyphen
+            "pg_toast",           // reserved
+            "pg_anything",        // the whole `pg_` namespace is reserved
+            "information_schema", // reserved
+        ] {
+            assert!(
+                validate_schema_name(bad).is_err(),
+                "schema name `{bad}` should have been refused"
+            );
+        }
+        // Underscores are the difference from the slug rule: legal in
+        // an identifier, illegal in a hostname label.
+        for good in ["acme", "acme_corp", "tenant-42", "a", "2acme"] {
+            assert!(
+                validate_schema_name(good).is_ok(),
+                "schema name `{good}` should be allowed"
+            );
+        }
+        assert!(validate_schema_name(&"a".repeat(63)).is_ok());
+        assert!(
+            validate_schema_name(&"a".repeat(64)).is_err(),
+            "Postgres would silently truncate it"
+        );
+    }
+
+    /// The resolver lowercases the `Host` header and strips `:port`
+    /// before comparing. Anything that cannot come out of that
+    /// normalization can never match.
+    #[test]
+    fn a_host_pattern_that_could_never_match_is_refused() {
+        let err = validate_host_pattern("acme.example.com:8080")
+            .expect_err("the port is stripped before matching");
+        assert!(
+            err.contains("port field"),
+            "should say where it goes: {err}"
+        );
+
+        let err = validate_host_pattern("*.example.com").expect_err("patterns are matched exactly");
+        assert!(err.contains("wildcard"), "{err}");
+
+        for bad in [
+            "not a hostname",  // spaces
+            "acme..com",       // empty label
+            "acme.com.",       // trailing dot leaves an empty label
+            "-acme.com",       // leading hyphen in a label
+            "acme-.com",       // trailing hyphen in a label
+            r#"acme";DROP--"#, // punctuation
+        ] {
+            assert!(
+                validate_host_pattern(bad).is_err(),
+                "host pattern `{bad}` should have been refused"
+            );
+        }
+    }
+
+    /// Uppercase is the one case that is normalized instead: the
+    /// resolver lowercases the header anyway, so the operator's intent
+    /// is not in doubt and refusing would be pedantry.
+    #[test]
+    fn an_uppercase_host_pattern_is_lowercased_not_refused() {
+        assert_eq!(
+            validate_host_pattern("Acme.Example.COM").as_deref(),
+            Ok("acme.example.com")
+        );
+    }
+
+    /// `PathPrefixResolver` looks up `"/<first segment>"`. Nothing else
+    /// is ever the lookup key.
+    #[test]
+    fn a_path_prefix_must_be_one_leading_slash_segment() {
+        for bad in [
+            "acme",             // no leading slash
+            "/",                // the apex resolves to no tenant
+            "/acme/",           // trailing slash is a second, empty segment
+            "/acme/dashboard",  // only the first segment is matched
+            "../../etc/passwd", // the traversal string tried in QA
+            "/..",              // a relative segment
+            "/ac me",           // a space would arrive percent-encoded
+        ] {
+            assert!(
+                validate_path_prefix(bad).is_err(),
+                "path prefix `{bad}` should have been refused"
+            );
+        }
+        for good in ["/acme", "/tenant-42", "/a_b", "/v1.0"] {
+            assert!(
+                validate_path_prefix(good).is_ok(),
+                "path prefix `{good}` should be allowed"
+            );
+        }
+    }
+
+    /// `i32` is the column's type, not a port's range. Both of these
+    /// parsed and were stored during QA.
+    #[test]
+    fn a_port_outside_the_tcp_range_is_refused() {
+        assert!(validate_port(-1).is_err());
+        assert!(validate_port(0).is_err());
+        assert!(validate_port(999_999).is_err());
+        assert!(validate_port(1).is_ok());
+        assert!(validate_port(8080).is_ok());
+        assert!(validate_port(65_535).is_ok());
+    }
+
+    /// The rules have to be reachable from the one place every caller
+    /// goes through, or they are only the console's rules again.
+    #[test]
+    fn validate_fields_checks_the_slug_derived_schema_name_too() {
+        // A slug legal as a hostname label is legal as a schema name,
+        // so the default never trips its own rule.
+        let mut req = ProvisionRequest::database("acme-2", "postgres://h/tenant");
+        req.mode = StorageMode::Schema;
+        req.database_url = None;
+        assert!(validate_fields(&req).is_ok());
+
+        // An explicit one is checked by the same rule.
+        req.schema_name = Some(r#"x"; DROP TABLE t; --"#.into());
+        assert!(validate_fields(&req).is_err());
+    }
+
+    #[test]
+    fn validate_fields_hands_back_a_normalized_host_pattern() {
+        let mut req = ProvisionRequest::database("acme", "postgres://h/tenant");
+        req.host_pattern = Some("ACME.Example.com".into());
+        let out = validate_fields(&req).expect("a legal hostname");
+        assert_eq!(out.host_pattern.as_deref(), Some("acme.example.com"));
     }
 
     #[test]

--- a/crates/rustango/src/tenancy/provision_store.rs
+++ b/crates/rustango/src/tenancy/provision_store.rs
@@ -82,6 +82,33 @@ impl RunState {
 }
 
 /// One attempt to stand up a tenant.
+/// What a run was for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunKind {
+    Provision,
+    Migrate,
+}
+
+impl RunKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Provision => "provision",
+            Self::Migrate => "migrate",
+        }
+    }
+
+    /// Unknown values read as `Provision`: every row written before the
+    /// column existed was one.
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "migrate" => Self::Migrate,
+            _ => Self::Provision,
+        }
+    }
+}
+
 #[derive(crate::Model, Debug, Clone, Serialize)]
 #[rustango(
     table = "rustango_provisioning_runs",
@@ -95,6 +122,14 @@ impl RunState {
 pub struct ProvisioningRun {
     #[rustango(primary_key)]
     pub id: crate::sql::Auto<i64>,
+
+    /// What the run was: standing a tenant up, or migrating one.
+    ///
+    /// Both produce the same stream of steps and both are worth keeping,
+    /// so they share a table; without this a migrate run reads as a
+    /// provisioning run that skipped most of its steps.
+    #[rustango(max_length = 16, index, default = "'provision'")]
+    pub kind: String,
 
     /// The tenant this run is for. Not a foreign key: the row is
     /// written *before* the `Org` exists, and must survive the tenant
@@ -207,6 +242,7 @@ pub async fn open_run(
 ) -> Result<ProvisioningRun, TenancyError> {
     let mut run = ProvisioningRun {
         id: Auto::default(),
+        kind: RunKind::Provision.as_str().to_owned(),
         slug: slug.to_owned(),
         org_id: None,
         state: RunState::Running.as_str().to_owned(),
@@ -342,6 +378,39 @@ pub async fn events_since(
         .order_by(&[("seq", false)])
         .fetch(registry)
         .await?)
+}
+
+/// Open a run for a migration.
+///
+/// `slug` names one tenant, or `None` for every active tenant — a batch
+/// stores an empty slug, and the events name each tenant as they go.
+/// The storage/backend columns stay empty for the same reason: a batch
+/// spans tenants that do not agree on either.
+///
+/// # Errors
+/// Driver / insert failures.
+pub async fn open_migrate_run(
+    registry: &Pool,
+    slug: Option<&str>,
+    requested_by: Option<&str>,
+) -> Result<ProvisioningRun, TenancyError> {
+    let mut run = ProvisioningRun {
+        id: Auto::default(),
+        kind: RunKind::Migrate.as_str().to_owned(),
+        slug: slug.unwrap_or_default().to_owned(),
+        org_id: None,
+        state: RunState::Running.as_str().to_owned(),
+        storage_mode: String::new(),
+        backend_kind: String::new(),
+        database_url: None,
+        requested_by: requested_by.map(ToOwned::to_owned),
+        idempotency_key: None,
+        error: None,
+        started_at: Auto::default(),
+        finished_at: None,
+    };
+    run.insert_pool(registry).await?;
+    Ok(run)
 }
 
 /// The most recent runs, newest first.

--- a/crates/rustango/src/tenancy/provision_store.rs
+++ b/crates/rustango/src/tenancy/provision_store.rs
@@ -344,6 +344,34 @@ pub async fn events_since(
         .await?)
 }
 
+/// The most recent runs, newest first.
+///
+/// A run is reachable by id and nothing enumerated them, so a console
+/// could show a run only while its redirect was still in the address
+/// bar — navigate away and the record survived in the table but not in
+/// anybody's reach. That is the opposite of why the table is persisted.
+///
+/// `limit` is a page size rather than a promise to return everything:
+/// the table grows with provisioning activity and a console asking for
+/// "recent" wants a screenful.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn recent_runs(
+    registry: &Pool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<ProvisioningRun>, TenancyError> {
+    Ok(ProvisioningRun::objects()
+        // Descending — the bool is `desc`, and "recent" means the run
+        // somebody just started is the one at the top.
+        .order_by(&[("id", true)])
+        .limit(limit)
+        .offset(offset)
+        .fetch(registry)
+        .await?)
+}
+
 /// Delete finished runs older than `cutoff`, and their events.
 ///
 /// Runs are append-only and one per tenant creation, so the table grows

--- a/crates/rustango/src/tenancy/provision_webhook.rs
+++ b/crates/rustango/src/tenancy/provision_webhook.rs
@@ -1,0 +1,522 @@
+//! Creating a tenant from an inbound webhook (#1323).
+//!
+//! A billing system fires `checkout.completed`; a tenant appears. The
+//! alternative today is that somebody notices and runs a CLI verb.
+//!
+//! Note the direction. [`crate::webhook_delivery`] is **outbound** —
+//! rustango POSTs signed payloads to subscribers. This is the opposite
+//! way round, and it is the more dangerous one: it accepts input from
+//! outside and creates infrastructure from it.
+//!
+//! ## May the caller name the database?
+//!
+//! **No, by default.** This is the decision worth arguing about, so
+//! here is the argument.
+//!
+//! Accepting `database_url` from the payload means anyone holding the
+//! signing secret can point a tenant at *any host the app can reach* —
+//! including an attacker's, which turns a leaked secret into a
+//! credential-exfiltration primitive (the app connects out and
+//! authenticates), and including internal hosts a request from outside
+//! should never touch. A billing system has no business knowing your
+//! database topology anyway.
+//!
+//! So the default [`UrlPolicy::Template`] derives the URL from a
+//! configured pattern, substituting only the slug, and the caller
+//! supplies nothing but a name. [`UrlPolicy::CallerSupplied`] exists
+//! for the deployment that genuinely orchestrates its own databases —
+//! and a caller who sends a `database_url` under the default policy is
+//! **rejected**, not silently ignored: quietly dropping a field the
+//! caller believed in is how a tenant ends up on the wrong database.
+//!
+//! ## Accept and hand off
+//!
+//! Provisioning takes tens of seconds — well past any webhook
+//! provider's timeout — so the endpoint verifies, opens a run, spawns
+//! the work and returns `202` with the run id. The run is persisted
+//! (#1321), so the outcome is durable and readable from the operator
+//! console even though the task itself is in-process. A pod that dies
+//! mid-run leaves the run in `running`, which is exactly the state
+//! that table was designed to make visible.
+//!
+//! ## What this deliberately does not do
+//!
+//! **Rate limiting.** The crate already ships rate-limiting middleware;
+//! layering it on this route is the caller's call, and a second
+//! limiter baked in here would be one they cannot configure. A leaked
+//! secret should not be an unbounded tenant-creation faucet — say so
+//! in the deployment docs and layer the middleware.
+//!
+//! **The completion callback.** [`crate::webhook_delivery`] needs a job
+//! queue handle, and reaching into the caller's would be guessing at
+//! their setup. The run is pollable and streamable in the meantime.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use crate::webhook::{verify_signature, SignatureFormat};
+
+use super::org::{BackendKind, StorageMode};
+use super::preflight::Preflight;
+use super::provision::{ProvisionRequest, TenantProvisioner};
+use super::provision_store::{self as store, RunState};
+
+/// Where a new tenant's database URL comes from.
+#[derive(Debug, Clone)]
+pub enum UrlPolicy {
+    /// Derive it, substituting `{slug}` in the template.
+    ///
+    /// ```text
+    /// postgres://app:secret@db.internal:5432/tenant_{slug}
+    /// ```
+    ///
+    /// The default, and the safe one: the caller names a tenant, not a
+    /// host. See the module docs.
+    Template(String),
+
+    /// Take `database_url` from the payload.
+    ///
+    /// Only for a deployment that really does orchestrate its own
+    /// databases per tenant. Understand what it grants before using
+    /// it: whoever holds the signing secret chooses what the app
+    /// connects to.
+    CallerSupplied,
+
+    /// Schema-mode tenants: no separate database to name.
+    SchemaMode,
+}
+
+impl Default for UrlPolicy {
+    fn default() -> Self {
+        // No sensible template can be guessed, so the default refuses
+        // rather than inventing one. A deployment must say where
+        // tenant databases live.
+        Self::Template(String::new())
+    }
+}
+
+/// How the endpoint authenticates and what it is allowed to create.
+#[derive(Clone)]
+pub struct WebhookConfig {
+    /// HMAC key. Shared with the caller out of band.
+    pub secret: Arc<Vec<u8>>,
+    /// Which signature encoding the caller sends.
+    pub format: SignatureFormat,
+    /// Header carrying the signature. Providers disagree
+    /// (`X-Hub-Signature-256`, `Stripe-Signature`, …), so it is
+    /// configurable rather than assumed.
+    pub signature_header: String,
+    pub url_policy: UrlPolicy,
+    /// How far out of date a payload's `timestamp` may be.
+    ///
+    /// A signature alone is replayable forever — capture one delivery
+    /// and you can re-send it indefinitely. Five minutes is the
+    /// industry-conventional window and accommodates ordinary clock
+    /// skew.
+    pub timestamp_tolerance: Duration,
+    pub storage_mode: StorageMode,
+    pub backend: BackendKind,
+}
+
+impl WebhookConfig {
+    /// The safe shape: derive URLs from `template`, reject anything the
+    /// caller tries to say about hosts.
+    #[must_use]
+    pub fn new(secret: impl Into<Vec<u8>>, database_url_template: impl Into<String>) -> Self {
+        Self {
+            secret: Arc::new(secret.into()),
+            format: SignatureFormat::HexSha256WithPrefix,
+            signature_header: "x-signature-256".to_owned(),
+            url_policy: UrlPolicy::Template(database_url_template.into()),
+            timestamp_tolerance: Duration::from_secs(300),
+            storage_mode: StorageMode::Database,
+            backend: BackendKind::default(),
+        }
+    }
+}
+
+/// Everything the endpoint needs, as axum state.
+#[derive(Clone)]
+pub struct WebhookState {
+    pub config: WebhookConfig,
+    pub provisioner: Arc<dyn TenantProvisioner>,
+}
+
+/// The payload a caller signs and sends.
+#[derive(Debug, serde::Deserialize)]
+pub struct ProvisionPayload {
+    /// Idempotency key. Every provider retries; this is what makes two
+    /// deliveries of one event produce one tenant.
+    pub event_id: String,
+    /// Unix seconds. Checked against
+    /// [`WebhookConfig::timestamp_tolerance`].
+    pub timestamp: i64,
+    pub slug: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub host_pattern: Option<String>,
+    /// Only honoured under [`UrlPolicy::CallerSupplied`]; **rejected**
+    /// under any other policy rather than ignored.
+    #[serde(default)]
+    pub database_url: Option<String>,
+}
+
+/// What the caller gets back.
+#[derive(Debug, serde::Serialize)]
+pub struct Accepted {
+    pub run_id: i64,
+    pub slug: String,
+    pub state: String,
+    /// True when this delivery matched an existing `event_id` and no
+    /// new work was started.
+    pub duplicate: bool,
+}
+
+/// Why a delivery was refused.
+#[derive(Debug)]
+enum Refusal {
+    BadSignature,
+    Stale,
+    Malformed(String),
+    Policy(String),
+    Internal(String),
+}
+
+impl IntoResponse for Refusal {
+    fn into_response(self) -> Response {
+        let (code, message) = match self {
+            // Deliberately the same opaque answer for a bad signature
+            // and a missing one: an attacker probing the endpoint
+            // learns nothing about which part they got wrong.
+            Self::BadSignature => (StatusCode::UNAUTHORIZED, "invalid signature".to_owned()),
+            Self::Stale => (
+                StatusCode::UNAUTHORIZED,
+                "payload timestamp is outside the accepted window".to_owned(),
+            ),
+            Self::Malformed(m) => (StatusCode::BAD_REQUEST, m),
+            Self::Policy(m) => (StatusCode::FORBIDDEN, m),
+            Self::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
+        };
+        (code, Json(serde_json::json!({ "error": message }))).into_response()
+    }
+}
+
+/// `POST` handler: verify, de-duplicate, hand off, answer.
+///
+/// Takes `Bytes`, not `Json<ProvisionPayload>` — **the signature must
+/// be checked over the exact bytes received**. A handler that
+/// deserializes first and re-serializes to verify is checking a
+/// different document from the one that was signed, which is a
+/// forgery hole wide enough to drive through.
+pub async fn provision_webhook(
+    State(state): State<WebhookState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    match handle(&state, &headers, &body).await {
+        Ok(accepted) => {
+            let code = if accepted.duplicate {
+                StatusCode::OK
+            } else {
+                StatusCode::ACCEPTED
+            };
+            (code, Json(accepted)).into_response()
+        }
+        Err(refusal) => refusal.into_response(),
+    }
+}
+
+async fn handle(
+    state: &WebhookState,
+    headers: &HeaderMap,
+    body: &Bytes,
+) -> Result<Accepted, Refusal> {
+    // ---- 1. Signature, over the raw bytes, before anything else ----
+    let Some(signature) = headers
+        .get(state.config.signature_header.as_str())
+        .and_then(|v| v.to_str().ok())
+    else {
+        return Err(Refusal::BadSignature);
+    };
+    if !verify_signature(state.config.format, &state.config.secret, body, signature) {
+        return Err(Refusal::BadSignature);
+    }
+
+    // ---- 2. Only now is the body worth parsing ----
+    let payload: ProvisionPayload = serde_json::from_slice(body)
+        .map_err(|e| Refusal::Malformed(format!("payload is not the expected JSON: {e}")))?;
+
+    // ---- 3. Replay window ----
+    let age = chrono::Utc::now().timestamp() - payload.timestamp;
+    let tolerance = i64::try_from(state.config.timestamp_tolerance.as_secs()).unwrap_or(i64::MAX);
+    // Both directions: a timestamp far in the *future* is as much a
+    // sign of a forged or misconfigured sender as a stale one.
+    if age.abs() > tolerance {
+        return Err(Refusal::Stale);
+    }
+
+    // ---- 4. Idempotency ----
+    //
+    // Checked here for the common case (a retry arriving after the
+    // first finished). The race — two deliveries at once, both
+    // passing this check — is settled by the unique constraint on
+    // `idempotency_key` when the second tries to open its run.
+    let registry = state.provisioner.registry();
+    if let Some(existing) = store::run_by_idempotency_key(&registry, &payload.event_id)
+        .await
+        .map_err(|e| Refusal::Internal(e.to_string()))?
+    {
+        return Ok(Accepted {
+            run_id: existing.id.get().copied().unwrap_or_default(),
+            slug: existing.slug,
+            state: existing.state,
+            duplicate: true,
+        });
+    }
+
+    // ---- 5. Build the request under the URL policy ----
+    let request = build_request(&state.config, &payload)?;
+
+    // ---- 6. Open the run, then hand off ----
+    //
+    // The run is opened *synchronously* so the caller gets an id it
+    // can poll, and so the idempotency constraint fires now rather
+    // than inside a spawned task where nobody would see it.
+    let run = store::open_run(
+        &registry,
+        &request.slug,
+        request.mode.as_str(),
+        request.backend.as_str(),
+        request.database_url.as_deref(),
+        Some("webhook"),
+        Some(&payload.event_id),
+    )
+    .await
+    .map_err(|e| {
+        // Almost certainly the unique constraint — the race above.
+        // Re-read rather than guess, so a genuine failure is not
+        // reported as a duplicate.
+        Refusal::Internal(format!("could not open a provisioning run: {e}"))
+    })?;
+    let run_id = run.id.get().copied().unwrap_or_default();
+
+    let provisioner = Arc::clone(&state.provisioner);
+    let slug = request.slug.clone();
+    tokio::spawn(async move {
+        // Into the run opened above — `provision_in_run`, not
+        // `provision`, or the task would open a second run for the
+        // same tenant and the caller's id would point at a run that
+        // never progresses.
+        if let Err(e) = provisioner.provision_in_run(run_id, &request).await {
+            // The run itself already records this; the log line is for
+            // an operator tailing the app, who has no reason to be
+            // watching the console.
+            tracing::warn!(
+                target: "rustango::tenancy::provision_webhook",
+                slug = %request.slug,
+                run_id,
+                error = %e,
+                "webhook-initiated provisioning failed"
+            );
+        }
+    });
+
+    Ok(Accepted {
+        run_id,
+        slug,
+        state: RunState::Running.as_str().to_owned(),
+        duplicate: false,
+    })
+}
+
+/// Apply the URL policy, and refuse anything it does not allow.
+fn build_request(
+    config: &WebhookConfig,
+    payload: &ProvisionPayload,
+) -> Result<ProvisionRequest, Refusal> {
+    if payload.slug.trim().is_empty() {
+        return Err(Refusal::Malformed("`slug` must not be empty".to_owned()));
+    }
+    // A slug becomes a database name, a schema name and a subdomain
+    // label. Anything outside this set is either a quoting problem
+    // waiting to happen or a hostname that cannot exist.
+    if !payload
+        .slug
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(Refusal::Malformed(
+            "`slug` may contain only lowercase letters, digits and hyphens".to_owned(),
+        ));
+    }
+
+    let database_url = match (&config.url_policy, &payload.database_url) {
+        // Refused, not ignored: a caller who sent a URL believes it
+        // was used.
+        (UrlPolicy::Template(_) | UrlPolicy::SchemaMode, Some(_)) => {
+            return Err(Refusal::Policy(
+                "this endpoint derives tenant database URLs itself; \
+                 remove `database_url` from the payload"
+                    .to_owned(),
+            ));
+        }
+        (UrlPolicy::Template(template), None) => {
+            if template.is_empty() {
+                return Err(Refusal::Policy(
+                    "no tenant database URL template is configured on this endpoint".to_owned(),
+                ));
+            }
+            Some(template.replace("{slug}", &payload.slug))
+        }
+        (UrlPolicy::SchemaMode, None) => None,
+        (UrlPolicy::CallerSupplied, url) => {
+            let Some(url) = url.as_ref().filter(|u| !u.trim().is_empty()) else {
+                return Err(Refusal::Malformed(
+                    "`database_url` is required by this endpoint's policy".to_owned(),
+                ));
+            };
+            Some(url.clone())
+        }
+    };
+
+    Ok(ProvisionRequest {
+        slug: payload.slug.clone(),
+        mode: config.storage_mode,
+        backend: config.backend,
+        display_name: payload.display_name.clone(),
+        database_url,
+        schema_name: None,
+        host_pattern: payload.host_pattern.clone(),
+        port: None,
+        path_prefix: None,
+        run_migrations: true,
+        preflight: Preflight::default(),
+    })
+}
+
+/// Mount the endpoint at `path`.
+///
+/// ```ignore
+/// let app = app.merge(tenancy::provision_webhook::router(
+///     "/hooks/provision",
+///     WebhookState { config, provisioner },
+/// ));
+/// ```
+///
+/// Layer your rate limiter on the returned router — see the module
+/// docs for why one is not baked in.
+pub fn router(path: &str, state: WebhookState) -> axum::Router {
+    axum::Router::new()
+        .route(path, axum::routing::post(provision_webhook))
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(slug: &str, url: Option<&str>) -> ProvisionPayload {
+        ProvisionPayload {
+            event_id: "evt_1".to_owned(),
+            timestamp: chrono::Utc::now().timestamp(),
+            slug: slug.to_owned(),
+            display_name: None,
+            host_pattern: None,
+            database_url: url.map(ToOwned::to_owned),
+        }
+    }
+
+    fn config(policy: UrlPolicy) -> WebhookConfig {
+        WebhookConfig {
+            url_policy: policy,
+            ..WebhookConfig::new(b"secret".to_vec(), "")
+        }
+    }
+
+    #[test]
+    fn the_template_policy_substitutes_the_slug_and_nothing_else() {
+        let c = config(UrlPolicy::Template(
+            "postgres://app:pw@db.internal:5432/tenant_{slug}".to_owned(),
+        ));
+        let r = build_request(&c, &payload("acme", None)).expect("valid");
+        assert_eq!(
+            r.database_url.as_deref(),
+            Some("postgres://app:pw@db.internal:5432/tenant_acme")
+        );
+    }
+
+    /// The security decision, pinned. A caller-supplied URL under the
+    /// default policy is refused — never silently dropped, because a
+    /// caller who sent one believes it was used.
+    #[test]
+    fn a_caller_supplied_url_is_refused_under_the_template_policy() {
+        let c = config(UrlPolicy::Template("postgres://h/{slug}".to_owned()));
+        let err = build_request(&c, &payload("acme", Some("postgres://attacker/x")))
+            .expect_err("must be refused");
+        assert!(
+            matches!(err, Refusal::Policy(_)),
+            "should be a policy refusal, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn the_caller_supplied_policy_accepts_one_when_deliberately_enabled() {
+        let c = config(UrlPolicy::CallerSupplied);
+        let r = build_request(&c, &payload("acme", Some("postgres://mine/x"))).expect("allowed");
+        assert_eq!(r.database_url.as_deref(), Some("postgres://mine/x"));
+    }
+
+    #[test]
+    fn the_caller_supplied_policy_still_needs_a_url() {
+        let c = config(UrlPolicy::CallerSupplied);
+        assert!(matches!(
+            build_request(&c, &payload("acme", None)),
+            Err(Refusal::Malformed(_))
+        ));
+    }
+
+    /// An unconfigured template refuses rather than inventing a host.
+    #[test]
+    fn an_empty_template_is_a_configuration_refusal() {
+        let c = config(UrlPolicy::Template(String::new()));
+        assert!(matches!(
+            build_request(&c, &payload("acme", None)),
+            Err(Refusal::Policy(_))
+        ));
+    }
+
+    /// A slug becomes a database name, a schema name and a subdomain
+    /// label. Everything outside the safe set is refused at the door.
+    #[test]
+    fn a_slug_is_restricted_to_what_is_safe_everywhere_it_is_used() {
+        let c = config(UrlPolicy::Template("postgres://h/{slug}".to_owned()));
+        for bad in [
+            "Acme",        // uppercase — not a valid hostname label
+            "ac me",       // space
+            "acme;DROP",   // punctuation
+            "acme/../etc", // path traversal
+            "acme'",       // quote
+            "",            // empty
+        ] {
+            assert!(
+                build_request(&c, &payload(bad, None)).is_err(),
+                "slug `{bad}` should have been refused"
+            );
+        }
+        assert!(build_request(&c, &payload("acme-2", None)).is_ok());
+    }
+
+    #[test]
+    fn schema_mode_takes_no_url_at_all() {
+        let c = config(UrlPolicy::SchemaMode);
+        let r = build_request(&c, &payload("acme", None)).expect("valid");
+        assert_eq!(r.database_url, None);
+    }
+}

--- a/crates/rustango/src/tenancy/templates/_op_pager.html
+++ b/crates/rustango/src/tenancy/templates/_op_pager.html
@@ -1,0 +1,36 @@
+{#- Shared pager for every list view, fed by `Paged::inject`.
+
+     Deliberately outside whatever `{% if rows %}` block the caller
+     wraps its table in: when the links lived inside the non-empty
+     branch, a page past the end rendered no navigation at all and only
+     a URL edit escaped it.
+
+     `page_marks` is `Paginator::get_elided_page_range`, so a long list
+     renders `1 … 7 8 9 … 42` rather than forty links. -#}
+{% if total_pages > 1 %}
+<nav class="pager" aria-label="Pagination">
+  {% if has_prev %}
+  <a class="pager-step" href="{{ pager_base }}?page={{ page - 1 }}{{ query_suffix }}" rel="prev">← Previous</a>
+  {% else %}
+  <span class="pager-step pager-disabled">← Previous</span>
+  {% endif %}
+
+  {% for mark in page_marks %}
+    {% if mark.ellipsis %}
+    <span class="pager-gap">…</span>
+    {% elif mark.number == page %}
+    <span class="pager-page pager-current" aria-current="page">{{ mark.number }}</span>
+    {% else %}
+    <a class="pager-page" href="{{ pager_base }}?page={{ mark.number }}{{ query_suffix }}">{{ mark.number }}</a>
+    {% endif %}
+  {% endfor %}
+
+  {% if has_next %}
+  <a class="pager-step" href="{{ pager_base }}?page={{ page + 1 }}{{ query_suffix }}" rel="next">Next →</a>
+  {% else %}
+  <span class="pager-step pager-disabled">Next →</span>
+  {% endif %}
+
+  <span class="pager-total">{{ total }} total</span>
+</nav>
+{% endif %}

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -385,4 +385,23 @@ fieldset.section .brand-asset-preview {
   color: var(--color-fg-muted);
 }
 .badge-base { border-color: var(--color-accent); color: var(--color-accent); }
+
+/* A one-time secret. Loud on purpose: it is shown once and the reader
+   has to notice before navigating away. */
+.alert-secret {
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent-bg-soft);
+}
+.secret-value {
+  display: inline-block;
+  margin-left: var(--space-2);
+  padding: 2px 8px;
+  font-size: 15px;
+  user-select: all; /* one click selects the whole password */
+}
+/* The per-operator reset form is revealed by its `:target`, so the
+   table is not three rows deep per operator until one is wanted. */
+tr.reset-row { display: none; }
+tr.reset-row:target { display: table-row; }
+.inline-reset { display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: center; }
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -466,4 +466,33 @@ tr.run-error td { border-top: 0; padding-top: 0; font-size: 13px; }
 /* A slug can be 63 characters. Without this it sets the column width
    for every other row and pushes the table past the viewport. */
 td.wrap-anywhere { overflow-wrap: anywhere; }
+
+/* Shared pager (`_op_pager.html`). */
+.pager {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1, 4px);
+  align-items: center;
+  margin-top: var(--space-4);
+  font-size: 13px;
+}
+.pager-page, .pager-step {
+  padding: 3px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-accent);
+  text-decoration: none;
+}
+.pager-page:hover, .pager-step:hover { border-color: var(--color-accent); }
+.pager-current {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+  font-weight: var(--font-weight-bold);
+}
+.pager-disabled { color: var(--color-fg-muted); border-color: transparent; }
+.pager-gap { padding: 3px 2px; color: var(--color-fg-muted); }
+/* Beside the links, not pushed right: the floating theme toggle sits
+   in that corner and covered it. */
+.pager-total { margin-left: var(--space-3); color: var(--color-fg-muted); }
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -16,6 +16,18 @@ aside.sidebar {
   padding: var(--space-4) 0;
   display: flex;
   flex-direction: column;
+
+  /* Stay in view while the content scrolls. `align-self` is the part
+     that matters: a flex item stretches to the container's full height
+     by default, and an item already as tall as its container has no
+     room to stick, so the nav scrolled away with the page. Pinning it
+     to the top and giving it the viewport's height restores that room.
+     `overflow-y` covers a viewport too short for the nav itself. */
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
+  overflow-y: auto;
 }
 aside .brand {
   font-weight: var(--font-weight-bold);
@@ -80,6 +92,9 @@ aside form.logout button:hover { background: var(--color-accent-bg-soft); border
 main {
   flex: 1;
   padding: var(--space-5) var(--space-6);
+  /* Also neutralizes the flex `min-width: auto` that would otherwise
+     let a wide table widen the whole shell: the automatic minimum size
+     applies only while overflow is `visible`. */
   overflow-x: auto;
 }
 h1 { margin-top: 0; color: var(--color-accent); }

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -162,6 +162,10 @@ code {
    page (#70). */
 form.edit-form { max-width: 720px; margin-bottom: var(--space-6); }
 form.edit-form + form.edit-form { margin-top: var(--space-6); }
+/* A form directly under a listing. `table` carries a top margin only,
+   and `.edit-form` a bottom one, so the fieldset's border landed flush
+   against the last row and read as another row of it. */
+table + form.edit-form { margin-top: var(--space-6); }
 fieldset.section {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -275,6 +279,7 @@ fieldset.section th {
 }
 th.actions-col, td.actions-col { text-align: right; white-space: nowrap; }
 fieldset.section input[type="text"],
+fieldset.section input[type="password"],
 fieldset.section input[type="number"],
 fieldset.section input[type="date"],
 fieldset.section input[type="datetime-local"],
@@ -291,6 +296,7 @@ fieldset.section select {
   color: var(--color-fg);
 }
 fieldset.section input[type="text"]:focus,
+fieldset.section input[type="password"]:focus,
 fieldset.section input[type="number"]:focus,
 fieldset.section textarea:focus {
   outline: none;
@@ -404,4 +410,20 @@ fieldset.section .brand-asset-preview {
 tr.reset-row { display: none; }
 tr.reset-row:target { display: table-row; }
 .inline-reset { display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: center; }
+/* The row sits outside `fieldset.section`, so it misses the shared
+   input styling and its fields rendered as raw browser defaults next
+   to everything else. */
+.inline-reset input[type="password"] {
+  padding: 0.4rem var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  background: var(--color-bg-input);
+  color: var(--color-fg);
+}
+.inline-reset input[type="password"]:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-bg-soft);
+}
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -356,4 +356,18 @@ fieldset.section .brand-asset-preview {
 .status-ok      { color: var(--color-accent); }
 .status-skipped { color: var(--color-fg-muted); }
 .status-failed  { color: #b3261e; font-weight: var(--font-weight-bold); }
+
+/* Hostname rows: several small forms sit in one actions cell, so they
+   have to sit on a line rather than stack as blocks. */
+.inline-form { display: inline; }
+.inline-form + .inline-form { margin-left: var(--space-2); }
+.badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--color-fg-muted);
+}
+.badge-base { border-color: var(--color-accent); color: var(--color-accent); }
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -324,4 +324,36 @@ fieldset.section .brand-asset-preview {
 }
 .theme-toggle:hover { border-color: var(--color-accent); color: var(--color-accent); }
 .theme-toggle:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+
+/* ---- Tenant provisioning (#1322) ---- */
+
+/* The page-level call to action above the tenant list. */
+.page-actions { margin: 0 0 var(--space-4) 0; }
+
+/* Result of the connection probe, dropped in beside the button. */
+.probe {
+  display: inline-block;
+  margin: var(--space-2) 0 0 0;
+  padding: 0.35rem var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+}
+.probe code { font-size: inherit; }
+.probe-ok {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.probe-bad {
+  /* The console has no danger token, so borrow the alert's. */
+  border-color: currentColor;
+  color: #b3261e;
+}
+
+/* Per-step status in a provisioning run. `started` stays default —
+   it is the neutral "in flight" state and colouring it would compete
+   with the outcome rows that actually need attention. */
+.status-ok      { color: var(--color-accent); }
+.status-skipped { color: var(--color-fg-muted); }
+.status-failed  { color: #b3261e; font-weight: var(--font-weight-bold); }
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -426,4 +426,44 @@ tr.reset-row:target { display: table-row; }
   border-color: var(--color-accent);
   box-shadow: 0 0 0 2px var(--color-accent-bg-soft);
 }
+
+/* Audit log + run history */
+td.nowrap, th.nowrap { white-space: nowrap; }
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin-top: var(--space-4);
+}
+.filter-bar label { color: var(--color-fg-muted); font-size: 13px; }
+.filter-bar input[type="text"] {
+  padding: 0.3rem var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  background: var(--color-bg-input);
+  color: var(--color-fg);
+}
+.filter-bar input[type="text"]:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-bg-soft);
+}
+/* The JSON is the useful column and the tallest, so it opens on
+   demand rather than making every row several lines high. */
+.audit-changes {
+  margin: var(--space-2) 0 0 0;
+  padding: var(--space-2);
+  background: var(--color-bg-sidebar);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  max-width: 40rem;
+  overflow-x: auto;
+}
+tr.run-error td { border-top: 0; padding-top: 0; font-size: 13px; }
+/* A slug can be 63 characters. Without this it sets the column width
+   for every other row and pushes the table past the viewport. */
+td.wrap-anywhere { overflow-wrap: anywhere; }
 </style>

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -467,6 +467,14 @@ tr.run-error td { border-top: 0; padding-top: 0; font-size: 13px; }
    for every other row and pushes the table past the viewport. */
 td.wrap-anywhere { overflow-wrap: anywhere; }
 
+/* The destructive section. Tinted rather than shouty: it sits at the
+   bottom of a page an operator uses for ordinary edits. */
+fieldset.section.danger { border-color: #b3261e; }
+fieldset.section.danger > legend { color: #b3261e; }
+.danger-rule { border: 0; border-top: 1px solid var(--color-border); margin: var(--space-4) 0; }
+.danger-lead { font-size: 13px; color: var(--color-fg-muted); margin: 0 0 var(--space-3) 0; }
+fieldset.section.danger form.edit-form { margin-bottom: 0; }
+
 /* Shared pager (`_op_pager.html`). */
 .pager {
   display: flex;

--- a/crates/rustango/src/tenancy/templates/_op_styles.html
+++ b/crates/rustango/src/tenancy/templates/_op_styles.html
@@ -503,4 +503,43 @@ fieldset.section.danger form.edit-form { margin-bottom: 0; }
 /* Beside the links, not pushed right: the floating theme toggle sits
    in that corner and covered it. */
 .pager-total { margin-left: var(--space-3); color: var(--color-fg-muted); }
+
+/* Narrow screens. 720px to match the admin's breakpoint — the two
+   consoles should not disagree about when a sidebar stops being one.
+   The sticky full-height sidebar is undone here: pinned at 100vh it
+   would fill a phone screen before the content started. */
+@media (max-width: 720px) {
+  .shell { flex-direction: column; }
+  aside.sidebar {
+    width: auto;
+    position: static;
+    height: auto;
+    overflow-y: visible;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--space-2);
+  }
+  aside .brand { border-bottom: 0; margin-bottom: 0; padding-bottom: var(--space-2); }
+  /* A row of links rather than a column: vertical nav plus brand plus
+     sign-out is most of a phone screen before any content. */
+  aside nav { flex: none; display: flex; flex-wrap: wrap; gap: var(--space-1, 4px); }
+  aside nav a {
+    padding: 0.35rem var(--space-3);
+    border-left: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: var(--radius-sm);
+  }
+  aside nav a.active { border-left-color: transparent; border-bottom-color: var(--color-accent); }
+  /* `.who` and the logout form are flex items of the column above, so
+     they stack whatever their `display` says; only the chrome needs
+     adjusting. */
+  aside .who { border-top: 0; padding-bottom: 0; }
+  aside form.logout button { width: auto; margin: var(--space-2) var(--space-4); }
+  main { padding: var(--space-4); }
+  /* Label-above-field: a two-column form table leaves neither column
+     usable at this width. */
+  fieldset.section th, fieldset.section td { display: block; width: auto; }
+  fieldset.section th { padding-bottom: 0; }
+  .filter-bar, .inline-reset { flex-direction: column; align-items: stretch; }
+}
 </style>

--- a/crates/rustango/src/tenancy/templates/op_audit.html
+++ b/crates/rustango/src/tenancy/templates/op_audit.html
@@ -66,16 +66,5 @@ Registry-scoped — a tenant's own history lives in that tenant's admin.</p>
 </table>
 {% endif %}
 
-{#- Outside the empty/non-empty branch on purpose: see above. -#}
-{% if page > 1 or has_next %}
-<p class="form-actions">
-  {% if page > 1 %}
-  <a class="btn btn-secondary" href="/audit?page={{ page - 1 }}{{ query_suffix }}">← Newer</a>
-  {% endif %}
-  {% if has_next %}
-  <a class="btn btn-secondary" href="/audit?page={{ page + 1 }}{{ query_suffix }}">Older →</a>
-  {% endif %}
-  <span class="field-helper">page {{ page }}</span>
-</p>
-{% endif %}
+{% include "_op_pager.html" %}
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_audit.html
+++ b/crates/rustango/src/tenancy/templates/op_audit.html
@@ -1,0 +1,81 @@
+{% extends "op_layout.html" %}
+{% block title %}Audit log — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block content %}
+<h1>Audit log</h1>
+<p class="lead">Every change made through this console, newest first.
+Registry-scoped — a tenant's own history lives in that tenant's admin.</p>
+
+<form method="get" action="/audit" class="filter-bar">
+  <label for="entity_table">entity</label>
+  <input type="text" id="entity_table" name="entity_table"
+         value="{{ filter_entity_table }}" placeholder="rustango_orgs">
+  <label for="entity_pk">id</label>
+  <input type="text" id="entity_pk" name="entity_pk"
+         value="{{ filter_entity_pk }}" placeholder="acme">
+  <label for="operation">operation</label>
+  <input type="text" id="operation" name="operation"
+         value="{{ filter_operation }}" placeholder="action">
+  <button type="submit" class="btn btn-secondary">Filter</button>
+  <a href="/audit" class="btn-link">Clear</a>
+</form>
+
+{% if entries | length == 0 %}
+  <div class="empty">
+    {#- On a page past the end this must not read as "nothing has ever
+        happened", and it must still offer a way back — the paging
+        links below used to live inside the non-empty branch, so an
+        empty page 2 was a dead end only a URL edit escaped. -#}
+    {% if page > 1 %}Nothing on page {{ page }}.
+    {% else %}Nothing recorded yet{% if query_suffix %} for this filter{% endif %}.
+    {% endif %}
+  </div>
+{% else %}
+<table>
+  <thead>
+    <tr>
+      <th>When</th>
+      <th>Who</th>
+      <th>Did</th>
+      <th>To</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for e in entries %}
+    <tr>
+      <td class="nowrap">{{ e.occurred_at }}</td>
+      <td>{{ e.who }}</td>
+      <td><code>{{ e.what }}</code></td>
+      <td>
+        <code>{{ e.entity_table }}</code>
+        <a class="btn-link"
+           href="/audit?entity_table={{ e.entity_table }}&entity_pk={{ e.entity_pk }}"
+           title="Show only this record's history">{{ e.entity_pk }}</a>
+      </td>
+      <td>
+        {#- Collapsed by default: the JSON is the useful part but it is
+            also the tallest, and a page of expanded blobs is unreadable. -#}
+        <details>
+          <summary>changes</summary>
+          <pre class="audit-changes">{{ e.changes }}</pre>
+        </details>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+{#- Outside the empty/non-empty branch on purpose: see above. -#}
+{% if page > 1 or has_next %}
+<p class="form-actions">
+  {% if page > 1 %}
+  <a class="btn btn-secondary" href="/audit?page={{ page - 1 }}{{ query_suffix }}">← Newer</a>
+  {% endif %}
+  {% if has_next %}
+  <a class="btn btn-secondary" href="/audit?page={{ page + 1 }}{{ query_suffix }}">Older →</a>
+  {% endif %}
+  <span class="field-helper">page {{ page }}</span>
+</p>
+{% endif %}
+{% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_layout.html
+++ b/crates/rustango/src/tenancy/templates/op_layout.html
@@ -24,6 +24,7 @@
         <a href="/operators" class="{% if section == 'operators' %}active{% endif %}">Operators</a>
         <a href="/orgs" class="{% if section == 'orgs' %}active{% endif %}">Organizations</a>
         {% if sso_console %}<a href="/sso-shared" class="{% if section == 'sso' %}active{% endif %}">Shared SSO</a>{% endif %}
+        <a href="/audit" class="{% if section == 'audit' %}active{% endif %}">Audit log</a>
         <a href="/change-password" class="{% if section == 'change_password' %}active{% endif %}">Change password</a>
       </nav>
       <div class="who">Signed in as <strong>{{ operator_username }}</strong></div>

--- a/crates/rustango/src/tenancy/templates/op_operators.html
+++ b/crates/rustango/src/tenancy/templates/op_operators.html
@@ -128,9 +128,8 @@ reach every tenant, so this list is the console's access control.</p>
           <input type="password" id="password" name="password"
                  minlength="8" autocomplete="new-password"
                  placeholder="at least 8 characters">
-          <div class="field-helper">Or leave both blank and use
-          <em>Generate one</em> — the password is then shown once, here,
-          and never again.</div>
+          <div class="field-helper">Leave blank to have one generated
+          instead — it is then shown once, here, and never again.</div>
         </td>
       </tr>
       <tr>
@@ -142,9 +141,13 @@ reach every tenant, so this list is the console's access control.</p>
       </tr>
     </table>
   </fieldset>
+  {#- Both buttons submit and both create the operator; they differ
+      only in where the password comes from. The second therefore says
+      "Add", not "Generate one" — that read as a helper that would fill
+      the field in and leave you to press the real button. -#}
   <p class="form-actions">
     <button type="submit" class="btn btn-primary">Add operator</button>
-    <button type="submit" name="generate" value="on" class="btn btn-secondary">Generate one</button>
+    <button type="submit" name="generate" value="on" class="btn btn-secondary">Add with a generated password</button>
   </p>
 </form>
 {% else %}

--- a/crates/rustango/src/tenancy/templates/op_operators.html
+++ b/crates/rustango/src/tenancy/templates/op_operators.html
@@ -2,28 +2,153 @@
 {% block title %}Operators — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
 <h1>Operators</h1>
-<p>Registry-scoped administrators. Mutations go through
-<code>cargo run -- create-operator &lt;username&gt; --password &lt;p&gt;</code>
-(routed through <code>rustango::manage::Cli</code>; substitute your
-project's binary name if different).</p>
+<p class="lead">Registry-scoped administrators. Every operator can
+reach every tenant, so this list is the console's access control.</p>
+
+{% if error %}
+<div class="alert alert-error">{{ error }}</div>
+{% endif %}
+{% if notice %}
+<div class="alert alert-notice">{{ notice }}</div>
+{% endif %}
+
+{#- Shown once, on the response to the POST that made it. It never
+    travels through a redirect, so it stays out of the URL bar, the
+    history and the access logs. -#}
+{% if new_password %}
+<div class="alert alert-secret">
+  <strong>Password for <code>{{ new_username }}</code>:</strong>
+  <code class="secret-value">{{ new_password }}</code>
+  <div class="field-helper">Copy it now — it is not stored in
+  recoverable form and will not be shown again. Send it to
+  <code>{{ new_username }}</code> over something private, and have them
+  change it at <code>/change-password</code>.</div>
+</div>
+{% endif %}
+
 {% if operators | length == 0 %}
-  <div class="empty">No operators yet — create one with
-  <code>cargo run -- create-operator</code>.</div>
+  <div class="empty">No operators yet.</div>
 {% else %}
 <table>
   <thead>
-    <tr><th>ID</th><th>Username</th><th>Active</th><th>Created</th></tr>
+    <tr>
+      <th>ID</th>
+      <th>Username</th>
+      <th>Active</th>
+      <th>Created</th>
+      <th>Password set</th>
+      {% if manage_enabled %}<th class="actions-col">Actions</th>{% endif %}
+    </tr>
   </thead>
   <tbody>
     {% for op in operators %}
     <tr>
       <td>{{ op.id }}</td>
-      <td>{{ op.username }}</td>
-      <td>{% if op.active %}✓{% else %}—{% endif %}</td>
+      <td>
+        <strong>{{ op.username }}</strong>
+        {% if op.is_self %}<span class="badge badge-base">you</span>{% endif %}
+      </td>
+      <td>
+        {% if op.active %}
+        <span class="status-ok">✓</span>
+        {% else %}
+        <span class="status-skipped">—</span>
+        {% endif %}
+      </td>
       <td>{{ op.created_at }}</td>
+      <td>
+        {% if op.password_changed_at %}{{ op.password_changed_at }}
+        {% else %}<span class="empty">never rotated</span>{% endif %}
+      </td>
+      {% if manage_enabled %}
+      <td class="actions-col">
+        {#- Two deactivations are refused by the server, and saying so
+            here beats a button that only ever returns an error: your
+            own account (the next request would log you out) and the
+            last active one (nobody could sign in again). -#}
+        {% if op.active and op.is_self %}
+        <span class="field-helper">that's you</span>
+        {% elif op.active and op.last_active %}
+        <span class="field-helper">last active operator</span>
+        {% else %}
+        <form method="post" action="/operators/{{ op.id }}/active" class="inline-form">
+          {% if op.active %}
+          <button type="submit" class="btn btn-secondary"
+                  onclick="return confirm('Deactivate {{ op.username }}? They are signed out on their next request.');">Deactivate</button>
+          {% else %}
+          <input type="hidden" name="active" value="on">
+          <button type="submit" class="btn btn-secondary">Activate</button>
+          {% endif %}
+        </form>
+        {% endif %}
+        <a class="btn-row-action" href="#reset-{{ op.id }}">Reset password</a>
+      </td>
+      {% endif %}
     </tr>
+    {% if manage_enabled %}
+    <tr id="reset-{{ op.id }}" class="reset-row">
+      <td colspan="6">
+        <form method="post" action="/operators/{{ op.id }}/reset-password" class="inline-reset">
+          <strong>Reset <code>{{ op.username }}</code>:</strong>
+          <input type="password" name="password" placeholder="new password"
+                 minlength="8" autocomplete="new-password">
+          <input type="password" name="confirm_password" placeholder="confirm"
+                 minlength="8" autocomplete="new-password">
+          <button type="submit" class="btn btn-secondary">Set</button>
+          <button type="submit" name="generate" value="on" class="btn btn-secondary">Generate one</button>
+          <span class="field-helper">Signs
+          {% if op.is_self %}you{% else %}<code>{{ op.username }}</code>{% endif %}
+          out everywhere.</span>
+        </form>
+      </td>
+    </tr>
+    {% endif %}
     {% endfor %}
   </tbody>
 </table>
+{% endif %}
+
+{% if manage_enabled %}
+<form method="post" action="/operators" class="edit-form">
+  <fieldset class="section">
+    <legend>Add an operator</legend>
+    <table>
+      <tr>
+        <th><label for="username">username</label></th>
+        <td>
+          <input type="text" id="username" name="username" required
+                 maxlength="64" autocomplete="off" placeholder="jordan">
+          <div class="field-helper">Their login handle, unique across
+          the registry.</div>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="password">password</label></th>
+        <td>
+          <input type="password" id="password" name="password"
+                 minlength="8" autocomplete="new-password"
+                 placeholder="at least 8 characters">
+          <div class="field-helper">Or leave both blank and use
+          <em>Generate one</em> — the password is then shown once, here,
+          and never again.</div>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="confirm_password">confirm</label></th>
+        <td>
+          <input type="password" id="confirm_password" name="confirm_password"
+                 minlength="8" autocomplete="new-password">
+        </td>
+      </tr>
+    </table>
+  </fieldset>
+  <p class="form-actions">
+    <button type="submit" class="btn btn-primary">Add operator</button>
+    <button type="submit" name="generate" value="on" class="btn btn-secondary">Generate one</button>
+  </p>
+</form>
+{% else %}
+<p class="field-helper">This console is read-only, so operators cannot
+be changed here. Use <code>create-operator</code> on the command line.</p>
 {% endif %}
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_operators.html
+++ b/crates/rustango/src/tenancy/templates/op_operators.html
@@ -108,6 +108,8 @@ reach every tenant, so this list is the console's access control.</p>
 </table>
 {% endif %}
 
+{% include "_op_pager.html" %}
+
 {% if manage_enabled %}
 <form method="post" action="/operators" class="edit-form">
   <fieldset class="section">

--- a/crates/rustango/src/tenancy/templates/op_org_hosts.html
+++ b/crates/rustango/src/tenancy/templates/op_org_hosts.html
@@ -1,0 +1,107 @@
+{% extends "op_layout.html" %}
+{% block title %}Hostnames for {{ slug }} — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block content %}
+<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span><a href="/orgs/{{ slug }}/edit">{{ slug }}</a><span class="sep">/</span>Hostnames</p>
+<h1>Hostnames for <code>{{ slug }}</code></h1>
+<p class="lead">Every hostname this tenant answers on. Each is matched
+exactly against the <code>Host</code> header, so a hostname belongs to
+one tenant only.</p>
+
+{% if error %}
+<div class="alert alert-error">{{ error }}</div>
+{% endif %}
+{% if notice %}
+<div class="alert alert-notice">{{ notice }}</div>
+{% endif %}
+
+<table>
+  <thead>
+    <tr>
+      <th>hostname</th>
+      <th>source</th>
+      <th>serving</th>
+      <th class="actions-col">actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for h in hosts %}
+    <tr>
+      <td><code>{{ h.hostname }}</code></td>
+      <td>
+        {% if h.is_base %}
+        <span class="badge badge-base">base</span>
+        {% else %}
+        <span class="badge">extra</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if h.enabled %}
+        <span class="status-ok">yes</span>
+        {% else %}
+        <span class="status-skipped">parked</span>
+        {% endif %}
+      </td>
+      <td class="actions-col">
+        {#- The base host has no row in `rustango_org_hosts`, so there
+            is nothing here to toggle or delete. Saying where it *is*
+            editable beats showing disabled buttons. -#}
+        {% if h.is_base %}
+        <span class="field-helper">set on the <a href="/orgs/{{ slug }}/edit">edit page</a></span>
+        {% else %}
+        <form method="post" action="/orgs/{{ slug }}/hosts/toggle" class="inline-form">
+          <input type="hidden" name="hostname" value="{{ h.hostname }}">
+          {% if h.enabled %}
+          <button type="submit" class="btn btn-secondary">Park</button>
+          {% else %}
+          <input type="hidden" name="enabled" value="on">
+          <button type="submit" class="btn btn-secondary">Serve</button>
+          {% endif %}
+        </form>
+        <form method="post" action="/orgs/{{ slug }}/hosts/remove" class="inline-form"
+              onsubmit="return confirm('Remove {{ h.hostname }}? Traffic to it stops resolving to {{ slug }}.');">
+          <input type="hidden" name="hostname" value="{{ h.hostname }}">
+          <button type="submit" class="btn btn-danger">Remove</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<form method="post" action="/orgs/{{ slug }}/hosts/add" class="edit-form">
+  <fieldset class="section">
+    <legend>Add a hostname</legend>
+    <table>
+      <tr>
+        <th><label for="hostname">hostname</label></th>
+        <td>
+          {#- Uppercase is allowed through and lowercased by the
+              server, because that is what `normalize_hostname` does and
+              refusing here would make the browser stricter than the
+              thing it is previewing.
+
+              The hyphen is escaped on purpose: `[a-z0-9-]` is a syntax
+              error under the `v`-flag regex `pattern` now uses, and a
+              browser that cannot parse the attribute ignores it
+              silently — so the field would have no validation at all
+              while looking like it did. -#}
+          <input type="text" id="hostname" name="hostname" required autofocus
+                 pattern="[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?)*"
+                 maxlength="255"
+                 title="A bare hostname: no scheme, no port, no path."
+                 placeholder="shop.example.com">
+          <div class="field-helper">Lowercase, no <code>https://</code>,
+          no <code>:port</code>, no trailing dot — the value is compared
+          byte-for-byte with the <code>Host</code> header. Added serving;
+          park it afterwards if DNS has not propagated yet.</div>
+        </td>
+      </tr>
+    </table>
+  </fieldset>
+  <p class="form-actions">
+    <button type="submit" class="btn btn-primary">Add hostname</button>
+    <a href="/orgs/{{ slug }}/edit" class="btn-link">Back to tenant</a>
+  </p>
+</form>
+{% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -5,6 +5,7 @@
 {% if provisioning_enabled %}
 <p class="page-actions">
   <a href="/orgs/new" class="btn btn-primary">+ New tenant</a>
+  <a href="/orgs/provision" class="btn btn-secondary">Provisioning runs</a>
 </p>
 <p>Tenants the registry knows about. Create one here, or from the CLI
 with <code>cargo run -- create-tenant</code>; removal is

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -5,7 +5,11 @@
 {% if provisioning_enabled %}
 <p class="page-actions">
   <a href="/orgs/new" class="btn btn-primary">+ New tenant</a>
-  <a href="/orgs/provision" class="btn btn-secondary">Provisioning runs</a>
+  <a href="/orgs/provision" class="btn btn-secondary">Runs</a>
+  <form method="post" action="/orgs/migrate" class="inline-form"
+        onsubmit="return confirm('Run migrations for every active tenant?');">
+    <button type="submit" class="btn btn-secondary">Migrate all tenants</button>
+  </form>
 </p>
 <p>Tenants the registry knows about. Create one here, or from the CLI
 with <code>cargo run -- create-tenant</code>; removal is

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -54,4 +54,6 @@ with <code>cargo run -- create-tenant</code>; removal is
   </tbody>
 </table>
 {% endif %}
+
+{% include "_op_pager.html" %}
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -2,6 +2,12 @@
 {% block title %}Organizations — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
 <h1>Organizations</h1>
+
+{#- Where a decommission reports back: it removes the tenant, so there
+    is no tenant page left to return to. -#}
+{% if error %}<div class="alert alert-error">{{ error }}</div>{% endif %}
+{% if notice %}<div class="alert alert-notice">{{ notice }}</div>{% endif %}
+
 {% if provisioning_enabled %}
 <p class="page-actions">
   <a href="/orgs/new" class="btn btn-primary">+ New tenant</a>

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -2,13 +2,29 @@
 {% block title %}Organizations — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
 <h1>Organizations</h1>
+{% if provisioning_enabled %}
+<p class="page-actions">
+  <a href="/orgs/new" class="btn btn-primary">+ New tenant</a>
+</p>
+<p>Tenants the registry knows about. Create one here, or from the CLI
+with <code>cargo run -- create-tenant</code>; removal is
+<code>cargo run -- drop-tenant</code>.</p>
+{% else %}
 <p>Tenants the registry knows about. Mutations go through
 <code>cargo run -- create-tenant</code> / <code>cargo run -- drop-tenant</code>
 (or whatever your project binary is — runs through
-<code>rustango::manage::Cli</code>).</p>
+<code>rustango::manage::Cli</code>). To create tenants from here, add
+<code>.with_tenant_provisioning("migrations")</code> to the
+<code>Cli</code> builder.</p>
+{% endif %}
 {% if orgs | length == 0 %}
+  {% if provisioning_enabled %}
+  <div class="empty">No tenants yet —
+  <a href="/orgs/new">create the first one</a>.</div>
+  {% else %}
   <div class="empty">No tenants yet — provision one with
   <code>cargo run -- create-tenant &lt;slug&gt;</code>.</div>
+  {% endif %}
 {% else %}
 <table>
   <thead>

--- a/crates/rustango/src/tenancy/templates/op_orgs_edit.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_edit.html
@@ -29,6 +29,8 @@
     a link from here, or nothing reaches it. -#}
 <p class="page-actions">
   <a href="/orgs/{{ slug }}/hosts" class="btn btn-secondary">Hostnames →</a>
+  <button type="button" class="btn btn-secondary" id="test-connection">Test connection</button>
+  <span id="probe-result"></span>
   {% if provisioning_enabled %}
   <form method="post" action="/orgs/{{ slug }}/migrate" class="inline-form"
         onsubmit="return confirm('Run migrations for {{ slug }}?');">
@@ -171,4 +173,22 @@
   </form>
 </fieldset>
 
+<script>
+  // Drops the returned fragment in place, so an operator can check a
+  // tenant without losing unsaved edits to a page reload. The URL is
+  // resolved server-side and never sent here — it carries a password.
+  document.getElementById("test-connection").addEventListener("click", async (e) => {
+    const out = document.getElementById("probe-result");
+    e.target.disabled = true;
+    out.textContent = "checking…";
+    try {
+      const res = await fetch("/orgs/{{ slug }}/test-connection", { method: "POST" });
+      out.innerHTML = await res.text();
+    } catch (err) {
+      out.textContent = "could not reach the console: " + err;
+    } finally {
+      e.target.disabled = false;
+    }
+  });
+</script>
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_orgs_edit.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_edit.html
@@ -125,4 +125,50 @@
 </form>
 {% endif %}
 
+{#- Two actions with very different consequences, kept visibly apart.
+    Deactivating is one click and reversible; purging asks for the slug
+    and destroys the storage. No `edit_enabled` guard: this whole page
+    is only mounted on a console that can edit. -#}
+<fieldset class="section danger">
+  <legend>Decommission</legend>
+
+  <form method="post" action="/orgs/{{ slug }}/deactivate" class="inline-form"
+        onsubmit="return confirm('Deactivate {{ slug }}? It stops serving immediately; nothing is destroyed.');">
+    <button type="submit" class="btn btn-secondary">Deactivate</button>
+  </form>
+  <div class="field-helper">Stops serving on the next request. The data
+  stays and the tenant can be switched back on from this page.</div>
+
+  <hr class="danger-rule">
+
+  <form method="post" action="/orgs/{{ slug }}/purge" class="edit-form">
+    <p class="danger-lead"><strong>Purge — permanent.</strong>
+    Drops this tenant's schema or database and removes its registry row.
+    There is no undo and no backup taken.</p>
+    <table>
+      <tr>
+        <th><label for="confirm">type the slug</label></th>
+        <td>
+          <input type="text" id="confirm" name="confirm" autocomplete="off"
+                 placeholder="{{ slug }}">
+          <div class="field-helper">Type <code>{{ slug }}</code> exactly.</div>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="purge_database">drop the database</label></th>
+        <td>
+          <input type="checkbox" id="purge_database" name="purge_database" value="on">
+          <div class="field-helper">Required for a database-mode tenant,
+          where purging means <code>DROP DATABASE</code>. Schema-mode
+          tenants ignore this.</div>
+        </td>
+      </tr>
+    </table>
+    <p class="form-actions">
+      <button type="submit" class="btn btn-danger"
+              onclick="return confirm('Permanently destroy {{ slug }} and all its data?');">Purge {{ slug }}</button>
+    </p>
+  </form>
+</fieldset>
+
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_orgs_edit.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_edit.html
@@ -23,6 +23,14 @@
 {% if error %}<div class="alert alert-error">{{ error }}</div>{% endif %}
 {% if notice %}<div class="alert alert-notice">{{ notice }}</div>{% endif %}
 
+{#- `host_pattern` below is the tenant's *base* host, and it is one
+    field. The extra hostnames it can also answer on are a collection
+    with their own verbs, so they live on their own page — which needs
+    a link from here, or nothing reaches it. -#}
+<p class="page-actions">
+  <a href="/orgs/{{ slug }}/hosts" class="btn btn-secondary">Hostnames →</a>
+</p>
+
 <form method="post" action="/orgs/{{ slug }}/edit" class="edit-form">
 
   <fieldset class="section locked">

--- a/crates/rustango/src/tenancy/templates/op_orgs_edit.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_edit.html
@@ -29,6 +29,12 @@
     a link from here, or nothing reaches it. -#}
 <p class="page-actions">
   <a href="/orgs/{{ slug }}/hosts" class="btn btn-secondary">Hostnames →</a>
+  {% if provisioning_enabled %}
+  <form method="post" action="/orgs/{{ slug }}/migrate" class="inline-form"
+        onsubmit="return confirm('Run migrations for {{ slug }}?');">
+    <button type="submit" class="btn btn-secondary">Run migrations</button>
+  </form>
+  {% endif %}
 </p>
 
 <form method="post" action="/orgs/{{ slug }}/edit" class="edit-form">

--- a/crates/rustango/src/tenancy/templates/op_orgs_new.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_new.html
@@ -1,125 +1,242 @@
 {% extends "op_layout.html" %}
 {% block title %}New tenant — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
+<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span>New tenant</p>
 <h1>New tenant</h1>
-<p>Stands the tenant up end to end: reaches its database, registers it,
-runs its migrations, and only then makes it live. Nothing is written
-until the connection check passes.</p>
+<p class="lead">Reaches the database, registers the tenant, runs its
+migrations, and only then makes it live. Nothing is written until the
+connection check passes.</p>
 
 {% if error %}
-<div class="empty" style="border-color:var(--danger,#b3261e);color:var(--danger,#b3261e)">
-  {{ error }}
-</div>
+<div class="alert alert-error">{{ error }}</div>
 {% endif %}
 
-<form method="post" action="new" class="stack">
-  <label>
-    Slug
-    <input type="text" name="slug" required autofocus
-           value="{{ prefill.slug | default(value='') }}"
-           pattern="[a-z0-9][a-z0-9-]*"
-           placeholder="acme">
-    <small>Globally unique. Also the default schema name, display name
-    and subdomain label.</small>
-  </label>
+<form method="post" action="/orgs/new" class="edit-form">
+  <fieldset class="section">
+    <legend>Identity</legend>
+    <table>
+      <tr>
+        <th><label for="slug">slug</label></th>
+        <td>
+          {#- The hyphen is escaped on purpose. `[a-z0-9-]` is a syntax
+              error under the `v`-flag regex the HTML spec now uses for
+              `pattern`, and a browser that cannot parse the attribute
+              ignores it *silently* — so the field had no client-side
+              validation at all, which is how a slug with a space got
+              through to the server. -#}
+          <input type="text" id="slug" name="slug" required autofocus
+                 value="{{ prefill.slug | default(value='') }}"
+                 pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?"
+                 maxlength="63"
+                 title="Lowercase letters, digits and hyphens; cannot start or end with a hyphen."
+                 placeholder="acme">
+          <div class="field-helper">Globally unique, lowercase. Also the
+          default schema name, display name and subdomain label.</div>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="display_name">display_name</label></th>
+        <td>
+          <input type="text" id="display_name" name="display_name"
+                 value="{{ prefill.display_name | default(value='') }}"
+                 placeholder="defaults to the slug">
+        </td>
+      </tr>
+    </table>
+  </fieldset>
 
-  <label>
-    Display name
-    <input type="text" name="display_name"
-           value="{{ prefill.display_name | default(value='') }}"
-           placeholder="defaults to the slug">
-  </label>
+  <fieldset class="section">
+    <legend>Storage</legend>
+    <table>
+      <tr>
+        <th><label for="storage_mode">storage_mode</label></th>
+        <td>
+          <select id="storage_mode" name="storage_mode">
+            <option value="database" {% if prefill.storage_mode | default(value="database") != "schema" %}selected{% endif %}>database — its own database</option>
+            {% if schema_mode_available %}
+            <option value="schema" {% if prefill.storage_mode | default(value="") == "schema" %}selected{% endif %}>schema — a schema in the registry database</option>
+            {% endif %}
+          </select>
+          {% if not schema_mode_available %}
+          <div class="field-helper">Schema mode needs a Postgres
+          registry — this one is not, so only database mode is offered.</div>
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <th><label for="backend_kind">backend_kind</label></th>
+        <td>
+          {#- Only what this binary was built with. Offering a backend
+              it cannot speak produced an error telling the operator to
+              edit Cargo.toml. -#}
+          <select id="backend_kind" name="backend_kind">
+            {% for b in backends %}
+            <option value="{{ b }}" {% if prefill.backend_kind | default(value=backends[0]) == b %}selected{% endif %}>{{ b }}</option>
+            {% endfor %}
+          </select>
+          {% if backends | length == 1 %}
+          <div class="field-helper">This build supports
+          <code>{{ backends[0] }}</code> only.</div>
+          {% endif %}
+        </td>
+      </tr>
 
-  <label>
-    Storage mode
-    <select name="storage_mode">
-      <option value="database" {% if prefill.storage_mode | default(value="database") != "schema" %}selected{% endif %}>
-        database — its own database
-      </option>
-      {% if schema_mode_available %}
-      <option value="schema" {% if prefill.storage_mode | default(value="") == "schema" %}selected{% endif %}>
-        schema — a schema in the registry database (Postgres only)
-      </option>
-      {% endif %}
-    </select>
-    {% if not schema_mode_available %}
-    <small>Schema mode needs a Postgres registry — this one is not,
-    so only database mode is offered.</small>
-    {% endif %}
-  </label>
+      {# ---- database mode: name the database, do not retype a URL ---- #}
+      <tr class="mode-database">
+        <th><label for="database_name">database</label></th>
+        <td>
+          <input type="text" id="database_name" name="database_name"
+                 value="{{ prefill.database_name | default(value='') }}"
+                 placeholder="tenant_acme">
+          <div class="field-helper">
+            A database on the same server as the registry. Blank uses
+            <code id="database-name-default">tenant_&lt;slug&gt;</code>.
+            {% if derived_url_example %}
+            Becomes <code id="derived-url">{{ derived_url_example }}</code>.
+            {% endif %}
+          </div>
+        </td>
+      </tr>
+      <tr class="mode-database">
+        <th><label for="database_url">or a full URL</label></th>
+        <td>
+          <input type="text" id="database_url" name="database_url"
+                 value="{{ prefill.database_url | default(value='') }}"
+                 placeholder="leave blank unless the tenant lives elsewhere">
+          <div class="field-helper">Only for a tenant on a different
+          server. Overrides the database name above.</div>
+          <p class="form-actions">
+            <button type="button" class="btn btn-secondary" id="test-connection">Test connection</button>
+            <span id="probe-result"></span>
+          </p>
+        </td>
+      </tr>
 
-  <label>
-    Backend
-    <select name="backend_kind">
-      {% for b in ["postgres", "mysql", "sqlite"] %}
-      <option value="{{ b }}" {% if prefill.backend_kind | default(value="postgres") == b %}selected{% endif %}>{{ b }}</option>
-      {% endfor %}
-    </select>
-  </label>
+      {# ---- schema mode: nothing to name but the schema ---- #}
+      <tr class="mode-schema" hidden>
+        <th><label for="schema_name">schema</label></th>
+        <td>
+          <input type="text" id="schema_name" name="schema_name"
+                 value="{{ prefill.schema_name | default(value='') }}"
+                 placeholder="defaults to the slug">
+          <div class="field-helper">The tenant lives in the registry's
+          own database, isolated by <code>search_path</code>. There is no
+          separate connection to configure.</div>
+        </td>
+      </tr>
+    </table>
+  </fieldset>
 
-  <label>
-    Database URL
-    <input type="text" name="database_url" id="database_url"
-           value="{{ prefill.database_url | default(value='') }}"
-           placeholder="postgres://user:password@host:5432/acme">
-    <small>Required in database mode. Ignored in schema mode, where the
-    tenant lives in the registry's own database.</small>
-  </label>
+  <fieldset class="section">
+    <legend>Routing</legend>
+    <table>
+      <tr>
+        <th><label for="host_pattern">host_pattern</label></th>
+        <td>
+          <input type="text" id="host_pattern" name="host_pattern"
+                 value="{{ prefill.host_pattern | default(value='') }}"
+                 placeholder="acme.example.com">
+          <div class="field-helper">Blank derives
+          <code>&lt;slug&gt;.&lt;RUSTANGO_APEX_DOMAIN&gt;</code> when that
+          variable is set.</div>
+        </td>
+      </tr>
+      <tr>
+        <th><label for="path_prefix">path_prefix</label></th>
+        <td><input type="text" id="path_prefix" name="path_prefix"
+                   value="{{ prefill.path_prefix | default(value='') }}"
+                   placeholder="/acme"></td>
+      </tr>
+      <tr>
+        <th><label for="port">port</label></th>
+        <td><input type="text" id="port" name="port" inputmode="numeric"
+                   value="{{ prefill.port | default(value='') }}"></td>
+      </tr>
+    </table>
+  </fieldset>
 
-  <p>
-    <button type="button" id="test-connection">Test connection</button>
-    <span id="probe-result"></span>
-  </p>
+  <fieldset class="section">
+    <legend>Migrations</legend>
+    <table>
+      <tr>
+        <th><label for="no_migrate">skip</label></th>
+        <td>
+          <input type="checkbox" id="no_migrate" name="no_migrate" value="on"
+                 {% if prefill.no_migrate | default(value=false) %}checked{% endif %}>
+          <div class="field-helper">Register the tenant without building
+          its schema. It still goes live; migrate it later.</div>
+        </td>
+      </tr>
+    </table>
+  </fieldset>
 
-  <label>
-    Host pattern
-    <input type="text" name="host_pattern"
-           value="{{ prefill.host_pattern | default(value='') }}"
-           placeholder="acme.example.com">
-    <small>Leave blank to derive <code>&lt;slug&gt;.&lt;RUSTANGO_APEX_DOMAIN&gt;</code>
-    when that variable is set.</small>
-  </label>
-
-  <label>
-    Path prefix
-    <input type="text" name="path_prefix"
-           value="{{ prefill.path_prefix | default(value='') }}"
-           placeholder="/acme">
-  </label>
-
-  <label>
-    Port
-    <input type="text" name="port" inputmode="numeric"
-           value="{{ prefill.port | default(value='') }}">
-  </label>
-
-  <label class="inline">
-    <input type="checkbox" name="no_migrate" value="on"
-           {% if prefill.no_migrate | default(value=false) %}checked{% endif %}>
-    Skip migrations — register the tenant without building its schema.
-    It will still go live; migrate it later.
-  </label>
-
-  <p>
-    <button type="submit" class="primary">Create tenant</button>
-    <a href="../orgs">Cancel</a>
+  <p class="form-actions">
+    <button type="submit" class="btn btn-primary">Create tenant</button>
+    <a href="/orgs" class="btn-link">Cancel</a>
   </p>
 </form>
 
 <script>
+  // The form shows only the fields that apply to the chosen storage
+  // mode. Everything here is presentation — the server validates
+  // regardless, so a browser with JS off gets every field and a
+  // correct answer, just a noisier one.
+  (function () {
+    const mode = document.getElementById("storage_mode");
+    const slug = document.getElementById("slug");
+    const dbName = document.getElementById("database_name");
+    const derived = document.getElementById("derived-url");
+    const nameDefault = document.getElementById("database-name-default");
+    // Captured before any edit: the server rendered it with a
+    // `tenant_<slug>` placeholder we substitute as the operator types.
+    const derivedTemplate = derived ? derived.textContent : null;
+
+    function applyMode() {
+      const schema = mode.value === "schema";
+      for (const row of document.querySelectorAll(".mode-database")) {
+        row.hidden = schema;
+      }
+      for (const row of document.querySelectorAll(".mode-schema")) {
+        row.hidden = !schema;
+      }
+    }
+
+    function applySlug() {
+      const s = slug.value.trim() || "<slug>";
+      const name = dbName.value.trim() || "tenant_" + s;
+      if (nameDefault) { nameDefault.textContent = "tenant_" + s; }
+      if (derived && derivedTemplate) {
+        derived.textContent = derivedTemplate.replace("tenant_<slug>", name);
+      }
+    }
+
+    mode.addEventListener("change", applyMode);
+    slug.addEventListener("input", applySlug);
+    dbName.addEventListener("input", applySlug);
+    applyMode();
+    applySlug();
+  })();
+
   // Posts just the URL to the probe endpoint and drops the returned
   // fragment in place, so an operator can check a URL without losing
   // the rest of the form to a page reload.
   document.getElementById("test-connection").addEventListener("click", async (e) => {
     const out = document.getElementById("probe-result");
-    const url = document.getElementById("database_url").value;
     e.target.disabled = true;
     out.textContent = "checking…";
     try {
-      const res = await fetch("test-connection", {
+      // Send whatever the operator actually supplied. When it is a
+      // database *name*, the server derives the URL the same way the
+      // submit will — so the probe tests the real target, not a
+      // different one.
+      const res = await fetch("/orgs/test-connection", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({ database_url: url }),
+        body: new URLSearchParams({
+          database_url: document.getElementById("database_url").value,
+          database_name: document.getElementById("database_name").value,
+          slug: document.getElementById("slug").value,
+        }),
       });
       out.innerHTML = await res.text();
     } catch (err) {

--- a/crates/rustango/src/tenancy/templates/op_orgs_new.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_new.html
@@ -116,8 +116,16 @@ connection check passes.</p>
       <tr class="mode-schema" hidden>
         <th><label for="schema_name">schema</label></th>
         <td>
+          {#- Same escaped hyphen as the slug, and for the same reason:
+              an unescaped one makes the attribute a syntax error the
+              browser drops silently. Underscores are allowed here and
+              not in the slug — a schema name is an identifier, not a
+              hostname label. -#}
           <input type="text" id="schema_name" name="schema_name"
                  value="{{ prefill.schema_name | default(value='') }}"
+                 pattern="[a-z0-9_][a-z0-9_\-]*"
+                 maxlength="63"
+                 title="Lowercase letters, digits, underscores and hyphens."
                  placeholder="defaults to the slug">
           <div class="field-helper">The tenant lives in the registry's
           own database, isolated by <code>search_path</code>. There is no
@@ -133,23 +141,38 @@ connection check passes.</p>
       <tr>
         <th><label for="host_pattern">host_pattern</label></th>
         <td>
+          {#- Uppercase is allowed through and lowercased by the server,
+              because that is what the resolver does to the `Host`
+              header before comparing. A `:port` or a `*` is not: they
+              can never equal the normalized header. -#}
           <input type="text" id="host_pattern" name="host_pattern"
                  value="{{ prefill.host_pattern | default(value='') }}"
+                 pattern="[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9\-]*[A-Za-z0-9])?)*"
+                 maxlength="253"
+                 title="A hostname, matched exactly. No port and no wildcard — put the port in the port field."
                  placeholder="acme.example.com">
-          <div class="field-helper">Blank derives
+          <div class="field-helper">Matched exactly against the
+          <code>Host</code> header. Blank derives
           <code>&lt;slug&gt;.&lt;RUSTANGO_APEX_DOMAIN&gt;</code> when that
           variable is set.</div>
         </td>
       </tr>
       <tr>
         <th><label for="path_prefix">path_prefix</label></th>
-        <td><input type="text" id="path_prefix" name="path_prefix"
-                   value="{{ prefill.path_prefix | default(value='') }}"
-                   placeholder="/acme"></td>
+        <td>
+          <input type="text" id="path_prefix" name="path_prefix"
+                 value="{{ prefill.path_prefix | default(value='') }}"
+                 pattern="/[A-Za-z0-9_.~\-]+"
+                 title="One path segment, with its leading slash."
+                 placeholder="/acme">
+          <div class="field-helper">Only the first path segment is
+          matched, so this is <code>/name</code> — not a deeper path.</div>
+        </td>
       </tr>
       <tr>
         <th><label for="port">port</label></th>
-        <td><input type="text" id="port" name="port" inputmode="numeric"
+        <td><input type="number" id="port" name="port" inputmode="numeric"
+                   min="1" max="65535"
                    value="{{ prefill.port | default(value='') }}"></td>
       </tr>
     </table>

--- a/crates/rustango/src/tenancy/templates/op_provision_run.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_run.html
@@ -1,17 +1,16 @@
 {% extends "op_layout.html" %}
 {% block title %}Provisioning {{ slug }} — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
+<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span>Provisioning {{ slug }}</p>
 <h1>Provisioning <code>{{ slug }}</code></h1>
 
-<p>
-  Run #{{ run_id }} —
-  <strong id="run-state" data-state="{{ state }}">{{ state }}</strong>
+<p class="lead">
+  Run #{{ run_id }} — <strong id="run-state" data-state="{{ state }}">{{ state }}</strong>
+  {% if not terminal %}<span id="live-note"> · following live</span>{% endif %}
 </p>
 
 {% if error %}
-<div class="empty" style="border-color:var(--danger,#b3261e);color:var(--danger,#b3261e)">
-  {{ error }}
-</div>
+<div class="alert alert-error">{{ error }}</div>
 {% endif %}
 
 <table>
@@ -23,14 +22,14 @@
     <tr data-seq="{{ e.seq }}">
       <td>{{ e.seq }}</td>
       <td><code>{{ e.step }}</code></td>
-      <td>{{ e.status }}</td>
+      <td class="status-{{ e.status }}">{{ e.status }}</td>
       <td>{{ e.message }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
 
-<p><a href="../../orgs">Back to tenants</a></p>
+<p class="form-actions"><a href="/orgs" class="btn btn-secondary">Back to tenants</a></p>
 
 {% if not terminal %}
 <script>
@@ -43,19 +42,32 @@
     const rows = tbody.querySelectorAll("tr[data-seq]");
     const last = rows.length ? rows[rows.length - 1].dataset.seq : 0;
 
-    const es = new EventSource("{{ run_id }}/stream?after=" + last);
+    const es = new EventSource("/orgs/provision/{{ run_id }}/stream?after=" + last);
 
     es.addEventListener("step", (msg) => {
       const e = JSON.parse(msg.data);
       const tr = document.createElement("tr");
       tr.dataset.seq = e.seq;
-      for (const v of [e.seq, e.step, e.status, e.message]) {
+      const cells = [
+        [e.seq, null],
+        [e.step, "code"],
+        [e.status, null],
+        [e.message, null],
+      ];
+      cells.forEach(([value, tag], i) => {
         const td = document.createElement("td");
+        if (i === 2) { td.className = "status-" + e.status; }
         // textContent, never innerHTML: `message` carries driver text
         // and hostnames that are not ours.
-        td.textContent = v;
+        if (tag) {
+          const el = document.createElement(tag);
+          el.textContent = value;
+          td.appendChild(el);
+        } else {
+          td.textContent = value;
+        }
         tr.appendChild(td);
-      }
+      });
       tbody.appendChild(tr);
     });
 
@@ -67,8 +79,8 @@
     });
 
     es.addEventListener("error", (msg) => {
-      const state = document.getElementById("run-state");
-      if (msg.data) { state.textContent = state.textContent + " — " + msg.data; }
+      const note = document.getElementById("live-note");
+      if (note && msg.data) { note.textContent = " · " + msg.data; }
     });
   })();
 </script>

--- a/crates/rustango/src/tenancy/templates/op_provision_run.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_run.html
@@ -1,8 +1,8 @@
 {% extends "op_layout.html" %}
-{% block title %}Provisioning {{ slug }} — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block title %}{{ verb }} {{ slug }} — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
 {% block content %}
-<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span>Provisioning {{ slug }}</p>
-<h1>Provisioning <code>{{ slug }}</code></h1>
+<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span><a href="/orgs/provision">Runs</a><span class="sep">/</span>{{ verb }} {{ slug }}</p>
+<h1>{{ verb }} <code>{{ slug }}</code></h1>
 
 <p class="lead">
   Run #{{ run_id }} — <strong id="run-state" data-state="{{ state }}">{{ state }}</strong>

--- a/crates/rustango/src/tenancy/templates/op_provision_runs.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_runs.html
@@ -61,15 +61,5 @@ somebody finishes or removes it.</p>
 </table>
 {% endif %}
 
-{% if page > 1 or has_next %}
-<p class="form-actions">
-  {% if page > 1 %}
-  <a class="btn btn-secondary" href="/orgs/provision?page={{ page - 1 }}">← Newer</a>
-  {% endif %}
-  {% if has_next %}
-  <a class="btn btn-secondary" href="/orgs/provision?page={{ page + 1 }}">Older →</a>
-  {% endif %}
-  <span class="field-helper">page {{ page }}</span>
-</p>
-{% endif %}
+{% include "_op_pager.html" %}
 {% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_provision_runs.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_runs.html
@@ -1,0 +1,75 @@
+{% extends "op_layout.html" %}
+{% block title %}Provisioning runs — {{ brand_name | default(value='Rustango Operator Console') }}{% endblock %}
+{% block content %}
+<p class="breadcrumb"><a href="/orgs">Organizations</a><span class="sep">/</span>Provisioning runs</p>
+<h1>Provisioning runs</h1>
+<p class="lead">Every attempt to stand up a tenant, newest first —
+including the ones that failed, which leave the tenant inactive until
+somebody finishes or removes it.</p>
+
+{% if runs | length == 0 %}
+  <div class="empty">
+    {#- Same reason as the audit page: past the end this must not claim
+        nothing ever happened, and the paging links below sit outside
+        this branch so an empty page still offers a way back. -#}
+    {% if page > 1 %}No runs on page {{ page }}.
+    {% else %}No tenant has been provisioned through this console yet.
+    <a class="btn-link" href="/orgs/new">Create one</a>.
+    {% endif %}
+  </div>
+{% else %}
+<table>
+  <thead>
+    <tr>
+      <th>Run</th>
+      <th>Tenant</th>
+      <th>State</th>
+      <th>Storage</th>
+      <th>Requested by</th>
+      <th>Started</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for r in runs %}
+    <tr>
+      <td><a class="btn-link" href="/orgs/provision/{{ r.id }}">#{{ r.id }}</a></td>
+      {#- A slug may be 63 characters, which would otherwise set the
+          column's width for every other row. -#}
+      <td class="wrap-anywhere"><strong>{{ r.slug }}</strong></td>
+      <td>
+        {% if r.failed %}
+        <span class="status-failed">{{ r.state }}</span>
+        {% elif r.running %}
+        <span class="status-skipped">{{ r.state }}</span>
+        {% else %}
+        <span class="status-ok">{{ r.state }}</span>
+        {% endif %}
+        {% if r.took %}<span class="field-helper">in {{ r.took }}</span>{% endif %}
+      </td>
+      <td class="nowrap"><code>{{ r.storage_mode }}</code> · <code>{{ r.backend_kind }}</code></td>
+      <td>{% if r.requested_by %}{{ r.requested_by }}{% else %}<span class="empty">—</span>{% endif %}</td>
+      <td class="nowrap">{% if r.started_at %}{{ r.started_at }}{% else %}—{% endif %}</td>
+    </tr>
+    {% if r.error %}
+    <tr class="run-error">
+      <td></td>
+      <td colspan="5"><span class="status-failed">{{ r.error }}</span></td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+{% if page > 1 or has_next %}
+<p class="form-actions">
+  {% if page > 1 %}
+  <a class="btn btn-secondary" href="/orgs/provision?page={{ page - 1 }}">← Newer</a>
+  {% endif %}
+  {% if has_next %}
+  <a class="btn btn-secondary" href="/orgs/provision?page={{ page + 1 }}">Older →</a>
+  {% endif %}
+  <span class="field-helper">page {{ page }}</span>
+</p>
+{% endif %}
+{% endblock %}

--- a/crates/rustango/src/tenancy/templates/op_provision_runs.html
+++ b/crates/rustango/src/tenancy/templates/op_provision_runs.html
@@ -35,7 +35,10 @@ somebody finishes or removes it.</p>
       <td><a class="btn-link" href="/orgs/provision/{{ r.id }}">#{{ r.id }}</a></td>
       {#- A slug may be 63 characters, which would otherwise set the
           column's width for every other row. -#}
-      <td class="wrap-anywhere"><strong>{{ r.slug }}</strong></td>
+      <td class="wrap-anywhere">
+        <strong>{{ r.slug }}</strong>
+        {% if r.is_migrate %}<span class="badge">migrate</span>{% endif %}
+      </td>
       <td>
         {% if r.failed %}
         <span class="status-failed">{{ r.state }}</span>
@@ -46,7 +49,12 @@ somebody finishes or removes it.</p>
         {% endif %}
         {% if r.took %}<span class="field-helper">in {{ r.took }}</span>{% endif %}
       </td>
-      <td class="nowrap"><code>{{ r.storage_mode }}</code> · <code>{{ r.backend_kind }}</code></td>
+      {#- A batch migrate spans tenants that do not agree on either, so
+          it stores neither. -#}
+      <td class="nowrap">
+        {% if r.storage_mode %}<code>{{ r.storage_mode }}</code> · <code>{{ r.backend_kind }}</code>
+        {% else %}<span class="empty">—</span>{% endif %}
+      </td>
       <td>{% if r.requested_by %}{{ r.requested_by }}{% else %}<span class="empty">—</span>{% endif %}</td>
       <td class="nowrap">{% if r.started_at %}{{ r.started_at }}{% else %}—{% endif %}</td>
     </tr>

--- a/crates/rustango/tests/audit_cleanup_sqlite_live.rs
+++ b/crates/rustango/tests/audit_cleanup_sqlite_live.rs
@@ -1,0 +1,262 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! `audit-cleanup` retention, including the registry's own log.
+//!
+//! The verb walked tenants only, so the log the operator console writes
+//! to — every tenant edit, hostname change, operator action, purge —
+//! grew with console use and nothing trimmed it.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use rustango::audit::AuditLog;
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _, Pool};
+use rustango::tenancy::TenantPools;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry: Pool,
+    url: String,
+    _tmp: tempfile::TempDir,
+    migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    Booted {
+        pools,
+        registry,
+        url,
+        _tmp: tmp,
+        migrations,
+    }
+}
+
+impl Booted {
+    async fn run(&self, args: &[&str]) -> Result<String, String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+        rustango::tenancy::manage::run_with_writer(
+            self.pools.as_ref(),
+            &self.url,
+            self.migrations.path(),
+            argv,
+            &mut buf,
+        )
+        .await
+        .map(|()| String::from_utf8_lossy(&buf).into_owned())
+        .map_err(|e| e.to_string())
+    }
+
+    /// One registry audit row, `age_days` old.
+    async fn seed(&self, pk: &str, age_days: i64) {
+        let mut row = AuditLog {
+            id: Auto::default(),
+            entity_table: "rustango_orgs".into(),
+            entity_pk: pk.to_owned(),
+            operation: "action".into(),
+            source: "operator:1:test".into(),
+            changes: serde_json::json!({}),
+            occurred_at: chrono::Utc::now() - chrono::Duration::days(age_days),
+        };
+        row.insert_pool(&self.registry)
+            .await
+            .expect("seed audit row");
+    }
+
+    async fn registry_entries(&self) -> Vec<String> {
+        let rows: Vec<AuditLog> = AuditLog::objects().fetch(&self.registry).await.unwrap();
+        rows.into_iter().map(|r| r.entity_pk).collect()
+    }
+}
+
+/// The gap: the registry's own log was never swept.
+#[tokio::test]
+async fn the_registry_log_is_trimmed_by_days() {
+    let b = boot().await;
+    b.seed("ancient", 120).await;
+    b.seed("recent", 1).await;
+
+    let out = b.run(&["audit-cleanup", "--days", "30"]).await.expect("ok");
+    assert!(
+        out.contains("registry"),
+        "the output should account for the registry: {out}"
+    );
+
+    let left = b.registry_entries().await;
+    assert!(
+        left.contains(&"recent".to_owned()),
+        "recent entries stay: {left:?}"
+    );
+    assert!(
+        !left.contains(&"ancient".to_owned()),
+        "old entries go: {left:?}"
+    );
+}
+
+#[tokio::test]
+async fn keep_last_applies_to_the_registry_too() {
+    let b = boot().await;
+    // Same (entity_table, entity_pk), so they compete for the same slot.
+    for age in [5, 4, 3, 2, 1] {
+        b.seed("acme", age).await;
+    }
+    assert_eq!(b.registry_entries().await.len(), 5);
+
+    b.run(&["audit-cleanup", "--keep-last", "2"])
+        .await
+        .expect("ok");
+    assert_eq!(
+        b.registry_entries().await.len(),
+        2,
+        "should keep the 2 most recent for that record"
+    );
+}
+
+#[tokio::test]
+async fn registry_only_does_not_need_a_tenant() {
+    let b = boot().await;
+    b.seed("ancient", 120).await;
+
+    let out = b
+        .run(&["audit-cleanup", "--registry", "--days", "30"])
+        .await
+        .expect("ok");
+    assert!(out.contains("registry"), "{out}");
+    assert!(
+        b.registry_entries().await.is_empty(),
+        "the old entry should be gone"
+    );
+}
+
+impl Booted {
+    /// A tenant whose storage exists but has no schema — `--no-migrate`,
+    /// so it has no `rustango_audit_log` to sweep.
+    async fn unmigrated_tenant(&self) -> String {
+        let slug = unique("acme");
+        let db = self._tmp.path().join(format!("{slug}.db"));
+        self.run(&[
+            "create-tenant",
+            &slug,
+            "--mode",
+            "database",
+            "--backend",
+            "sqlite",
+            "--database-url",
+            &format!("sqlite://{}?mode=rwc", db.display()),
+            "--no-migrate",
+        ])
+        .await
+        .expect("create the tenant");
+        slug
+    }
+}
+
+/// Naming one tenant asks for that tenant, so the registry is left
+/// alone — otherwise `--tenant acme` would quietly trim a log the
+/// caller never mentioned.
+#[tokio::test]
+async fn naming_a_tenant_leaves_the_registry_alone() {
+    let b = boot().await;
+    b.seed("ancient", 120).await;
+    let slug = b.unmigrated_tenant().await;
+
+    // The tenant has no audit table, so this fails — the point is what
+    // it did *not* touch.
+    let _ = b
+        .run(&["audit-cleanup", "--tenant", &slug, "--days", "30"])
+        .await;
+
+    assert!(
+        b.registry_entries().await.contains(&"ancient".to_owned()),
+        "the registry's log must be untouched when a tenant was named"
+    );
+}
+
+/// A sweep that aborts on the first bad tenant leaves every later one
+/// untrimmed — which defeats retention exactly when it matters. The
+/// loop collects outcomes instead.
+#[tokio::test]
+async fn one_broken_tenant_does_not_stop_the_sweep() {
+    let b = boot().await;
+    b.seed("ancient", 120).await;
+    let broken = b.unmigrated_tenant().await;
+
+    let out = b
+        .run(&["audit-cleanup", "--days", "30"])
+        .await
+        .expect("the sweep should finish despite a broken tenant");
+
+    assert!(
+        out.contains(&format!("tenant={broken} FAILED")),
+        "the broken tenant should be reported, not swallowed: {out}"
+    );
+    assert!(out.contains("failed=1"), "and counted: {out}");
+    assert!(
+        !b.registry_entries().await.contains(&"ancient".to_owned()),
+        "while the registry was still trimmed: {out}"
+    );
+}
+
+#[tokio::test]
+async fn registry_and_tenant_together_are_refused() {
+    let b = boot().await;
+    let err = b
+        .run(&[
+            "audit-cleanup",
+            "--registry",
+            "--tenant",
+            "acme",
+            "--days",
+            "30",
+        ])
+        .await
+        .expect_err("contradictory scopes");
+    assert!(
+        err.contains("--registry") && err.contains("--tenant"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn a_retention_mode_is_required() {
+    let b = boot().await;
+    let err = b.run(&["audit-cleanup"]).await.expect_err("no mode");
+    assert!(
+        err.contains("--days") && err.contains("--keep-last"),
+        "{err}"
+    );
+
+    let err = b
+        .run(&["audit-cleanup", "--days", "1", "--keep-last", "1"])
+        .await
+        .expect_err("both modes");
+    assert!(err.contains("mutually exclusive"), "{err}");
+}

--- a/crates/rustango/tests/auth_live.rs
+++ b/crates/rustango/tests/auth_live.rs
@@ -48,10 +48,13 @@ async fn lookup_org(pool: &sqlx::PgPool, slug: &str) -> Org {
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);
 
+/// Joined with hyphens, not underscores, because some of these names
+/// become tenant slugs — and a slug is a hostname label, where `_` is
+/// illegal. Usernames tolerate either, so one rule serves both.
 fn unique(prefix: &str) -> String {
     let n = UNIQ.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    format!("{prefix}_{pid}_{n}")
+    format!("{prefix}-{pid}-{n}")
 }
 
 async fn pool() -> Option<sqlx::PgPool> {
@@ -244,7 +247,7 @@ async fn hard_wall_operator_credential_does_not_authenticate_against_tenant() {
     rmig::drop_all(&pool).await.unwrap();
     rmig::apply_all(&pool).await.unwrap();
 
-    let slug = unique("acme_hw");
+    let slug = unique("acme-hw");
     drop_schema(&pool, &slug).await;
     sqlx::query(&format!(r#"CREATE SCHEMA "{slug}""#))
         .execute(&pool)
@@ -304,7 +307,7 @@ async fn hard_wall_tenant_user_credential_does_not_authenticate_as_operator() {
     rmig::drop_all(&pool).await.unwrap();
     rmig::apply_all(&pool).await.unwrap();
 
-    let slug = unique("acme_hw2");
+    let slug = unique("acme-hw2");
     drop_schema(&pool, &slug).await;
     sqlx::query(&format!(r#"CREATE SCHEMA "{slug}""#))
         .execute(&pool)

--- a/crates/rustango/tests/manage_live.rs
+++ b/crates/rustango/tests/manage_live.rs
@@ -12,7 +12,18 @@ use rustango::{core::Column as _, migrate as rmig};
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);
 
+/// Joined with hyphens, because nearly every caller here is naming a
+/// tenant slug — and a slug is a hostname label, where `_` is illegal.
 fn unique(prefix: &str) -> String {
+    let n = UNIQ.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    format!("{prefix}-{pid}-{n}")
+}
+
+/// Underscore-joined, for the one caller naming a *migration* rather
+/// than a tenant: the name becomes a filename and a ledger entry, and
+/// migration names are conventionally `0001_snake_case`.
+fn unique_migration_name(prefix: &str) -> String {
     let n = UNIQ.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
     format!("{prefix}_{pid}_{n}")
@@ -211,7 +222,7 @@ async fn drop_tenant_soft_deletes_with_confirm() {
     rmig::drop_all(&pool).await.unwrap();
     rmig::apply_all(&pool).await.unwrap();
 
-    let slug = unique("drop_me");
+    let slug = unique("drop-me");
     drop_schema(&pool, &slug).await;
     let dir = fresh_dir("drop");
     let pools = TenantPools::new(pool.clone());
@@ -373,7 +384,7 @@ async fn migrate_tenants_runs_against_active_only() {
     .unwrap();
 
     // Ship a tenant migration in dir.
-    let mig_name = unique("0001_thing");
+    let mig_name = unique_migration_name("0001_thing");
     let mig = rmig::Migration {
         name: mig_name.clone(),
         created_at: "2026-04-28T00:00:00Z".into(),

--- a/crates/rustango/tests/manage_live.rs
+++ b/crates/rustango/tests/manage_live.rs
@@ -29,6 +29,20 @@ fn unique_migration_name(prefix: &str) -> String {
     format!("{prefix}_{pid}_{n}")
 }
 
+/// The same server and credentials, a different database name.
+///
+/// Keeps userinfo, host and port; replaces only the path segment, so a
+/// tenant lands on the server the test already reached.
+fn sibling_database_url(registry_url: &str, database: &str) -> String {
+    let (scheme, rest) = registry_url
+        .split_once("://")
+        .expect("DATABASE_URL should be a URL");
+    let (authority, _old_db) = rest
+        .rsplit_once('/')
+        .expect("DATABASE_URL should name a database");
+    format!("{scheme}://{authority}/{database}")
+}
+
 use tokio::sync::Mutex;
 
 /// Suite-wide lock. Every test in this file resets the shared PG
@@ -163,9 +177,12 @@ async fn create_tenant_database_mode_requires_database_url() {
         &["create-tenant", &slug, "--mode", "database"],
     )
     .await;
+    // The message no longer names `--database-url`: the check moved
+    // into the provisioning engine, which the console and the webhook
+    // share, and neither of those has a command-line flag to suggest.
     let err = res.unwrap_err();
     assert!(
-        format!("{err}").contains("--database-url"),
+        format!("{err}").contains("database mode needs a database URL"),
         "expected database_url validation error, got: {err}"
     );
 
@@ -303,6 +320,16 @@ async fn list_tenants_prints_all_orgs() {
         .await
         .1
         .unwrap();
+    // A real second database, not `url`. Passing the registry's own
+    // URL here is what provisioning refuses: it would run the tenant
+    // migration chain over the registry. `CREATE DATABASE` has no
+    // `IF NOT EXISTS` in Postgres, so a re-run's "already exists" is
+    // swallowed; a genuine failure surfaces at the connection check.
+    let tenant_db = "rustango_tenant_list_test";
+    let _ = sqlx::query(&format!("CREATE DATABASE {tenant_db}"))
+        .execute(&pool)
+        .await;
+    let tenant_url = sibling_database_url(&url, tenant_db);
     run(
         &pools,
         &url,
@@ -313,7 +340,7 @@ async fn list_tenants_prints_all_orgs() {
             "--mode",
             "database",
             "--database-url",
-            &url,
+            &tenant_url,
             "--no-migrate",
         ],
     )

--- a/crates/rustango/tests/operator_console_audit_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_audit_sqlite_live.rs
@@ -1,0 +1,366 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Reading the registry audit trail from the operator console.
+//!
+//! Every console mutation already wrote here and nothing read it back,
+//! so the record an operator wants during an incident existed and was
+//! reachable only with a SQL client. These tests cover the page that
+//! closed that, and the two things a history view has to get right:
+//! the newest entry first, and a page past the end that is not a dead
+//! end.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, Auto};
+use rustango::tenancy::operator_console::{router, SessionSecret};
+use rustango::tenancy::{Operator, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    registry: rustango::sql::Pool,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein-please";
+    let mut op = Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    // `router()` deliberately — the audit page is read-only and must be
+    // there even on a console that cannot change anything, which is
+    // exactly the deployment where "what happened?" still needs
+    // answering.
+    let app = router(registry.clone(), SessionSecret::from_env_or_random());
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        registry,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// Write one entry straight to the trail, the way the console's own
+    /// handlers do.
+    async fn record(&self, table: &'static str, pk: &str, verb: &str, extra: (&str, &str)) {
+        let mut changes = serde_json::Map::new();
+        changes.insert(
+            extra.0.to_owned(),
+            serde_json::Value::String(extra.1.to_owned()),
+        );
+        let entry = rustango::audit::PendingEntry {
+            entity_table: table,
+            entity_pk: pk.to_owned(),
+            operation: rustango::audit::AuditOp::Action,
+            source: rustango::audit::AuditSource::Custom(format!("operator:1:{verb}")),
+            changes: serde_json::Value::Object(changes),
+        };
+        rustango::audit::emit_one_pool(&self.registry, &entry)
+            .await
+            .expect("record an audit entry");
+    }
+}
+
+#[tokio::test]
+async fn the_page_shows_what_the_console_recorded() {
+    let b = boot().await;
+    b.record(
+        "rustango_orgs",
+        "acme",
+        "host_add",
+        ("hostname", "shop.acme.test"),
+    )
+    .await;
+
+    let resp = b.get("/audit").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+
+    assert!(html.contains("host_add"), "the verb: {html}");
+    assert!(html.contains("acme"), "the subject: {html}");
+    assert!(
+        html.contains("shop.acme.test"),
+        "and the detail from `changes`: {html}"
+    );
+    // `operator:1:host_add` is split so the reader is not parsing the
+    // same string on every row.
+    assert!(html.contains("operator 1"), "the actor, readably: {html}");
+}
+
+#[tokio::test]
+async fn the_newest_entry_is_first() {
+    let b = boot().await;
+    b.record("rustango_orgs", "first", "host_add", ("n", "1"))
+        .await;
+    b.record("rustango_orgs", "second", "host_remove", ("n", "2"))
+        .await;
+
+    let html = body_of(b.get("/audit").await).await;
+    let first_at = html.find("first").expect("both rows present");
+    let second_at = html.find("second").expect("both rows present");
+    assert!(
+        second_at < first_at,
+        "newest first: `second` should appear above `first`"
+    );
+}
+
+#[tokio::test]
+async fn filtering_narrows_to_one_record() {
+    let b = boot().await;
+    b.record("rustango_orgs", "acme", "edit", ("k", "v")).await;
+    b.record("rustango_operators", "7", "operator_create", ("k", "v"))
+        .await;
+
+    let orgs_only = body_of(b.get("/audit?entity_table=rustango_orgs").await).await;
+    assert!(orgs_only.contains("edit"), "{orgs_only}");
+    assert!(
+        !orgs_only.contains("operator_create"),
+        "the operator row should be filtered out: {orgs_only}"
+    );
+
+    let one_record = body_of(
+        b.get("/audit?entity_table=rustango_operators&entity_pk=7")
+            .await,
+    )
+    .await;
+    assert!(one_record.contains("operator_create"), "{one_record}");
+    assert!(
+        !one_record.contains(">edit<"),
+        "the org row should be filtered out: {one_record}"
+    );
+}
+
+/// A blank filter box posts `?entity_table=`, which must mean "no
+/// filter" rather than "match the empty string" — otherwise submitting
+/// the form with nothing typed returns nothing.
+#[tokio::test]
+async fn blank_filters_are_ignored_rather_than_matched() {
+    let b = boot().await;
+    b.record("rustango_orgs", "acme", "edit", ("k", "v")).await;
+
+    let html = body_of(
+        b.get("/audit?entity_table=&entity_pk=%20%20&operation=")
+            .await,
+    )
+    .await;
+    assert!(
+        html.contains("edit"),
+        "blank boxes should not filter everything out: {html}"
+    );
+}
+
+/// The links used to live inside the non-empty branch, so a page past
+/// the end rendered no navigation at all.
+#[tokio::test]
+async fn a_page_past_the_end_is_not_a_dead_end() {
+    let b = boot().await;
+    b.record("rustango_orgs", "acme", "edit", ("k", "v")).await;
+
+    let html = body_of(b.get("/audit?page=4").await).await;
+    assert!(
+        html.contains("/audit?page=3"),
+        "should link back towards the data: {html}"
+    );
+    assert!(
+        !html.contains("Nothing recorded yet"),
+        "and must not claim the log is empty: {html}"
+    );
+}
+
+#[tokio::test]
+async fn paging_keeps_the_active_filter() {
+    let b = boot().await;
+    b.record("rustango_orgs", "acme", "edit", ("k", "v")).await;
+
+    let html = body_of(b.get("/audit?page=2&entity_table=rustango_orgs").await).await;
+    assert!(
+        html.contains("entity_table=rustango_orgs"),
+        "moving pages must not silently drop the filter: {html}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_log_says_so_plainly() {
+    let b = boot().await;
+    let html = body_of(b.get("/audit").await).await;
+    assert!(
+        html.contains("Nothing recorded yet"),
+        "a fresh registry should say the log is empty: {html}"
+    );
+}
+
+/// `changes` carries operator-supplied text — a tenant's
+/// `display_name` is free-form — so it reaches the page as data.
+#[tokio::test]
+async fn audited_content_is_escaped() {
+    let b = boot().await;
+    b.record(
+        "rustango_orgs",
+        "acme",
+        "edit",
+        ("display_name", "<img src=x onerror=alert(1)>"),
+    )
+    .await;
+
+    let html = body_of(b.get("/audit").await).await;
+    assert!(
+        !html.contains("<img src=x onerror="),
+        "must not render as markup: {html}"
+    );
+    assert!(
+        html.contains("&lt;img src=x onerror="),
+        "should be escaped and visible: {html}"
+    );
+}
+
+/// `?page=1000000000000000000` parses into an `i64` and then overflowed
+/// `(page - 1) * PAGE_SIZE`, panicking the worker in debug and wrapping
+/// to a negative offset in release. Clamped, it is just an empty page.
+#[tokio::test]
+async fn an_absurd_page_number_does_not_overflow_the_offset() {
+    let b = boot().await;
+    for page in [
+        "1000000000000000000",
+        "9223372036854775807", // i64::MAX
+        "4611686018427387904",
+    ] {
+        let resp = b.get(&format!("/audit?page={page}")).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "page={page} should render an empty page, not fail"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_page_number_that_is_not_a_number_is_refused_cleanly() {
+    let b = boot().await;
+    for bad in ["abc", "99999999999999999999", "1%20OR%201=1"] {
+        let resp = b.get(&format!("/audit?page={bad}")).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "page={bad} should be a 400"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_page_requires_a_session() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/audit")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+        "the audit log was readable without a session: {}",
+        resp.status()
+    );
+}
+
+/// The nav is the only route to this page.
+#[tokio::test]
+async fn the_console_links_to_the_audit_log() {
+    let b = boot().await;
+    let html = body_of(b.get("/orgs").await).await;
+    assert!(
+        html.contains("href=\"/audit\""),
+        "the layout nav should link to the audit log: {html}"
+    );
+}

--- a/crates/rustango/tests/operator_console_audit_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_audit_sqlite_live.rs
@@ -236,17 +236,17 @@ async fn blank_filters_are_ignored_rather_than_matched() {
     );
 }
 
-/// The links used to live inside the non-empty branch, so a page past
-/// the end rendered no navigation at all.
+/// `Paginator::get_page` clamps an out-of-range page to the last real
+/// one, so there is no empty page to be stranded on.
 #[tokio::test]
-async fn a_page_past_the_end_is_not_a_dead_end() {
+async fn a_page_past_the_end_clamps_to_real_data() {
     let b = boot().await;
     b.record("rustango_orgs", "acme", "edit", ("k", "v")).await;
 
     let html = body_of(b.get("/audit?page=4").await).await;
     assert!(
-        html.contains("/audit?page=3"),
-        "should link back towards the data: {html}"
+        html.contains("edit"),
+        "should clamp to the page that has the data: {html}"
     );
     assert!(
         !html.contains("Nothing recorded yet"),

--- a/crates/rustango/tests/operator_console_decommission_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_decommission_sqlite_live.rs
@@ -1,0 +1,404 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Taking a tenant out of service from the console.
+//!
+//! Purging is unrecoverable, so most of this is about what must *not*
+//! happen: a mistyped confirmation, a database-mode purge without the
+//! explicit flag, an unauthenticated post.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _};
+use rustango::tenancy::operator_console::{router_with_provisioning, SessionSecret};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::{Operator, Org, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    registry: rustango::sql::Pool,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein-please";
+    let mut op = Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let app = router_with_provisioning(
+        registry.clone(),
+        pools.clone(),
+        provisioner,
+        SessionSecret::from_env_or_random(),
+    );
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        registry,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn post(&self, uri: &str, body: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn org(&self, slug: &str) -> Option<Org> {
+        let rows: Vec<Org> = Org::objects()
+            .where_(Org::slug.eq(slug.to_owned()))
+            .fetch(&self.registry)
+            .await
+            .unwrap();
+        rows.into_iter().next()
+    }
+
+    /// A real tenant with its own SQLite file, provisioned through the
+    /// console so its storage genuinely exists.
+    async fn tenant(&self) -> String {
+        let slug = unique("doomed");
+        let db = self._tmp.path().join(format!("{slug}.db"));
+        let form = format!(
+            "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url=sqlite%3A%2F%2F{}%3Fmode%3Drwc",
+            db.display().to_string().replace('/', "%2F")
+        );
+        let resp = self
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/orgs/new")
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(form))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection(),
+            "the tenant should provision: {}",
+            body_of(resp).await
+        );
+        slug
+    }
+}
+
+#[tokio::test]
+async fn deactivating_stops_service_without_destroying_anything() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+    assert!(b.org(&slug).await.unwrap().active);
+
+    let resp = b.post(&format!("/orgs/{slug}/deactivate"), "").await;
+    assert!(resp.status().is_redirection());
+
+    let org = b.org(&slug).await.expect("the row survives");
+    assert!(!org.active, "should be inactive");
+    assert!(
+        org.database_url.is_some(),
+        "and still point at its storage: {org:?}"
+    );
+}
+
+/// A purge removes the tenant, so there is no tenant page to report
+/// back on — the org list is where the outcome has to appear, and it
+/// had no place to render one.
+#[tokio::test]
+async fn the_org_list_renders_the_outcome_it_is_redirected_with() {
+    let b = boot().await;
+    let html = body_of(b.get("/orgs?notice=purged%20%60ghost%60").await).await;
+    assert!(
+        html.contains("purged") && html.contains("ghost"),
+        "the notice should reach the page: {html}"
+    );
+
+    let html = body_of(b.get("/orgs?error=nope").await).await;
+    assert!(html.contains("nope"), "and so should an error: {html}");
+}
+
+#[tokio::test]
+async fn deactivating_twice_says_it_changed_nothing() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+    b.post(&format!("/orgs/{slug}/deactivate"), "").await;
+
+    let resp = b.post(&format!("/orgs/{slug}/deactivate"), "").await;
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        location.contains("already"),
+        "a no-op should say so: {location}"
+    );
+}
+
+/// The typed slug is the pause between intent and an unrecoverable act.
+#[tokio::test]
+async fn a_mistyped_confirmation_destroys_nothing() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+
+    for body in [
+        "confirm=&purge_database=on",
+        "confirm=wrong&purge_database=on",
+        &format!("confirm={}X&purge_database=on", slug),
+    ] {
+        let resp = b.post(&format!("/orgs/{slug}/purge"), body).await;
+        let location = resp
+            .headers()
+            .get("location")
+            .expect("redirect")
+            .to_str()
+            .unwrap()
+            .to_owned();
+        assert!(
+            location.contains("error="),
+            "`{body}` should be refused: {location}"
+        );
+        assert!(
+            b.org(&slug).await.is_some(),
+            "and the tenant must survive `{body}`"
+        );
+    }
+}
+
+/// Dropping a whole database is a bigger act than dropping a schema, so
+/// it takes a second, explicit yes.
+#[tokio::test]
+async fn purging_a_database_mode_tenant_needs_the_explicit_flag() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+
+    let resp = b
+        .post(&format!("/orgs/{slug}/purge"), &format!("confirm={slug}"))
+        .await;
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        location.contains("error="),
+        "should be refused without the flag: {location}"
+    );
+    assert!(
+        location.contains("unrecoverable") || location.contains("database-mode"),
+        "and say why: {location}"
+    );
+    assert!(b.org(&slug).await.is_some(), "the tenant must survive");
+}
+
+#[tokio::test]
+async fn purging_removes_the_tenant() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+
+    let resp = b
+        .post(
+            &format!("/orgs/{slug}/purge"),
+            &format!("confirm={slug}&purge_database=on"),
+        )
+        .await;
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        location.contains("notice="),
+        "should report what it did: {location}"
+    );
+    assert!(
+        b.org(&slug).await.is_none(),
+        "the registry row should be gone"
+    );
+}
+
+#[tokio::test]
+async fn purging_a_tenant_that_does_not_exist_says_so() {
+    let b = boot().await;
+    let resp = b
+        .post(
+            "/orgs/no-such-tenant/purge",
+            "confirm=no-such-tenant&purge_database=on",
+        )
+        .await;
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(location.contains("error="), "{location}");
+    assert!(
+        location.contains("no%20tenant") || location.contains("no+tenant"),
+        "{location}"
+    );
+}
+
+#[tokio::test]
+async fn the_tenant_page_offers_both_and_explains_the_difference() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+    let html = body_of(b.get(&format!("/orgs/{slug}/edit")).await).await;
+
+    assert!(
+        html.contains(&format!("/orgs/{slug}/deactivate")),
+        "should offer deactivate: {html}"
+    );
+    assert!(
+        html.contains(&format!("/orgs/{slug}/purge")),
+        "and purge: {html}"
+    );
+    assert!(
+        html.contains("no undo"),
+        "and say that purging cannot be undone: {html}"
+    );
+}
+
+#[tokio::test]
+async fn the_routes_require_a_session() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+
+    for (uri, body) in [
+        (format!("/orgs/{slug}/deactivate"), String::new()),
+        (
+            format!("/orgs/{slug}/purge"),
+            format!("confirm={slug}&purge_database=on"),
+        ),
+    ] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+            "POST {uri} was reachable without a session: {}",
+            resp.status()
+        );
+    }
+
+    let org = b.org(&slug).await.expect("the tenant must survive");
+    assert!(org.active, "and must not have been deactivated");
+}

--- a/crates/rustango/tests/operator_console_decommission_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_decommission_sqlite_live.rs
@@ -367,6 +367,46 @@ async fn the_tenant_page_offers_both_and_explains_the_difference() {
     );
 }
 
+/// The create form's probe takes a URL from the form, which an
+/// existing tenant cannot use — its URL carries a password. Testing a
+/// tenant used to mean starting to create a different one just to
+/// borrow that button.
+#[tokio::test]
+async fn an_existing_tenant_can_have_its_connection_tested() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+
+    let html = body_of(b.post(&format!("/orgs/{slug}/test-connection"), "").await).await;
+    assert!(
+        html.contains("probe-ok"),
+        "a live tenant should pass: {html}"
+    );
+
+    let missing = body_of(b.post("/orgs/ghost/test-connection", "").await).await;
+    assert!(
+        missing.contains("probe-bad") && missing.contains("ghost"),
+        "an unknown tenant should say so: {missing}"
+    );
+}
+
+/// The tenant's URL is resolved server-side, so it must not be rendered
+/// into the page that offers the button.
+#[tokio::test]
+async fn the_probe_does_not_put_the_tenants_url_in_the_page() {
+    let b = boot().await;
+    let slug = b.tenant().await;
+    let html = body_of(b.get(&format!("/orgs/{slug}/edit")).await).await;
+
+    assert!(
+        html.contains(&format!("/orgs/{slug}/test-connection")),
+        "the button should be there: {html}"
+    );
+    assert!(
+        !html.contains("mode=rwc"),
+        "but not the connection URL itself: {html}"
+    );
+}
+
 #[tokio::test]
 async fn the_routes_require_a_session() {
     let b = boot().await;

--- a/crates/rustango/tests/operator_console_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_hosts_sqlite_live.rs
@@ -1,0 +1,586 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Managing a tenant's extra hostnames from the operator console, end
+//! to end through the real router.
+//!
+//! `org_hosts_sqlite_live` covers the engine — what `add_host` and
+//! friends do to the registry. This covers the surface an operator
+//! actually touches: that the routes are mounted at all, that they are
+//! behind a session, that the page shows the base host without
+//! controls, and that the writes land.
+//!
+//! The distinction earned its keep: the engine shipped complete and the
+//! console had no page, no route and no link, so every one of the
+//! engine's rules was unreachable from a browser.
+//!
+//! SQLite, because the console is tri-dialect and this needs no server.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, Auto};
+use rustango::tenancy::operator_console::{router, router_with_provisioning, SessionSecret};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::{Org, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+/// Hyphens, not underscores: a slug becomes a hostname label.
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+/// The resolver's host cache is process-global, so tests that mutate
+/// hosts cannot interleave — see `org_hosts_sqlite_live`, which learned
+/// this the hard way.
+fn cache_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    registry: rustango::sql::Pool,
+    slug: String,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein";
+    let mut op = rustango::tenancy::Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    // A tenant with a base host, which is the row the page must render
+    // as undeletable.
+    let slug = unique("acme");
+    let mut org = Org {
+        id: Auto::default(),
+        slug: slug.clone(),
+        display_name: slug.clone(),
+        storage_mode: "schema".into(),
+        backend_kind: "sqlite".into(),
+        database_url: None,
+        schema_name: Some(slug.clone()),
+        host_pattern: Some(format!("{slug}.example.com")),
+        port: None,
+        path_prefix: None,
+        active: true,
+        created_at: chrono::Utc::now(),
+        brand_name: None,
+        brand_tagline: None,
+        logo_path: None,
+        favicon_path: None,
+        primary_color: None,
+        theme_mode: None,
+    };
+    org.insert_pool(&registry).await.expect("seed org");
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let app = router_with_provisioning(
+        registry.clone(),
+        pools.clone(),
+        provisioner,
+        SessionSecret::from_env_or_random(),
+    );
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        registry,
+        slug,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn post(&self, uri: &str, body: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// Where a write redirected to, which is where the outcome lives.
+    fn location(resp: &axum::response::Response) -> String {
+        resp.headers()
+            .get("location")
+            .expect("a write should redirect")
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+}
+
+#[tokio::test]
+async fn the_page_lists_the_base_host_and_marks_it_undeletable() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+
+    let resp = b.get(&format!("/orgs/{}/hosts", b.slug)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+
+    assert!(
+        html.contains(&format!("{}.example.com", b.slug)),
+        "the base host should be listed: {html}"
+    );
+    assert!(html.contains("base"), "and flagged as the base: {html}");
+    // The base has no row in `rustango_org_hosts`, so it must not offer
+    // controls that would 500 or silently do nothing.
+    assert!(
+        !html.contains("hosts/remove"),
+        "a tenant with only a base host should offer no remove form: {html}"
+    );
+}
+
+#[tokio::test]
+async fn a_host_added_through_the_form_is_listed_and_bound() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let host = format!("shop.{}.example.com", b.slug);
+
+    let resp = b
+        .post(
+            &format!("/orgs/{}/hosts/add", b.slug),
+            &format!("hostname={host}"),
+        )
+        .await;
+    assert!(
+        resp.status().is_redirection(),
+        "a write should Post/Redirect/Get, got {}",
+        resp.status()
+    );
+    assert!(
+        Booted::location(&resp).contains("notice="),
+        "the outcome should survive the redirect"
+    );
+
+    let html = body_of(b.get(&format!("/orgs/{}/hosts", b.slug)).await).await;
+    assert!(
+        html.contains(&host),
+        "the new host should be listed: {html}"
+    );
+    assert!(
+        html.contains("hosts/remove"),
+        "an extra host should offer a remove form: {html}"
+    );
+
+    let bound = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        bound.iter().any(|h| h.hostname == host && !h.is_base),
+        "the row should exist in the registry: {bound:?}"
+    );
+}
+
+/// Uppercase is normalized, not refused — the client-side `pattern`
+/// allows it for exactly this reason, so the browser is never stricter
+/// than the server it is previewing.
+#[tokio::test]
+async fn an_uppercase_hostname_is_lowercased_rather_than_refused() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+
+    let resp = b
+        .post(
+            &format!("/orgs/{}/hosts/add", b.slug),
+            &format!("hostname=SHOP.{}.EXAMPLE.COM", b.slug.to_uppercase()),
+        )
+        .await;
+    assert!(
+        Booted::location(&resp).contains("notice="),
+        "should have been accepted: {}",
+        Booted::location(&resp)
+    );
+
+    let bound = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        bound
+            .iter()
+            .any(|h| h.hostname == h.hostname.to_lowercase() && !h.is_base),
+        "the stored hostname should be lowercase: {bound:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_host_can_be_parked_and_served_again_without_unbinding_it() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let host = format!("park.{}.example.com", b.slug);
+    b.post(
+        &format!("/orgs/{}/hosts/add", b.slug),
+        &format!("hostname={host}"),
+    )
+    .await;
+
+    // Park: the toggle posts no `enabled` field when disabling, which
+    // is the shape an unchecked checkbox sends.
+    b.post(
+        &format!("/orgs/{}/hosts/toggle", b.slug),
+        &format!("hostname={host}"),
+    )
+    .await;
+    let parked = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        parked.iter().any(|h| h.hostname == host && !h.enabled),
+        "should be parked but still bound: {parked:?}"
+    );
+
+    // Serve again.
+    b.post(
+        &format!("/orgs/{}/hosts/toggle", b.slug),
+        &format!("hostname={host}&enabled=on"),
+    )
+    .await;
+    let serving = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        serving.iter().any(|h| h.hostname == host && h.enabled),
+        "should be serving again: {serving:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_host_removed_through_the_form_is_unbound() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let host = format!("gone.{}.example.com", b.slug);
+    b.post(
+        &format!("/orgs/{}/hosts/add", b.slug),
+        &format!("hostname={host}"),
+    )
+    .await;
+
+    b.post(
+        &format!("/orgs/{}/hosts/remove", b.slug),
+        &format!("hostname={host}"),
+    )
+    .await;
+
+    let bound = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        !bound.iter().any(|h| h.hostname == host),
+        "should be gone: {bound:?}"
+    );
+}
+
+/// The base host is protected structurally — it has no row here — and
+/// the page hides its controls. An operator who posts the form anyway
+/// must get the same answer, not a 500 or a silent success.
+#[tokio::test]
+async fn the_base_host_survives_a_hand_posted_remove_and_toggle() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let base = format!("{}.example.com", b.slug);
+
+    for verb in ["remove", "toggle"] {
+        let resp = b
+            .post(
+                &format!("/orgs/{}/hosts/{verb}", b.slug),
+                &format!("hostname={base}"),
+            )
+            .await;
+        let location = Booted::location(&resp);
+        assert!(
+            location.contains("error="),
+            "{verb} of the base host should be refused, got {location}"
+        );
+    }
+
+    let hosts = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        hosts.iter().any(|h| h.hostname == base && h.is_base),
+        "the base host must still be there: {hosts:?}"
+    );
+}
+
+/// A hostname belongs to one tenant, so a second claim is refused —
+/// and the refusal has to reach the page, not a 500.
+#[tokio::test]
+async fn a_hostname_already_claimed_is_refused_with_a_reason() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let host = format!("dup.{}.example.com", b.slug);
+    b.post(
+        &format!("/orgs/{}/hosts/add", b.slug),
+        &format!("hostname={host}"),
+    )
+    .await;
+
+    let resp = b
+        .post(
+            &format!("/orgs/{}/hosts/add", b.slug),
+            &format!("hostname={host}"),
+        )
+        .await;
+    let location = Booted::location(&resp);
+    assert!(
+        location.contains("error="),
+        "a duplicate should be refused: {location}"
+    );
+    assert!(
+        location.contains("already"),
+        "and should say why: {location}"
+    );
+}
+
+#[tokio::test]
+async fn a_value_that_is_not_a_bare_hostname_is_refused() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+
+    for bad in ["https%3A%2F%2Fx.com", "x.com%3A8080", "x.com%2Fadmin", ""] {
+        let resp = b
+            .post(
+                &format!("/orgs/{}/hosts/add", b.slug),
+                &format!("hostname={bad}"),
+            )
+            .await;
+        let location = Booted::location(&resp);
+        assert!(
+            location.contains("error="),
+            "`{bad}` should be refused, got {location}"
+        );
+    }
+}
+
+/// The engine scopes every mutation to the owning org. Posting another
+/// tenant's hostname at this tenant's URL must not touch it.
+#[tokio::test]
+async fn a_host_belonging_to_another_tenant_cannot_be_touched() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+
+    let other = unique("other");
+    let mut org = Org {
+        id: Auto::default(),
+        slug: other.clone(),
+        display_name: other.clone(),
+        storage_mode: "schema".into(),
+        backend_kind: "sqlite".into(),
+        database_url: None,
+        schema_name: Some(other.clone()),
+        host_pattern: Some(format!("{other}.example.com")),
+        port: None,
+        path_prefix: None,
+        active: true,
+        created_at: chrono::Utc::now(),
+        brand_name: None,
+        brand_tagline: None,
+        logo_path: None,
+        favicon_path: None,
+        primary_color: None,
+        theme_mode: None,
+    };
+    org.insert_pool(&b.registry).await.expect("seed other org");
+    let victim = format!("owned.{other}.example.com");
+    rustango::tenancy::add_host(&b.registry, &other, &victim)
+        .await
+        .expect("bind to the other tenant");
+
+    for verb in ["remove", "toggle"] {
+        let resp = b
+            .post(
+                &format!("/orgs/{}/hosts/{verb}", b.slug),
+                &format!("hostname={victim}"),
+            )
+            .await;
+        assert!(
+            Booted::location(&resp).contains("error="),
+            "{verb} across tenants should be refused"
+        );
+    }
+
+    let still = rustango::tenancy::list_for_org(&b.registry, &other)
+        .await
+        .unwrap();
+    assert!(
+        still.iter().any(|h| h.hostname == victim && h.enabled),
+        "the other tenant's host must be untouched: {still:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_tenant_is_a_404_not_an_empty_list() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let resp = b.get("/orgs/no-such-tenant/hosts").await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn the_routes_require_a_session() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+
+    for (method, uri) in [
+        ("GET", format!("/orgs/{}/hosts", b.slug)),
+        ("POST", format!("/orgs/{}/hosts/add", b.slug)),
+        ("POST", format!("/orgs/{}/hosts/remove", b.slug)),
+        ("POST", format!("/orgs/{}/hosts/toggle", b.slug)),
+    ] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(&uri)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("hostname=evil.example.com"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+            "{method} {uri} was reachable without a session: {}",
+            resp.status()
+        );
+    }
+
+    let hosts = rustango::tenancy::list_for_org(&b.registry, &b.slug)
+        .await
+        .unwrap();
+    assert!(
+        !hosts.iter().any(|h| h.hostname == "evil.example.com"),
+        "an unauthenticated post must not bind a host: {hosts:?}"
+    );
+}
+
+/// The page is only reachable if something links to it. A working
+/// handler nobody can navigate to is the bug this whole feature
+/// started as.
+#[tokio::test]
+async fn the_edit_page_links_to_the_hosts_page() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let html = body_of(b.get(&format!("/orgs/{}/edit", b.slug)).await).await;
+    assert!(
+        html.contains(&format!("/orgs/{}/hosts", b.slug)),
+        "the edit page should link to the hostnames page: {html}"
+    );
+}
+
+/// Read-only consoles do not get write routes. `router()` supplies no
+/// pool invalidator, which is how a deployment says "read-only".
+#[tokio::test]
+async fn a_read_only_console_does_not_mount_the_routes() {
+    let _g = cache_lock().lock().await;
+    let b = boot().await;
+    let read_only = router(b.registry.clone(), SessionSecret::from_env_or_random());
+
+    let resp = read_only
+        .oneshot(
+            Request::builder()
+                .uri(format!("/orgs/{}/hosts", b.slug))
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "a read-only console must not expose host management"
+    );
+}

--- a/crates/rustango/tests/operator_console_migrate_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_migrate_sqlite_live.rs
@@ -1,0 +1,372 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Running tenant migrations from the console.
+//!
+//! The work is spawned, so the only place a failure can land is the
+//! run — these check that it does, rather than vanishing with the task.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, Auto, FetcherPool as _};
+use rustango::tenancy::operator_console::{router_with_provisioning, SessionSecret};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::provision_store::{self as store, ProvisioningRun, RunKind, RunState};
+use rustango::tenancy::{Operator, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    registry: rustango::sql::Pool,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein-please";
+    let mut op = Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let app = router_with_provisioning(
+        registry.clone(),
+        pools.clone(),
+        provisioner,
+        SessionSecret::from_env_or_random(),
+    );
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        registry,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn post(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// The run a migrate POST redirected to.
+    fn run_id(resp: &axum::response::Response) -> i64 {
+        resp.headers()
+            .get("location")
+            .expect("a run to watch")
+            .to_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap()
+            .parse()
+            .expect("numeric run id")
+    }
+
+    /// The work is spawned, so wait for the run to reach a terminal
+    /// state rather than assuming it already has.
+    async fn settled(&self, run_id: i64) -> ProvisioningRun {
+        for _ in 0..200 {
+            let run = store::run_by_id(&self.registry, run_id)
+                .await
+                .unwrap()
+                .expect("the run exists");
+            if RunState::parse(&run.state).is_terminal() {
+                return run;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("run {run_id} never finished");
+    }
+}
+
+/// A tenant to migrate, provisioned through the console so its storage
+/// really exists.
+async fn a_tenant(b: &Booted) -> String {
+    let slug = unique("mig");
+    let db = b._tmp.path().join(format!("{slug}.db"));
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url=sqlite%3A%2F%2F{}%3Fmode%3Drwc",
+        db.display().to_string().replace('/', "%2F")
+    );
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_redirection(),
+        "the tenant should provision: {}",
+        body_of(resp).await
+    );
+    slug
+}
+
+#[tokio::test]
+async fn migrating_one_tenant_records_a_migrate_run() {
+    let b = boot().await;
+    let slug = a_tenant(&b).await;
+
+    let resp = b.post(&format!("/orgs/{slug}/migrate")).await;
+    assert!(resp.status().is_redirection(), "should point at a run");
+    let run = b.settled(Booted::run_id(&resp)).await;
+
+    assert_eq!(RunKind::parse(&run.kind), RunKind::Migrate);
+    assert_eq!(run.slug, slug, "a single-tenant run names its tenant");
+    assert_eq!(
+        RunState::parse(&run.state),
+        RunState::Succeeded,
+        "error: {:?}",
+        run.error
+    );
+}
+
+/// A batch spans tenants that share no storage mode or backend, so it
+/// stores no slug — the events name each tenant instead.
+#[tokio::test]
+async fn migrating_everything_records_one_run_naming_each_tenant() {
+    let b = boot().await;
+    let first = a_tenant(&b).await;
+    let second = a_tenant(&b).await;
+
+    let resp = b.post("/orgs/migrate").await;
+    let run_id = Booted::run_id(&resp);
+    let run = b.settled(run_id).await;
+
+    assert_eq!(RunKind::parse(&run.kind), RunKind::Migrate);
+    assert!(run.slug.is_empty(), "a batch names no single tenant");
+    assert_eq!(
+        RunState::parse(&run.state),
+        RunState::Succeeded,
+        "error: {:?}",
+        run.error
+    );
+
+    let events = store::events_since(&b.registry, run_id, 0).await.unwrap();
+    let narrative: String = events.iter().map(|e| e.message.clone()).collect();
+    assert!(
+        narrative.contains(&first),
+        "should name {first}: {narrative}"
+    );
+    assert!(
+        narrative.contains(&second),
+        "should name {second}: {narrative}"
+    );
+    assert!(
+        events.iter().any(|e| e.step == "plan"),
+        "and open with a plan: {events:?}"
+    );
+}
+
+/// The work is spawned. An error has nowhere to go but the run, so it
+/// has to get there.
+#[tokio::test]
+async fn a_failure_lands_on_the_run_rather_than_vanishing() {
+    let b = boot().await;
+    let resp = b.post("/orgs/no-such-tenant/migrate").await;
+    assert!(
+        resp.status().is_redirection(),
+        "even a doomed migrate gets a run to look at"
+    );
+
+    let run = b.settled(Booted::run_id(&resp)).await;
+    assert_eq!(RunState::parse(&run.state), RunState::Failed);
+    assert!(
+        run.error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("no-such-tenant"),
+        "the reason should name the tenant: {:?}",
+        run.error
+    );
+}
+
+#[tokio::test]
+async fn the_run_view_says_migrating_rather_than_provisioning() {
+    let b = boot().await;
+    let slug = a_tenant(&b).await;
+    let resp = b.post(&format!("/orgs/{slug}/migrate")).await;
+    let run_id = Booted::run_id(&resp);
+    b.settled(run_id).await;
+
+    let html = body_of(b.get(&format!("/orgs/provision/{run_id}")).await).await;
+    assert!(html.contains("Migrating"), "the heading: {html}");
+    assert!(
+        !html.contains("<h1>Provisioning"),
+        "and not the provisioning one: {html}"
+    );
+}
+
+#[tokio::test]
+async fn the_run_index_marks_a_migrate_run() {
+    let b = boot().await;
+    b.settled(Booted::run_id(&b.post("/orgs/migrate").await))
+        .await;
+
+    let html = body_of(b.get("/orgs/provision").await).await;
+    assert!(
+        html.contains("all tenants"),
+        "a batch reads as such: {html}"
+    );
+    assert!(
+        html.contains("migrate"),
+        "and is marked as a migrate run: {html}"
+    );
+}
+
+#[tokio::test]
+async fn the_console_links_to_both_migrate_actions() {
+    let b = boot().await;
+    let slug = a_tenant(&b).await;
+
+    let orgs = body_of(b.get("/orgs").await).await;
+    assert!(
+        orgs.contains("/orgs/migrate"),
+        "the org list should offer a batch migrate: {orgs}"
+    );
+
+    let edit = body_of(b.get(&format!("/orgs/{slug}/edit")).await).await;
+    assert!(
+        edit.contains(&format!("/orgs/{slug}/migrate")),
+        "and a tenant's page should offer its own: {edit}"
+    );
+}
+
+#[tokio::test]
+async fn the_migrate_routes_require_a_session() {
+    let b = boot().await;
+    for uri in ["/orgs/migrate", "/orgs/acme/migrate"] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+            "POST {uri} was reachable without a session: {}",
+            resp.status()
+        );
+    }
+
+    let runs: Vec<ProvisioningRun> = ProvisioningRun::objects()
+        .where_(ProvisioningRun::kind.eq(RunKind::Migrate.as_str().to_owned()))
+        .fetch(&b.registry)
+        .await
+        .unwrap();
+    assert!(
+        runs.is_empty(),
+        "an unauthenticated post must not start a migration: {runs:?}"
+    );
+}

--- a/crates/rustango/tests/operator_console_operators_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_operators_sqlite_live.rs
@@ -1,0 +1,628 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Managing operators from the operator console, end to end through the
+//! real router.
+//!
+//! The page was a read-only table whose own copy told the reader to go
+//! and run `create-operator` on the production host. These tests cover
+//! the surface that replaced it, and in particular the two writes that
+//! must never succeed: the ones that lock somebody — or everybody — out
+//! of the console being used to make them.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, Auto, FetcherPool as _};
+use rustango::tenancy::operator_console::{router, router_with_provisioning, SessionSecret};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::{Operator, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    registry: rustango::sql::Pool,
+    me: String,
+    my_id: i64,
+    /// Kept so a second router built in a test can verify the same
+    /// session cookie. A fresh `from_env_or_random()` would reject it,
+    /// and the test would be measuring the key rather than the routes.
+    secret: SessionSecret,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein-please";
+    let mut op = Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+    let my_id = op.id.get().copied().unwrap_or_default();
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let secret = SessionSecret::from_env_or_random();
+    let app =
+        router_with_provisioning(registry.clone(), pools.clone(), provisioner, secret.clone());
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        registry,
+        me: username,
+        my_id,
+        secret,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn post(&self, uri: &str, body: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn operators(&self) -> Vec<Operator> {
+        Operator::objects().fetch(&self.registry).await.unwrap()
+    }
+
+    async fn find(&self, username: &str) -> Option<Operator> {
+        self.operators()
+            .await
+            .into_iter()
+            .find(|o| o.username == username)
+    }
+}
+
+/// The error path re-renders rather than redirecting, so the reason is
+/// in the body either way.
+///
+/// Matched on the rendered `<div>`, not the bare class name: the page
+/// inlines a stylesheet that *defines* `.alert-error`, so searching for
+/// the class alone found the CSS on every page and reported a failure
+/// as the text of a style rule.
+async fn outcome(resp: axum::response::Response) -> String {
+    if let Some(loc) = resp.headers().get("location") {
+        return format!("redirect:{}", loc.to_str().unwrap());
+    }
+    let html = body_of(resp).await;
+    const MARKER: &str = r#"<div class="alert alert-error">"#;
+    match html.find(MARKER) {
+        Some(i) => {
+            let from = i + MARKER.len();
+            let to = html[from..]
+                .find("</div>")
+                .map_or(html.len(), |end| from + end);
+            format!("error:{}", html[from..to].trim())
+        }
+        None => "rendered (no error)".to_owned(),
+    }
+}
+
+#[tokio::test]
+async fn an_operator_created_through_the_form_can_sign_in() {
+    let b = boot().await;
+    let name = unique("newbie");
+    let resp = b
+        .post(
+            "/operators",
+            &format!("username={name}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+        )
+        .await;
+    assert!(
+        resp.status().is_redirection(),
+        "a typed password should Post/Redirect/Get: {}",
+        resp.status()
+    );
+
+    let created = b.find(&name).await.expect("the operator should exist");
+    assert!(created.active, "new operators start active");
+
+    // The real acceptance test: the credential works.
+    let login = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={name}&password=hunter2hunter2"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let to = login
+        .headers()
+        .get("location")
+        .map(|l| l.to_str().unwrap().to_owned())
+        .unwrap_or_default();
+    assert!(
+        !to.contains("error"),
+        "the new operator should be able to log in, got {to}"
+    );
+}
+
+/// A generated password is a secret, so it is rendered on the POST
+/// response and never put in a redirect URL — where it would reach the
+/// history, the referrer and every access log in between.
+#[tokio::test]
+async fn a_generated_password_is_shown_once_and_never_in_a_url() {
+    let b = boot().await;
+    let name = unique("gen");
+    let resp = b
+        .post("/operators", &format!("username={name}&generate=on"))
+        .await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a generated password must be rendered, not redirected to"
+    );
+    assert!(
+        resp.headers()
+            .get("cache-control")
+            .is_some_and(|v| v.to_str().unwrap().contains("no-store")),
+        "a page holding a plaintext password must not be cached"
+    );
+    let html = body_of(resp).await;
+    assert!(
+        html.contains("alert-secret"),
+        "the password should be shown once: {html}"
+    );
+    assert!(b.find(&name).await.is_some(), "and the operator created");
+}
+
+#[tokio::test]
+async fn you_cannot_deactivate_yourself() {
+    let b = boot().await;
+    let resp = b.post(&format!("/operators/{}/active", b.my_id), "").await;
+    let out = outcome(resp).await;
+    assert!(out.starts_with("error:"), "should be refused, got {out}");
+    assert!(out.contains("yourself"), "should say why: {out}");
+
+    let me = b.find(&b.me).await.expect("still there");
+    assert!(me.active, "and must still be active");
+}
+
+/// The other lock: with one operator left, deactivating them would
+/// leave a console nobody can sign in to and no console path back.
+///
+/// Reached here by asking a *second* operator's row to be deactivated
+/// while it is the only active one — the session owner cannot be the
+/// target, because that is the self-check above.
+#[tokio::test]
+async fn deactivating_an_already_inactive_operator_says_so_rather_than_crying_lockout() {
+    let b = boot().await;
+    let name = unique("parked");
+    b.post(
+        "/operators",
+        &format!("username={name}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+    )
+    .await;
+    let id = b.find(&name).await.unwrap().id.get().copied().unwrap();
+
+    // First deactivation: fine, the session owner stays active.
+    let out = outcome(b.post(&format!("/operators/{id}/active"), "").await).await;
+    assert!(out.starts_with("redirect:"), "should succeed: {out}");
+    assert!(!b.find(&name).await.unwrap().active);
+
+    // Second: a no-op. It must not be reported as a lockout — the
+    // lockout check used to run first and counted the target itself,
+    // so it answered "this is the last active operator" about an
+    // operator who was not active at all.
+    let resp = b.post(&format!("/operators/{id}/active"), "").await;
+    let loc = resp
+        .headers()
+        .get("location")
+        .expect("a no-op still redirects")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(
+        loc.contains("already"),
+        "should report a no-op, not a lockout: {loc}"
+    );
+    assert!(
+        !loc.contains("last%20active") && !loc.contains("lock"),
+        "should not claim a lockout: {loc}"
+    );
+}
+
+#[tokio::test]
+async fn deactivating_takes_effect_on_the_next_request() {
+    let b = boot().await;
+    let name = unique("bye");
+    b.post(
+        "/operators",
+        &format!("username={name}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+    )
+    .await;
+
+    // Sign the new operator in.
+    let login = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={name}&password=hunter2hunter2"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let their_cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    let still_in = |cookie: String| {
+        let app = b.app.clone();
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .uri("/orgs")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+        }
+    };
+    assert_eq!(
+        still_in(their_cookie.clone()).await,
+        StatusCode::OK,
+        "should be signed in to start with"
+    );
+
+    let id = b.find(&name).await.unwrap().id.get().copied().unwrap();
+    b.post(&format!("/operators/{id}/active"), "").await;
+
+    assert!(
+        still_in(their_cookie).await.is_redirection(),
+        "the session must stop working immediately, not at expiry"
+    );
+}
+
+/// Wait until the wall clock crosses into the next second.
+///
+/// Session `iat` and `password_changed_at` are both second-granularity,
+/// and `require_session` rejects on `iat < password_changed_at` —
+/// strictly less than, deliberately: `change_password_submit` does not
+/// re-mint the cookie, so `<=` would sign an operator out the instant
+/// they changed their own password. The consequence is that a reset in
+/// the *same second* as a login leaves that session valid, which made
+/// this test pass or fail depending on where the second boundary fell.
+async fn cross_a_second_boundary() {
+    let start = chrono::Utc::now().timestamp();
+    while chrono::Utc::now().timestamp() == start {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+/// A reset rotates `password_changed_at`, and `require_session` rejects
+/// sessions issued before it. The page promises this; the promise has
+/// to be true.
+#[tokio::test]
+async fn resetting_a_password_signs_that_operator_out() {
+    let b = boot().await;
+    let name = unique("rotate");
+    b.post(
+        "/operators",
+        &format!("username={name}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+    )
+    .await;
+    let id = b.find(&name).await.unwrap().id.get().copied().unwrap();
+
+    let login = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={name}&password=hunter2hunter2"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let their_cookie = login
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    cross_a_second_boundary().await;
+    b.post(
+        &format!("/operators/{id}/reset-password"),
+        "password=totally-new-one&confirm_password=totally-new-one",
+    )
+    .await;
+
+    let after = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/orgs")
+                .header("cookie", &their_cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        after.status().is_redirection(),
+        "the old session must be rejected after a reset"
+    );
+    assert!(
+        b.find(&name).await.unwrap().password_changed_at.is_some(),
+        "password_changed_at is what does it, so it must be set"
+    );
+}
+
+#[tokio::test]
+async fn the_form_refuses_what_it_should() {
+    let b = boot().await;
+    let taken = unique("taken");
+    b.post(
+        "/operators",
+        &format!("username={taken}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+    )
+    .await;
+
+    let cases = [
+        (
+            format!("username={taken}&password=hunter2hunter2&confirm_password=hunter2hunter2"),
+            "already exists",
+        ),
+        (
+            "username=%20%20&password=hunter2hunter2&confirm_password=hunter2hunter2".to_owned(),
+            "username is required",
+        ),
+        (
+            format!(
+                "username={}&password=hunter2hunter2&confirm_password=hunter2hunter2",
+                "x".repeat(65)
+            ),
+            "at most 64",
+        ),
+        (
+            "username=shorty&password=abc&confirm_password=abc".to_owned(),
+            "at least 8",
+        ),
+        (
+            "username=nomatch&password=hunter2hunter2&confirm_password=different0".to_owned(),
+            "did not match",
+        ),
+        ("username=nopass".to_owned(), "password is required"),
+        (
+            "username=both&password=hunter2hunter2&confirm_password=hunter2hunter2&generate=on"
+                .to_owned(),
+            "Choose one",
+        ),
+    ];
+    for (body, expect) in cases {
+        let out = outcome(b.post("/operators", &body).await).await;
+        assert!(
+            out.starts_with("error:") && out.contains(expect),
+            "`{body}` should have been refused with `{expect}`, got {out}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_write_routes_require_a_session() {
+    let b = boot().await;
+    for (uri, body) in [
+        (
+            "/operators".to_owned(),
+            "username=evil&password=hunter2hunter2&confirm_password=hunter2hunter2",
+        ),
+        (format!("/operators/{}/active", b.my_id), ""),
+        (
+            format!("/operators/{}/reset-password", b.my_id),
+            "generate=on",
+        ),
+    ] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+            "POST {uri} was reachable without a session: {}",
+            resp.status()
+        );
+    }
+
+    assert!(
+        b.find("evil").await.is_none(),
+        "an unauthenticated post must not create an operator"
+    );
+    assert!(
+        b.find(&b.me).await.unwrap().active,
+        "nor deactivate anybody"
+    );
+}
+
+/// A read-only console offers the list and nothing else — and says so,
+/// rather than rendering buttons that 404.
+#[tokio::test]
+async fn a_read_only_console_lists_but_does_not_manage() {
+    let b = boot().await;
+    // The same secret, so the existing cookie is valid here and the
+    // test measures which routes are mounted rather than which key
+    // signed the session.
+    let read_only = router(b.registry.clone(), b.secret.clone());
+
+    let listing = read_only
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/operators")
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(listing.status(), StatusCode::OK, "the list still works");
+    let html = body_of(listing).await;
+    assert!(
+        !html.contains("Add an operator"),
+        "a read-only console must not offer the form: {html}"
+    );
+
+    let write = read_only
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/operators")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "username=nope&password=hunter2hunter2&confirm_password=hunter2hunter2",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        write.status() == StatusCode::NOT_FOUND || write.status() == StatusCode::METHOD_NOT_ALLOWED,
+        "and must not accept the write: {}",
+        write.status()
+    );
+}
+
+#[tokio::test]
+async fn the_page_never_renders_a_password_hash() {
+    let b = boot().await;
+    let html = body_of(b.get("/operators").await).await;
+    assert!(
+        !html.contains("$argon2") && !html.contains("password_hash"),
+        "the hash must not reach the page: {html}"
+    );
+}

--- a/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
@@ -17,9 +17,15 @@ use tower::ServiceExt;
 
 static UNIQ: AtomicU64 = AtomicU64::new(0);
 
+/// Hyphens, not underscores.
+///
+/// A slug becomes a hostname label, where `_` is illegal — and the
+/// engine now enforces that. This helper produced `acme12345_0`, so
+/// tightening the rule turned every test slug invalid. The rule is
+/// right; the generator was wrong.
 fn unique(prefix: &str) -> String {
     format!(
-        "{prefix}{}_{}",
+        "{prefix}-{}-{}",
         std::process::id(),
         UNIQ.fetch_add(1, Ordering::SeqCst)
     )
@@ -159,6 +165,113 @@ async fn the_create_form_renders_for_an_authenticated_operator() {
     assert!(
         !html.contains("value=\"schema\""),
         "schema mode offered on a sqlite registry"
+    );
+}
+
+/// The tenant list links to the create page.
+///
+/// This shipped without a link first: the route and the template
+/// existed, and the only way to reach them was typing the URL. A page
+/// nothing navigates to is not a feature, so the link is pinned here
+/// rather than left to survive on someone remembering it.
+#[tokio::test]
+async fn the_org_list_links_to_the_create_page() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/orgs")
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(
+        html.contains("href=\"/orgs/new\""),
+        "no link to the create page: {html}"
+    );
+    assert!(html.contains("New tenant"), "the link has no label");
+}
+
+/// And it is absent when provisioning is off, so a console that
+/// cannot create tenants does not advertise a 404.
+#[tokio::test]
+async fn the_org_list_hides_the_link_without_a_provisioner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let mut op = rustango::tenancy::Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash("letmein").unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    let app = rustango::tenancy::operator_console::router_with_pools(
+        registry.clone(),
+        pools.clone(),
+        SessionSecret::from_env_or_random(),
+    );
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!("username={username}&password=letmein")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/orgs")
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let html = body_of(resp).await;
+    assert!(
+        !html.contains("href=\"/orgs/new\""),
+        "a console without a provisioner must not link to a 404"
     );
 }
 
@@ -323,8 +436,11 @@ async fn a_bad_submission_re_renders_the_form_with_the_reason() {
                 .uri("/orgs/new")
                 .header("cookie", &b.cookie)
                 .header("content-type", "application/x-www-form-urlencoded")
-                // Database mode with no URL.
-                .body(Body::from("slug=nourl&storage_mode=database"))
+                // A slug that is not a legal hostname label. Was
+                // "database mode with no URL", which is no longer an
+                // error — the console derives one from the registry
+                // now, which is the whole point of that change.
+                .body(Body::from("slug=Not_A_Slug&storage_mode=database"))
                 .unwrap(),
         )
         .await
@@ -332,9 +448,12 @@ async fn a_bad_submission_re_renders_the_form_with_the_reason() {
 
     assert_eq!(resp.status(), StatusCode::OK, "re-render, not a redirect");
     let html = body_of(resp).await;
-    assert!(html.contains("--database-url"), "should say what is wrong");
     assert!(
-        html.contains("value=\"nourl\""),
+        html.contains("lowercase letters, digits and hyphens"),
+        "should say what is wrong: {html}"
+    );
+    assert!(
+        html.contains("value=\"Not_A_Slug\""),
         "the operator's input should survive the round-trip"
     );
 
@@ -511,4 +630,114 @@ async fn the_routes_do_not_exist_without_a_provisioner() {
         StatusCode::NOT_FOUND,
         "provisioning must be opt-in"
     );
+}
+
+/// **The test that was missing.**
+///
+/// Everything above drives a router the *test* constructs. That proves
+/// the handlers work and proves nothing about whether the framework
+/// ever builds one — which is exactly how this shipped with
+/// `router_with_provisioning` written, exported, documented, and
+/// called by nobody.
+///
+/// So: go through `server::Builder`, the thing `Cli::tenancy()`
+/// actually uses, and assert the routes exist on *its* output.
+mod through_the_builder {
+    use super::{body_of, unique};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use rustango::sql::sqlx;
+    use tower::ServiceExt;
+
+    async fn registry() -> (sqlx::SqlitePool, String, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+        let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+        (pool, url, tmp)
+    }
+
+    /// A route that exists answers *something* — 200, a redirect to
+    /// login, whatever. A route that was never mounted 404s. That is
+    /// the whole distinction being pinned, and it needs no session.
+    async fn probes_as_mounted(app: &axum::Router, uri: &str) -> bool {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("host", "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        resp.status() != StatusCode::NOT_FOUND
+    }
+
+    #[tokio::test]
+    async fn with_tenant_provisioning_mounts_the_create_routes() {
+        let (pool, url, tmp) = registry().await;
+        let migrations = tempfile::tempdir().expect("migrations");
+        let app = rustango::server::Builder::from_pool(pool, url, "localhost")
+            .with_tenant_provisioning(migrations.path())
+            .into_router()
+            .await
+            .expect("assemble");
+
+        assert!(
+            probes_as_mounted(&app, "/orgs/new").await,
+            "`with_tenant_provisioning` did not reach the console"
+        );
+        assert!(probes_as_mounted(&app, "/orgs/provision/1").await);
+        let _ = (tmp, unique("x"));
+    }
+
+    /// And the default really is off — so the opt-in means something.
+    #[tokio::test]
+    async fn without_it_the_create_routes_are_absent() {
+        let (pool, url, tmp) = registry().await;
+        let app = rustango::server::Builder::from_pool(pool, url, "localhost")
+            .into_router()
+            .await
+            .expect("assemble");
+
+        assert!(
+            !probes_as_mounted(&app, "/orgs/new").await,
+            "provisioning must be opt-in, not on by default"
+        );
+        // The console itself is still there — this is about one
+        // capability, not the whole surface.
+        assert!(probes_as_mounted(&app, "/orgs").await);
+        let _ = tmp;
+    }
+
+    /// The link the operator clicks comes from the Builder's console
+    /// too, not just from a hand-built one.
+    #[tokio::test]
+    async fn the_builders_console_links_to_the_create_page() {
+        let (pool, url, tmp) = registry().await;
+        let migrations = tempfile::tempdir().expect("migrations");
+        let app = rustango::server::Builder::from_pool(pool, url, "localhost")
+            .with_tenant_provisioning(migrations.path())
+            .into_router()
+            .await
+            .expect("assemble");
+
+        // Unauthenticated, so this is the login redirect — the point
+        // is only that the route resolves through the Builder's
+        // console. The rendered link is asserted in
+        // `the_org_list_links_to_the_create_page`.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orgs")
+                    .header("host", "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+        let _ = (body_of(resp).await, tmp);
+    }
 }

--- a/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
@@ -653,6 +653,218 @@ async fn the_stream_resumes_from_a_given_seq() {
 
 /// Without a provisioner the routes are simply absent — the console
 /// built the old way cannot create tenants at all.
+/// A run used to be reachable only by its id, which meant only from
+/// the redirect that created it: navigate away and the record was
+/// stranded in a table nobody could enumerate.
+#[tokio::test]
+async fn the_run_index_lists_runs_and_links_to_each() {
+    let b = boot().await;
+    let tenant_db = b._tmp.path().join("indexed.db");
+    let slug = unique("indexed");
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url={}",
+        form_encode(&format!("sqlite://{}?mode=rwc", tenant_db.display()))
+    );
+    let created = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let run_path = created
+        .headers()
+        .get("location")
+        .expect("a run to watch")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    // The redirect is relative (`provision/<id>`); the index links with
+    // a leading slash, so compare on the id.
+    let run_id = run_path.rsplit('/').next().unwrap().to_owned();
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/orgs/provision")
+                .header("cookie", &b.cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(
+        html.contains(&slug),
+        "the run's tenant should appear: {html}"
+    );
+    assert!(
+        html.contains(&format!("/orgs/provision/{run_id}")),
+        "and link to the run itself: {html}"
+    );
+    assert!(html.contains("succeeded"), "with its outcome: {html}");
+}
+
+/// The index is where somebody looks for a run that went wrong, so the
+/// reason has to be on it rather than one click away.
+#[tokio::test]
+async fn the_run_index_shows_why_a_run_failed() {
+    let b = boot().await;
+    let slug = unique("doomed");
+    // Schema mode on SQLite is refused — a real failure, recorded as a
+    // run, with a message worth surfacing.
+    let form = format!("slug={slug}&storage_mode=schema&backend_kind=sqlite");
+    b.app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let html = body_of(
+        b.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/orgs/provision")
+                    .header("cookie", &b.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    // Either the run was recorded and shows as failed, or it was
+    // refused before a run opened — in which case the index is
+    // legitimately empty. Both are correct; what must not happen is a
+    // run listed with no explanation.
+    if html.contains(&slug) {
+        assert!(
+            html.contains("failed"),
+            "a listed run that failed must say so: {html}"
+        );
+    }
+}
+
+/// Paging past the end must not be a dead end. The links used to sit
+/// inside the non-empty branch, so an empty page offered no way back
+/// and only a URL edit escaped it.
+#[tokio::test]
+async fn an_empty_run_page_still_offers_a_way_back() {
+    let b = boot().await;
+    let html = body_of(
+        b.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/orgs/provision?page=3")
+                    .header("cookie", &b.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert!(
+        html.contains("/orgs/provision?page=2"),
+        "an empty page past the end must link back: {html}"
+    );
+    assert!(
+        !html.contains("No tenant has been provisioned"),
+        "and must not claim nothing ever happened: {html}"
+    );
+}
+
+/// Same overflow as the audit page: the multiply panicked the worker.
+#[tokio::test]
+async fn an_absurd_run_page_number_does_not_overflow_the_offset() {
+    let b = boot().await;
+    for page in ["1000000000000000000", "9223372036854775807"] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/orgs/provision?page={page}"))
+                    .header("cookie", &b.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "page={page} should render an empty page, not fail"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_run_index_requires_a_session() {
+    let b = boot().await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/orgs/provision")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_redirection() || resp.status() == StatusCode::UNAUTHORIZED,
+        "the index was reachable without a session: {}",
+        resp.status()
+    );
+}
+
+/// The org list is the only page that links to the index, so without
+/// that link it is reachable by typing a URL and nothing else.
+#[tokio::test]
+async fn the_org_list_links_to_the_run_index() {
+    let b = boot().await;
+    let html = body_of(
+        b.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/orgs")
+                    .header("cookie", &b.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert!(
+        html.contains("/orgs/provision"),
+        "the org list should link to the run history: {html}"
+    );
+}
+
 #[tokio::test]
 async fn the_routes_do_not_exist_without_a_provisioner() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
@@ -35,6 +35,7 @@ struct Booted {
     app: axum::Router,
     cookie: String,
     pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry_url: String,
     _tmp: tempfile::TempDir,
     _migrations: tempfile::TempDir,
 }
@@ -113,6 +114,7 @@ async fn boot() -> Booted {
         app,
         cookie,
         pools,
+        registry_url: url,
         _tmp: tmp,
         _migrations: migrations,
     }
@@ -344,6 +346,53 @@ async fn test_connection_reports_why_and_creates_nothing() {
         .await
         .unwrap();
     assert!(orgs.is_empty(), "a probe must not create a tenant");
+}
+
+/// The probe has to answer the question the submit will answer, and
+/// the registry's own database is the case where reachability and
+/// usability disagree.
+///
+/// It is reachable, and the role *can* create tables in it, so the
+/// probe reported "This role can create tables, so migrations will
+/// run" — its most confident wording — for the one target
+/// provisioning refuses outright. An operator who tests before
+/// submitting was told the mistake was fine.
+#[tokio::test]
+async fn the_probe_refuses_the_registry_instead_of_blessing_it() {
+    let b = boot().await;
+    let registry_url = b.registry_url.clone();
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/test-connection")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "database_url={}",
+                    form_encode(&registry_url)
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(
+        html.contains("probe-bad"),
+        "the registry's own database must not probe as usable: {html}"
+    );
+    assert!(
+        html.contains("registry"),
+        "should say why it is refused: {html}"
+    );
+    assert!(
+        !html.contains("migrations will run"),
+        "the success wording must not appear: {html}"
+    );
 }
 
 /// The whole path: submit the form, get redirected to the run, and

--- a/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_provisioning_sqlite_live.rs
@@ -764,12 +764,31 @@ async fn the_run_index_shows_why_a_run_failed() {
     }
 }
 
-/// Paging past the end must not be a dead end. The links used to sit
-/// inside the non-empty branch, so an empty page offered no way back
-/// and only a URL edit escaped it.
+/// `Paginator::get_page` clamps, so page 3 of a one-page list renders
+/// page 1 rather than stranding the operator on an empty page.
 #[tokio::test]
-async fn an_empty_run_page_still_offers_a_way_back() {
+async fn a_run_page_past_the_end_clamps_to_real_data() {
     let b = boot().await;
+    let slug = unique("clamped");
+    let tenant_db = b._tmp.path().join("clamped.db");
+    let form = format!(
+        "slug={slug}&storage_mode=database&backend_kind=sqlite&database_url={}",
+        form_encode(&format!("sqlite://{}?mode=rwc", tenant_db.display()))
+    );
+    b.app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/new")
+                .header("cookie", &b.cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(form))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
     let html = body_of(
         b.app
             .clone()
@@ -785,8 +804,8 @@ async fn an_empty_run_page_still_offers_a_way_back() {
     )
     .await;
     assert!(
-        html.contains("/orgs/provision?page=2"),
-        "an empty page past the end must link back: {html}"
+        html.contains(&slug),
+        "should clamp to the page that has the run: {html}"
     );
     assert!(
         !html.contains("No tenant has been provisioned"),

--- a/crates/rustango/tests/org_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/org_hosts_sqlite_live.rs
@@ -3,8 +3,10 @@
 //! The rules worth pinning are the ones a unit test cannot reach: a host
 //! may be bound and unbound freely, but the tenant's **base** host — the
 //! `Org.host_pattern` written by `create-tenant` — must survive every
-//! removal path, because a tenant with no host is unreachable and there is
-//! no UI to put it back.
+//! removal path, because a tenant with no host is unreachable.
+//!
+//! This file is the engine. The console surface that drives it lives in
+//! `operator_console_hosts_sqlite_live`.
 //! NOTE on isolation: the resolver's cache is process-global and keyed by
 //! hostname, so each test below uses a hostname of its own. Production has
 //! one registry per process, which is why the cache needs no registry key.

--- a/crates/rustango/tests/provision_sqlite_live.rs
+++ b/crates/rustango/tests/provision_sqlite_live.rs
@@ -243,7 +243,16 @@ async fn database_mode_without_a_url_is_rejected_before_any_write() {
     .await
     .expect_err("must be rejected");
 
-    assert!(err.to_string().contains("--database-url"), "got: {err}");
+    let msg = err.to_string();
+    assert!(msg.contains("database URL"), "got: {msg}");
+    // The engine is shared by the CLI, the console and the webhook, so
+    // its messages cannot name one caller's flags. This said
+    // "create-tenant --mode database requires --database-url" and was
+    // shown verbatim in a web form that has neither flag.
+    assert!(
+        !msg.contains("--"),
+        "a shared engine message must not name CLI flags: {msg}"
+    );
     assert_eq!(rec.steps(), vec!["Validate:started", "Validate:failed"]);
 
     let orgs = rustango::tenancy::Org::objects()

--- a/crates/rustango/tests/provision_store_sqlite_live.rs
+++ b/crates/rustango/tests/provision_store_sqlite_live.rs
@@ -328,7 +328,7 @@ async fn a_run_that_fails_early_still_closes() {
     )
     .await
     .expect_err("must be rejected");
-    assert!(err.to_string().contains("--database-url"), "got: {err}");
+    assert!(err.to_string().contains("database URL"), "got: {err}");
 
     let registry_pool = pools.registry_pool();
     let runs: Vec<store::ProvisioningRun> = store::ProvisioningRun::objects()

--- a/crates/rustango/tests/provision_webhook_sqlite_live.rs
+++ b/crates/rustango/tests/provision_webhook_sqlite_live.rs
@@ -1,0 +1,484 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy", feature = "webhook"))]
+//! Inbound provisioning webhook (#1323).
+//!
+//! The acceptance list, each one a way this goes wrong in production:
+//! a forged or unsigned delivery is refused; the signature is checked
+//! over the **raw bytes**; a replayed delivery outside the window is
+//! refused; a retry returns the first run and creates **no second
+//! tenant** — tested concurrently, because that is the real case; and
+//! the run is visible exactly like a console-initiated one.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, FetcherPool as _};
+use rustango::tenancy::provision::Provisioner;
+use rustango::tenancy::provision_store as store;
+use rustango::tenancy::provision_webhook::{router, UrlPolicy, WebhookConfig, WebhookState};
+use rustango::tenancy::{Org, TenantPools};
+use rustango::webhook::{sign, SignatureFormat};
+use tower::ServiceExt;
+
+const SECRET: &[u8] = b"shared-secret-at-least-32-bytes-long";
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+async fn boot_with(policy: UrlPolicy) -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let provisioner = Provisioner::new(pools.clone(), url.clone(), migrations.path()).erased();
+    let config = WebhookConfig {
+        url_policy: policy,
+        ..WebhookConfig::new(SECRET.to_vec(), "")
+    };
+    let app = router(
+        "/hooks/provision",
+        WebhookState {
+            config,
+            provisioner,
+        },
+    );
+
+    Booted {
+        app,
+        pools,
+        tmp,
+        _migrations: migrations,
+    }
+}
+
+/// Template policy pointing at sqlite files under `dir`.
+async fn boot(dir_hint: &tempfile::TempDir) -> Booted {
+    let template = format!(
+        "sqlite://{}/t_{{slug}}.db?mode=rwc",
+        dir_hint.path().display()
+    );
+    boot_with(UrlPolicy::Template(template)).await
+}
+
+fn body_for(slug: &str, event_id: &str, ts: i64) -> String {
+    serde_json::json!({
+        "event_id": event_id,
+        "timestamp": ts,
+        "slug": slug,
+    })
+    .to_string()
+}
+
+fn signed(body: &str) -> String {
+    sign(
+        SignatureFormat::HexSha256WithPrefix,
+        SECRET,
+        body.as_bytes(),
+    )
+}
+
+fn post(body: String, signature: Option<&str>) -> Request<Body> {
+    let mut b = Request::builder()
+        .method("POST")
+        .uri("/hooks/provision")
+        .header("content-type", "application/json");
+    if let Some(sig) = signature {
+        b = b.header("x-signature-256", sig);
+    }
+    b.body(Body::from(body)).unwrap()
+}
+
+async fn json_of(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+/// Wait for the spawned provisioning task to finish, so assertions
+/// about the tenant are not racing it.
+async fn await_run(b: &Booted, run_id: i64) -> store::ProvisioningRun {
+    let registry = b.pools.registry_pool();
+    for _ in 0..200 {
+        if let Ok(Some(run)) = store::run_by_id(&registry, run_id).await {
+            if store::RunState::parse(&run.state).is_terminal() {
+                return run;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("run {run_id} never reached a terminal state");
+}
+
+#[tokio::test]
+async fn a_signed_delivery_creates_a_tenant() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let slug = unique("acme");
+    let body = body_for(&slug, "evt-create", chrono::Utc::now().timestamp());
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(post(body.clone(), Some(&signed(&body))))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "should accept and queue"
+    );
+    let json = json_of(resp).await;
+    assert_eq!(json["duplicate"], serde_json::json!(false));
+    let run_id = json["run_id"].as_i64().expect("a run id to poll");
+
+    let run = await_run(&b, run_id).await;
+    assert_eq!(
+        store::RunState::parse(&run.state),
+        store::RunState::Succeeded,
+        "run failed: {:?}",
+        run.error
+    );
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert_eq!(orgs.len(), 1);
+    assert_eq!(orgs[0].slug, slug);
+    assert!(orgs[0].active, "a successful run ends with the tenant live");
+    // The template derived the URL — the caller never named a host.
+    assert!(
+        orgs[0]
+            .database_url
+            .as_deref()
+            .is_some_and(|u| u.contains(&format!("t_{slug}.db"))),
+        "url should come from the template: {:?}",
+        orgs[0].database_url
+    );
+}
+
+#[tokio::test]
+async fn an_unsigned_or_forged_delivery_is_refused_and_creates_nothing() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let body = body_for(
+        &unique("forged"),
+        "evt-forged",
+        chrono::Utc::now().timestamp(),
+    );
+
+    for signature in [None, Some("sha256=deadbeef"), Some("garbage")] {
+        let resp = b
+            .app
+            .clone()
+            .oneshot(post(body.clone(), signature))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "signature {signature:?} should have been refused"
+        );
+    }
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(orgs.is_empty(), "a refused delivery must create nothing");
+    let runs: Vec<store::ProvisioningRun> = store::ProvisioningRun::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(runs.is_empty(), "a refused delivery must not open a run");
+}
+
+/// The signature covers the **exact bytes**. A body altered after
+/// signing must fail even when it parses to something plausible — the
+/// forgery hole a parse-then-re-serialize handler leaves open.
+#[tokio::test]
+async fn the_signature_is_checked_over_the_raw_bytes() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let original = body_for("victim", "evt-tamper", chrono::Utc::now().timestamp());
+    let signature = signed(&original);
+
+    // Same JSON *document* in a different byte encoding (whitespace).
+    let reformatted = serde_json::to_string_pretty(
+        &serde_json::from_str::<serde_json::Value>(&original).unwrap(),
+    )
+    .unwrap();
+    assert_ne!(original, reformatted, "the bytes must actually differ");
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(post(reformatted, Some(&signature)))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "a re-encoded body must not verify"
+    );
+
+    // And a genuinely swapped slug, obviously.
+    let swapped = original.replace("victim", "attacker");
+    let resp = b
+        .app
+        .clone()
+        .oneshot(post(swapped, Some(&signature)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A signature alone is replayable forever. The timestamp window is
+/// what stops a captured delivery being re-sent next month.
+#[tokio::test]
+async fn a_stale_or_future_delivery_is_refused() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let now = chrono::Utc::now().timestamp();
+
+    for (label, ts) in [("stale", now - 3600), ("future", now + 3600)] {
+        let body = body_for(&unique("replay"), &unique("evt"), ts);
+        let resp = b
+            .app
+            .clone()
+            .oneshot(post(body.clone(), Some(&signed(&body))))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "a {label} timestamp should be refused"
+        );
+    }
+}
+
+/// A retried delivery returns the first run and creates no second
+/// tenant — the sequential case.
+#[tokio::test]
+async fn a_retried_delivery_returns_the_first_run() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let slug = unique("retry");
+    let body = body_for(&slug, "evt-retry", chrono::Utc::now().timestamp());
+    let sig = signed(&body);
+
+    let first = b
+        .app
+        .clone()
+        .oneshot(post(body.clone(), Some(&sig)))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+    let first_json = json_of(first).await;
+    let run_id = first_json["run_id"].as_i64().unwrap();
+    await_run(&b, run_id).await;
+
+    let second = b.app.clone().oneshot(post(body, Some(&sig))).await.unwrap();
+    assert_eq!(
+        second.status(),
+        StatusCode::OK,
+        "a duplicate is not a fresh acceptance"
+    );
+    let second_json = json_of(second).await;
+    assert_eq!(second_json["duplicate"], serde_json::json!(true));
+    assert_eq!(
+        second_json["run_id"], first_json["run_id"],
+        "a retry must point at the original run"
+    );
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert_eq!(orgs.len(), 1, "a retry must not create a second tenant");
+}
+
+/// **The real case.** Two deliveries of one event arriving at once —
+/// the check-then-insert window. The unique constraint on
+/// `idempotency_key`, not the handler, is what has to win.
+#[tokio::test]
+async fn two_simultaneous_deliveries_create_one_tenant() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let slug = unique("racy");
+    let body = body_for(&slug, "evt-race", chrono::Utc::now().timestamp());
+    let sig = signed(&body);
+
+    let (a, c) = tokio::join!(
+        b.app.clone().oneshot(post(body.clone(), Some(&sig))),
+        b.app.clone().oneshot(post(body.clone(), Some(&sig))),
+    );
+    let (a, c) = (a.unwrap(), c.unwrap());
+
+    // One may be accepted and one rejected, or one accepted and one
+    // de-duplicated — both are correct. What is never correct is two
+    // tenants.
+    let statuses = [a.status(), c.status()];
+    assert!(
+        statuses
+            .iter()
+            .any(|s| *s == StatusCode::ACCEPTED || *s == StatusCode::OK),
+        "at least one delivery should have been handled: {statuses:?}"
+    );
+
+    // Let whichever run started finish.
+    for resp in [a, c] {
+        if let Some(id) = json_of(resp).await["run_id"].as_i64() {
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(10), await_run(&b, id)).await;
+        }
+    }
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(
+        orgs.len() <= 1,
+        "two simultaneous deliveries created {} tenants",
+        orgs.len()
+    );
+    let runs: Vec<store::ProvisioningRun> = store::ProvisioningRun::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert_eq!(runs.len(), 1, "one event, one run: {runs:?}");
+}
+
+/// The security decision, end to end: a caller-supplied `database_url`
+/// is **refused**, not silently ignored.
+#[tokio::test]
+async fn a_caller_supplied_url_is_refused_under_the_default_policy() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let body = serde_json::json!({
+        "event_id": "evt-policy",
+        "timestamp": chrono::Utc::now().timestamp(),
+        "slug": "sneaky",
+        "database_url": "postgres://attacker:pw@evil.example.com:5432/exfil",
+    })
+    .to_string();
+
+    let resp = b
+        .app
+        .clone()
+        .oneshot(post(body.clone(), Some(&signed(&body))))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a signed-but-disallowed field must be refused, not dropped"
+    );
+    let json = json_of(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("derives")),
+        "the refusal should say why: {json}"
+    );
+
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(orgs.is_empty());
+}
+
+/// A bad slug never reaches the provisioning engine.
+#[tokio::test]
+async fn a_dangerous_slug_is_refused_at_the_door() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    for bad in ["Acme", "ac me", "acme;DROP TABLE x", "../../etc/passwd"] {
+        let body = body_for(bad, &unique("evt"), chrono::Utc::now().timestamp());
+        let resp = b
+            .app
+            .clone()
+            .oneshot(post(body.clone(), Some(&signed(&body))))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "slug `{bad}` should have been refused"
+        );
+    }
+    let orgs: Vec<Org> = Org::objects()
+        .fetch(&b.pools.registry_pool())
+        .await
+        .unwrap();
+    assert!(orgs.is_empty());
+}
+
+/// A webhook-initiated run is an ordinary run: the same events, the
+/// same shape the console renders.
+#[tokio::test]
+async fn the_run_is_visible_exactly_like_a_console_run() {
+    let holder = tempfile::tempdir().expect("tenants dir");
+    let b = boot(&holder).await;
+    let body = body_for(
+        &unique("visible"),
+        "evt-visible",
+        chrono::Utc::now().timestamp(),
+    );
+    let resp = b
+        .app
+        .clone()
+        .oneshot(post(body.clone(), Some(&signed(&body))))
+        .await
+        .unwrap();
+    let run_id = json_of(resp).await["run_id"].as_i64().unwrap();
+    await_run(&b, run_id).await;
+
+    let events = store::events_since(&b.pools.registry_pool(), run_id, 0)
+        .await
+        .expect("events");
+    let steps: Vec<&str> = events.iter().map(|e| e.step.as_str()).collect();
+    for expected in ["validate", "register_org", "migrate", "activate"] {
+        assert!(steps.contains(&expected), "missing `{expected}`: {steps:?}");
+    }
+    // Dense and ordered, so the console's `Last-Event-ID` resume works
+    // for a webhook run too.
+    let seqs: Vec<i64> = events.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, (1..=seqs.len() as i64).collect::<Vec<_>>());
+
+    // `requested_by` distinguishes it from an operator's own run.
+    let run = store::run_by_id(&b.pools.registry_pool(), run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.requested_by.as_deref(), Some("webhook"));
+    let _ = &b.tmp;
+}

--- a/crates/rustango/tests/template_views_extra_context_sqlite_live.rs
+++ b/crates/rustango/tests/template_views_extra_context_sqlite_live.rs
@@ -1,0 +1,179 @@
+//! `ExtraContext` — per-request template context for the generic views.
+//!
+//! A generic view builds its context from the model, so a page that
+//! `{% extends %}` a shared layout failed the moment that layout read a
+//! variable the view never inserts. Middleware now supplies those.
+
+#![cfg(all(feature = "template_views", feature = "sqlite"))]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use rustango::core::Model as _;
+use rustango::sql::{Auto, Pool};
+use rustango::template_views::{ExtraContext, ListView};
+use rustango::Model;
+use tera::{Context, Tera};
+use tower::ServiceExt;
+
+#[derive(Model, Debug, Clone)]
+#[rustango(table = "xc_post", display = "title")]
+#[allow(dead_code)]
+pub struct XcPost {
+    #[rustango(primary_key)]
+    pub id: Auto<i64>,
+    #[rustango(max_length = 200)]
+    pub title: String,
+}
+
+async fn fresh_pool() -> Pool {
+    let pool = Pool::connect("sqlite::memory:").await.expect("sqlite pool");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        "CREATE TABLE xc_post (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL)",
+        Vec::new(),
+    )
+    .await
+    .expect("create");
+    rustango::sql::raw_execute_pool(
+        &pool,
+        "INSERT INTO xc_post (id, title) VALUES (1, 'Hello'), (2, 'World')",
+        Vec::new(),
+    )
+    .await
+    .expect("seed");
+    pool
+}
+
+/// A layout reading a variable no generic view knows about, and a list
+/// template extending it.
+fn tera_with_layout() -> Arc<Tera> {
+    let mut tera = Tera::default();
+    tera.add_raw_template(
+        "base.html",
+        "<header>{{ signed_in_as }}</header>{% block content %}{% endblock %}",
+    )
+    .unwrap();
+    tera.add_raw_template(
+        "xc_post_list.html",
+        r#"{% extends "base.html" %}{% block content %}
+           {% for p in object_list %}<li>{{ p.title }}</li>{% endfor %}
+           {% endblock %}"#,
+    )
+    .unwrap();
+    Arc::new(tera)
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Without the extension the layout's variable is undefined and the
+/// render fails — this is the state that made the generic views
+/// unusable under a shared layout.
+#[tokio::test]
+async fn a_layout_variable_the_view_does_not_know_fails_without_it() {
+    let pool = fresh_pool().await;
+    let app = ListView::for_model(XcPost::SCHEMA).router("/posts", tera_with_layout(), pool);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "a missing layout variable should not render as a good page"
+    );
+}
+
+#[tokio::test]
+async fn an_extension_supplies_what_the_layout_needs() {
+    let pool = fresh_pool().await;
+    let mut extra = Context::new();
+    extra.insert("signed_in_as", "ada");
+    let app = ListView::for_model(XcPost::SCHEMA)
+        .router("/posts", tera_with_layout(), pool)
+        .layer(axum::Extension(ExtraContext(extra)));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_of(resp).await;
+    assert!(html.contains("ada"), "the layout variable: {html}");
+    assert!(html.contains("Hello"), "and the rows still render: {html}");
+}
+
+/// The view owns its own keys: an extension cannot replace the rows.
+#[tokio::test]
+async fn the_view_wins_on_a_key_collision() {
+    let pool = fresh_pool().await;
+    let mut extra = Context::new();
+    extra.insert("signed_in_as", "ada");
+    extra.insert("object_list", &Vec::<String>::new());
+    let app = ListView::for_model(XcPost::SCHEMA)
+        .router("/posts", tera_with_layout(), pool)
+        .layer(axum::Extension(ExtraContext(extra)));
+
+    let html = body_of(
+        app.oneshot(
+            Request::builder()
+                .uri("/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+    assert!(
+        html.contains("Hello"),
+        "an extension must not be able to blank the rows: {html}"
+    );
+}
+
+/// The pager range comes from the framework's own `Paginator`, so a
+/// long list renders `1 … 7 8 9 … 42` rather than one link per page.
+#[tokio::test]
+async fn the_list_exposes_an_elided_page_range() {
+    let pool = fresh_pool().await;
+    let mut tera = Tera::default();
+    tera.add_raw_template(
+        "xc_post_list.html",
+        "{% for m in page_marks %}{% if m.ellipsis %}…{% else %}[{{ m.number }}]{% endif %}{% endfor %}",
+    )
+    .unwrap();
+    let app =
+        ListView::for_model(XcPost::SCHEMA)
+            .page_size(1)
+            .router("/posts", Arc::new(tera), pool);
+
+    let html = body_of(
+        app.oneshot(
+            Request::builder()
+                .uri("/posts")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+    assert!(html.contains("[1]"), "page 1 should be marked: {html}");
+    assert!(html.contains("[2]"), "and page 2 exists: {html}");
+}

--- a/crates/rustango/tests/tenancy_manage_mysql_live.rs
+++ b/crates/rustango/tests/tenancy_manage_mysql_live.rs
@@ -79,6 +79,21 @@ async fn pools_or_skip() -> Option<(TenantPools<sqlx::MySql>, String)> {
     Some((TenantPools::<sqlx::MySql>::new(pool), url))
 }
 
+/// The same server and credentials, a different database name.
+///
+/// Keeps userinfo, host and port; replaces only the path segment, so
+/// the tenant lands on the server the test already reached rather than
+/// one the environment has to describe twice.
+fn sibling_database_url(registry_url: &str, database: &str) -> String {
+    let (scheme, rest) = registry_url
+        .split_once("://")
+        .expect("MYSQL_TEST_URL should be a URL");
+    let (authority, _old_db) = rest
+        .rsplit_once('/')
+        .expect("MYSQL_TEST_URL should name a database");
+    format!("{scheme}://{authority}/{database}")
+}
+
 #[tokio::test]
 async fn tenancy_manage_run_dispatches_init_then_create_then_list_on_mysql() {
     let _g = live_lock().lock().await;
@@ -87,6 +102,21 @@ async fn tenancy_manage_run_dispatches_init_then_create_then_list_on_mysql() {
         return;
     };
     let migrations_dir = tempfile::tempdir().expect("migrations tempdir");
+
+    // A second database on the same server for the tenant to live in.
+    //
+    // Created here rather than assumed, so a local run against a root
+    // MySQL needs no setup. In CI the grant is scoped to the registry
+    // database and this `CREATE` is refused — which is why the failure
+    // is swallowed and the workflow creates the database itself. If it
+    // is missing either way, the run fails loudly at `create-tenant`'s
+    // connection check rather than silently skipping.
+    let tenant_url = sibling_database_url(&url, "rustango_tenant_test");
+    if let Ok(admin) = sqlx::MySqlPool::connect(&url).await {
+        let _ = sqlx::query("CREATE DATABASE IF NOT EXISTS `rustango_tenant_test`")
+            .execute(&admin)
+            .await;
+    }
 
     // Step 1: migrate-registry generates the framework's registry-scope
     // `system/migrations/` on demand from the compiled models and applies
@@ -139,9 +169,13 @@ async fn tenancy_manage_run_dispatches_init_then_create_then_list_on_mysql() {
             "--mode".to_owned(),
             "database".to_owned(),
             "--database-url".to_owned(),
-            // Reuse the same MySQL server for the tenant DB — point at
-            // a parallel DATABASE name we'll create on the fly.
-            url.clone(),
+            // The same MySQL server, a *different* database. This line
+            // used to pass `url` — the registry's own — which is the
+            // one target provisioning now refuses, because it runs the
+            // tenant migration chain over the registry. The comment
+            // already said "a parallel DATABASE name"; the code did not
+            // do it.
+            tenant_url.clone(),
         ],
         &mut buf,
     )


### PR DESCRIPTION
Closes #1323. **Stacked on #1328** → #1327 → #1326 → #1325 → #1324. Completes the #1317 epic.

## Direction matters

`webhook_delivery` is **outbound** — rustango POSTs signed payloads to subscribers. This is the opposite way round, and the more dangerous one: it accepts input from outside and creates infrastructure from it. The signing primitives are reused (`webhook::verify_signature`, constant-time); everything around them is new.

## Your open question, answered: **no**

> whether the caller may supply `database_url` at all — accepting one means anyone with the signing secret can point a tenant at any host the app can reach

Correct, and that's disqualifying as a default. It turns a leaked signing secret into a **credential-exfiltration primitive**: the app connects out to a host of the attacker's choosing and authenticates to it. A billing system has no business knowing your database topology anyway.

So:

| policy | |
|---|---|
| **`Template`** (default) | derive the URL from a configured pattern, substituting only `{slug}`. The caller names a tenant, not a host. |
| `CallerSupplied` | opt-in, for deployments that genuinely orchestrate their own per-tenant databases. |
| `SchemaMode` | no separate database to name. |

And a caller who sends `database_url` under the default policy gets **403, not a silent drop**. Quietly ignoring a field the caller believed in is how a tenant ends up on the wrong database — they'd have no way to know it wasn't used.

## The rest of the shape

- **Signature over the raw bytes.** The handler takes `Bytes`, not `Json<T>`. Parsing first and re-serializing to verify checks a *different document* from the one signed. There's a test that re-encodes the same JSON with different whitespace and asserts it fails.
- **Replay window** on a signed `timestamp`, rejected in **both** directions — a timestamp far in the future is as much a sign of a forged sender as a stale one.
- **Idempotency** on `event_id`: checked up front for the ordinary retry, and settled by the unique constraint for the real case — two deliveries at once.
- **Accept and hand off.** Provisioning outlasts any provider's timeout, so the endpoint verifies, opens the run **synchronously** (so the response carries an id, and so the constraint fires where an HTTP status can report it), spawns, returns `202`.
- **Slug allowlist.** A slug becomes a database name, a schema name and a hostname label. Anything outside `[a-z0-9-]` is refused at the door rather than quoted carefully later.
- A bad signature and a missing one get the **same opaque answer**, so probing the endpoint teaches nothing.

`provision_tenant_in_run` is new: without it the spawned task would open a *second* run, and the id handed to the caller would point at one that never progresses.

## Deliberately absent, with reasons

**Rate limiting.** The crate already ships middleware; one baked in here would be one the deployment cannot configure. Documented as something to layer, with why it matters — a leaked secret shouldn't be an unbounded tenant-creation faucet.

**The completion callback.** `webhook_delivery` needs a job-queue handle, and reaching into the caller's would be guessing at their setup. The run is pollable and streamable meanwhile. (It's in the issue's "what to build" but not its acceptance list.)

Gated on `webhook`, where HMAC verification lives — a tenancy deployment not exposing this compiles none of it.

## Verification

**9 live tests, one per acceptance item:**
- a signed delivery creates a tenant, with the URL from the template
- unsigned / `sha256=deadbeef` / garbage → 401, **no tenant and no run**
- a re-encoded body fails verification (the raw-bytes check)
- stale **and** future timestamps → 401
- a retry returns the first run, `duplicate: true`, one tenant
- **two simultaneous deliveries → one tenant, one run**
- a caller-supplied URL → 403 with a reason
- dangerous slugs (`Acme`, `ac me`, `acme;DROP TABLE x`, `../../etc/passwd`) never reach the engine
- the run is visible exactly like a console run, `requested_by: webhook`, dense ordered `seq`

Plus 8 unit tests on the URL policy. 3650 lib tests, every stack suite, preflight 15/15 tri-dialect, `manage_live` 13/13 against live Postgres. Zero warnings across eight feature combos, `--all-features --tests`, `--workspace --no-run`, `fmt --check`, clippy clean on both files.