### PR TITLE
feat(scaffolder): choose backend and features when creating a project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,10 @@ jobs:
       # The compile test above cannot catch this — it builds with
       # `--rustango-path`, where any new feature exists by definition.
       - run: cargo test -p cargo-rustango --test templates_name_real_features
+      # #1345 — `cargo rustango new` with no arguments opens a wizard on a
+      # terminal. Off one, it must fail with a message rather than block on a
+      # prompt nobody can answer; this job is exactly that caller.
+      - run: cargo test -p cargo-rustango --test wizard_cli
 
   # #1208 — the feature table is a public promise, so check the promise.
   # `sqlite_litmus` below is a single combination, and it happens to be one

--- a/crates/cargo-rustango/src/main.rs
+++ b/crates/cargo-rustango/src/main.rs
@@ -6,7 +6,20 @@
 //!
 //!   $ cargo rustango new myapp --template fullstack
 //!   $ cargo rustango new api_demo --template api
-//!   $ cargo rustango new shop --template tenant
+//!   $ cargo rustango new shop --template tenant --backend sqlite --features csrf
+//!
+//! Run `new` with no arguments on a terminal for the wizard (`wizard.rs`),
+//! which asks the same questions as numbered menus and then prints the
+//! equivalent command line. It sets the same fields the flags do, so there is
+//! one code path deciding what a project contains (#1345).
+//!
+//! Three axes, independent:
+//!
+//! * `--template` — which files get written.
+//! * `--backend`  — which database the project defaults to, shaping
+//!                  `Cargo.toml`'s `default`, `.env.example`, the compose
+//!                  file, and the settings tiers together.
+//! * `--features` — rustango opt-ins no template turns on.
 //!
 //! The three templates correspond to the three rustango shapes:
 //!
@@ -39,6 +52,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 mod templates;
+mod wizard;
 
 fn main() -> ExitCode {
     let raw: Vec<String> = std::env::args().collect();
@@ -88,20 +102,126 @@ fn print_help() {
     println!();
     println!("OPTIONS:");
     println!("  -t, --template <name>    project template (default: fullstack)");
+    println!("  -b, --backend <name>     postgres | sqlite | mysql (default: postgres)");
+    println!("  -F, --features <list>    extra rustango features, comma-separated");
+    println!("  -i, --interactive        pick from numbered menus instead");
     println!("      --rustango-path <d>  depend on a local rustango checkout");
     println!("                           instead of the published crate");
     println!();
+    println!("INTERACTIVE:");
+    println!("  `cargo rustango new` with no arguments opens a wizard that asks");
+    println!("  for each of the above, then prints the equivalent command line.");
+    println!();
     println!("BACKEND:");
-    println!("  Projects default to Postgres. Switch without editing anything:");
+    println!("  --backend picks what `cargo run` uses and shapes .env.example,");
+    println!("  docker-compose.yml, and the settings tiers to match. The other");
+    println!("  two stay one flag away:");
     println!("    cargo run --no-default-features --features sqlite");
+    println!();
+    println!("FEATURES:");
+    let width = OPTIONAL_FEATURES
+        .iter()
+        .map(|(n, _)| n.len())
+        .max()
+        .unwrap_or(0);
+    for (name, about) in OPTIONAL_FEATURES {
+        println!("  {name:<width$}  {about}");
+    }
     println!();
     println!("EXAMPLES:");
     println!("  cargo rustango new myblog");
     println!("  cargo rustango new api_demo --template api");
     println!("  cargo rustango new api_demo --template=api");
     println!("  cargo rustango new shop --template tenant");
+    println!("  cargo rustango new edge --backend sqlite");
+    println!("  cargo rustango new saas --template tenant --features csrf,sso,cache-redis");
     println!("  cargo rustango new ex1 --rustango-path ../rustango/crates/rustango");
 }
+
+/// Database backend a generated project builds and runs with by default.
+///
+/// Only `default` in the project's own `[features]` changes — all three
+/// forwards stay defined, so switching later is still one flag away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    Postgres,
+    Sqlite,
+    Mysql,
+}
+
+impl Backend {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "postgres" | "postgresql" | "pg" => Ok(Self::Postgres),
+            "sqlite" | "sqlite3" => Ok(Self::Sqlite),
+            "mysql" | "mariadb" => Ok(Self::Mysql),
+            other => Err(format!(
+                "unknown backend `{other}` — must be `postgres`, `sqlite`, or `mysql`"
+            )),
+        }
+    }
+
+    /// The project's own feature name, which forwards to `rustango/<name>`.
+    pub fn feature(self) -> &'static str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::Sqlite => "sqlite",
+            Self::Mysql => "mysql",
+        }
+    }
+
+    /// Connection URL for cargo running on the host.
+    pub fn host_url(self, name: &str) -> String {
+        match self {
+            Self::Postgres => format!("postgres://rustango:rustango@localhost:5432/{name}_dev"),
+            Self::Mysql => format!("mysql://rustango:rustango@localhost:3306/{name}_dev"),
+            Self::Sqlite => self.compose_url(name),
+        }
+    }
+
+    /// Same, from inside the compose network — the service name is the host.
+    /// SQLite is a file, so both forms are the bind-mounted path.
+    pub fn compose_url(self, name: &str) -> String {
+        match self {
+            Self::Postgres => format!("postgres://rustango:rustango@postgres:5432/{name}_dev"),
+            Self::Mysql => format!("mysql://rustango:rustango@mysql:3306/{name}_dev"),
+            Self::Sqlite => format!("sqlite://./{name}_dev.db?mode=rwc"),
+        }
+    }
+
+    /// Compose service name, or `None` when the backend needs no server.
+    pub fn service(self) -> Option<&'static str> {
+        match self {
+            Self::Postgres => Some("postgres"),
+            Self::Mysql => Some("mysql"),
+            Self::Sqlite => None,
+        }
+    }
+}
+
+/// Opt-in rustango features `--features` accepts on top of a template's own.
+///
+/// The second field is the one-line description shown by `--help`. Kept
+/// curated rather than "every feature in the manifest": these are the ones
+/// no template reaches, which is the whole reason the flag exists.
+/// `tests/templates_name_real_features.rs` asserts the list stays both real
+/// and complete.
+pub const OPTIONAL_FEATURES: &[(&str, &str)] = &[
+    (
+        "tenancy",
+        "multi-tenancy: tenant registry, per-tenant databases, operator console",
+    ),
+    ("csrf", "CSRF protection middleware for form POSTs"),
+    ("sso", "OIDC single sign-on for application users"),
+    ("admin-sso", "OIDC single sign-on for the admin site"),
+    ("passkey", "WebAuthn / passkey authentication"),
+    ("cache-redis", "Redis cache backend"),
+    ("cache-page", "whole-page response caching"),
+    ("email-smtp", "SMTP transport for the email framework"),
+    ("mcp", "Model Context Protocol server for AI agents"),
+    ("testkit", "test-only schema builders and model factories"),
+    ("test_utils", "test-only constructors for downstream crates"),
+];
 
 #[derive(Debug, Clone, Copy)]
 enum Template {
@@ -122,78 +242,107 @@ impl Template {
         }
     }
 
+    /// The `--template` spelling, for echoing a choice back as a command.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Api => "api",
+            Self::Fullstack => "fullstack",
+            Self::Tenant => "tenant",
+        }
+    }
+
+    /// rustango features this template needs, before `--features` extras.
+    ///
+    /// The backend is deliberately absent (#1211) — see [`Template::rustango_dep`].
+    pub fn base_features(self) -> &'static [&'static str] {
+        match self {
+            // Bare ORM + axum + manage dispatcher; no auto-admin UI.
+            Self::Api => &["manage"],
+            // `batteries` is rustango's default set minus the backend.
+            Self::Fullstack => &["batteries"],
+            Self::Tenant => &["batteries", "tenancy"],
+        }
+    }
+
     /// The full `rustango = …` dependency value for a generated `Cargo.toml`.
     ///
     /// `path` is `--rustango-path`: it swaps the crates.io source for a local
     /// checkout while keeping the same feature selection, so an in-repo example
     /// needs no hand edit and the generate-and-check test can validate the
     /// working tree rather than the last release (#1211).
-    fn rustango_dep(self, path: Option<&str>) -> String {
-        let Some(p) = path else {
-            return self.rustango_features();
-        };
-        let feats = match self {
-            Self::Api => r#", features = ["manage"]"#,
-            Self::Fullstack => r#", features = ["batteries"]"#,
-            Self::Tenant => r#", features = ["batteries", "tenancy"]"#,
-        };
-        format!(r#"{{ path = "{p}", default-features = false{feats} }}"#)
-    }
-
-    fn rustango_features(self) -> String {
-        // Track our own (cargo-rustango) version, which is bumped
-        // in lockstep with the rustango crate via the workspace
-        // `version = "..."` declaration. Pin scaffolded projects
-        // to the same major.minor so a published scaffolder always
-        // produces a project that resolves against a real, current
-        // rustango release. Pre-v0.29 the version was hardcoded —
-        // and consequently rotted to `"0.23"` while the framework
-        // moved to v0.28+, breaking `cargo build` on every fresh
-        // tenant project (#79).
-        let v = mm_version();
-        // RELEASE ORDER IS LOAD-BEARING (#1217). A generated project pins the
-        // *published* rustango by version, while this feature list is written
-        // against the tree in this repo. Naming a feature that is not in the
-        // pinned release fails at resolution, before anything compiles:
-        //
-        //     package `myblog` depends on `rustango` with feature `batteries`
-        //     but `rustango` does not have that feature.
-        //
-        // Two things keep that from happening:
-        //   1. All four crates publish from one version, `rustango` BEFORE
-        //      `cargo-rustango` — so the pinned version always already exists
-        //      and already has whatever this names.
-        //   2. `tests/templates_name_real_features.rs` asserts every feature
-        //      named here is defined in `crates/rustango/Cargo.toml`.
-        //
-        // `generated_project_compiles.rs` cannot catch this: it builds with
-        // `--rustango-path` against the local tree, where the feature exists.
-        //
-        // #1211 — the backend is NOT named here. The generated `[features]`
-        // block forwards it (`postgres = ["rustango/postgres"]`, etc.), and
-        // `#[derive(Model)]` gates its emissions on the *project's* feature,
-        // because a cfg inside a derive resolves against the destination
-        // crate. Pinning `rustango/postgres` in the dependency while the
-        // project's own `postgres` feature was off made those two disagree:
-        // rustango wanted `MaybePgFromRow`, the derive had skipped emitting
-        // it, and `--no-default-features --features sqlite` — the switch the
-        // generated manifest advertises in a comment — failed to compile.
-        match self {
-            // Bare ORM + axum + manage dispatcher; no auto-admin UI.
-            Self::Api => {
-                format!(r#"{{ version = "{v}", default-features = false, features = ["manage"] }}"#)
+    ///
+    /// RELEASE ORDER IS LOAD-BEARING (#1217). A version-pinned project resolves
+    /// against the *published* rustango, while this list is written against the
+    /// tree in this repo; naming a feature the release lacks fails at
+    /// resolution, before anything compiles. Two things prevent that: all four
+    /// crates publish from one version with `rustango` first, and
+    /// `tests/templates_name_real_features.rs` asserts every name here is
+    /// defined in `crates/rustango/Cargo.toml`.
+    ///
+    /// The backend is NOT named here (#1211). The generated `[features]` block
+    /// forwards it, because `#[derive(Model)]` gates its emissions on the
+    /// *project's* features — a cfg inside a derive resolves against the
+    /// destination crate. Pinning `rustango/postgres` while the project's own
+    /// `postgres` feature was off made the two disagree.
+    fn rustango_dep(self, path: Option<&str>, extras: &[String]) -> String {
+        let feats = feature_list(self.base_features(), extras);
+        match path {
+            Some(p) => {
+                format!(r#"{{ path = "{p}", default-features = false, features = [{feats}] }}"#)
             }
-            // `batteries` is rustango's default set minus the backend, so the
-            // project picks the backend through its own feature and still gets
-            // everything `default` would have given it.
-            Self::Fullstack => format!(
-                r#"{{ version = "{v}", default-features = false, features = ["batteries"] }}"#
-            ),
-            Self::Tenant => format!(
-                r#"{{ version = "{v}", default-features = false, features = ["batteries", "tenancy"] }}"#
+            // Track our own version, bumped in lockstep with rustango, so a
+            // published scaffolder always pins a real, current release. It was
+            // hardcoded pre-v0.29 and rotted to `"0.23"` (#79).
+            None => format!(
+                r#"{{ version = "{}", default-features = false, features = [{feats}] }}"#,
+                mm_version()
             ),
         }
     }
+}
+
+/// `"a", "b"` — a template's own features plus `--features` extras, deduped,
+/// order preserved so the emitted manifest is stable.
+fn feature_list(base: &[&str], extras: &[String]) -> String {
+    let mut all: Vec<&str> = base.to_vec();
+    for e in extras {
+        if !all.contains(&e.as_str()) {
+            all.push(e);
+        }
+    }
+    all.iter()
+        .map(|f| format!("\"{f}\""))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Reject typos and misdirected backends before a project is written.
+///
+/// A bad feature name is otherwise invisible until `cargo build` fails at
+/// dependency resolution, with an error about the framework rather than the
+/// flag that caused it.
+fn validate_features(extras: &[String], template: Template) -> Result<(), String> {
+    for f in extras {
+        if ["postgres", "sqlite", "mysql"].contains(&f.as_str()) {
+            return Err(format!(
+                "`{f}` is a database backend — pass `--backend {f}` instead. \
+                 The project forwards its backend through its own feature, so \
+                 naming it here would break `#[derive(Model)]` (#1211)."
+            ));
+        }
+        if template.base_features().contains(&f.as_str()) {
+            continue;
+        }
+        if !OPTIONAL_FEATURES.iter().any(|(n, _)| n == f) {
+            let known: Vec<&str> = OPTIONAL_FEATURES.iter().map(|(n, _)| *n).collect();
+            return Err(format!(
+                "unknown feature `{f}` — available: {}.\n\
+                 Anything else can be added to the generated Cargo.toml by hand.",
+                known.join(", ")
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Major.minor of the current `cargo-rustango` build — e.g.
@@ -207,16 +356,34 @@ fn mm_version() -> String {
         .unwrap_or_else(|| full.to_owned())
 }
 
+#[derive(Debug)]
 struct NewArgs {
     name: String,
     template: Template,
+    /// `--backend <name>`: which backend the project defaults to. All three
+    /// stay switchable; this picks the one `cargo run` uses and shapes the
+    /// generated `.env`, compose file, and settings tiers to match.
+    backend: Backend,
+    /// `--features a,b`: rustango opt-ins on top of the template's own.
+    features: Vec<String>,
     /// `--rustango-path <dir>`: emit a path dependency instead of the crates.io
     /// version. For in-repo examples and for testing the working tree (#1211).
     rustango_path: Option<String>,
+    /// `-i` / `--interactive`, or a bare `new` on a terminal: ask the rest.
+    interactive: bool,
 }
 
 fn cmd_new(args: &[String]) -> Result<(), String> {
-    let parsed = parse_new_args(args)?;
+    // A bare `new` on a terminal is a request for the wizard; piped or in CI
+    // it stays the old "missing project name" error, so scripts don't hang on
+    // a prompt nobody can answer.
+    let asked = args.iter().any(|a| a == "-i" || a == "--interactive");
+    let bare = args.is_empty() && std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let mut parsed = parse_new_args(args, asked || bare)?;
+    if parsed.interactive {
+        let named = !parsed.name.is_empty();
+        parsed = wizard::run(parsed, named)?;
+    }
     validate_name(&parsed.name)?;
 
     let root = PathBuf::from(&parsed.name);
@@ -228,9 +395,10 @@ fn cmd_new(args: &[String]) -> Result<(), String> {
     }
 
     println!(
-        "scaffolding `{}` (template: {:?}) at {}",
+        "scaffolding `{}` (template: {}, backend: {}) at {}",
         parsed.name,
-        parsed.template,
+        parsed.template.name(),
+        parsed.backend.feature(),
         root.display()
     );
 
@@ -241,23 +409,59 @@ fn cmd_new(args: &[String]) -> Result<(), String> {
     println!("done. next:");
     println!("  cd {}", parsed.name);
     println!("  cp .env.example .env");
-    println!("  docker compose up -d");
+    // SQLite is a file the first migrate creates — nothing to boot.
+    if parsed.backend.service().is_some() {
+        println!("  docker compose up -d");
+    }
     println!(
         "  cargo run -- makemigrations  # generate schema migrations (incl. system/ framework tables)"
     );
     println!("  cargo run -- migrate         # apply them");
     println!("  cargo run                    # boot the HTTP server");
-    println!("  cargo run -- --help     # full verb list");
+    println!("  cargo run -- --help          # full verb list");
     Ok(())
 }
 
-fn parse_new_args(args: &[String]) -> Result<NewArgs, String> {
+/// Parse `new`'s arguments.
+///
+/// `interactive` relaxes the one requirement the flags impose — a project
+/// name — because the wizard asks for it. Everything else already has a
+/// default, so a bare `cargo rustango new` is a complete request.
+fn parse_new_args(args: &[String], interactive: bool) -> Result<NewArgs, String> {
     let mut name: Option<String> = None;
     let mut template = Template::Fullstack;
+    let mut backend = Backend::Postgres;
+    let mut features: Vec<String> = Vec::new();
     let mut rustango_path: Option<String> = None;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
+            "--backend" | "-b" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| "--backend requires a value".to_owned())?;
+                backend = Backend::parse(v)?;
+            }
+            _ if arg.starts_with("--backend=") => {
+                backend = Backend::parse(&arg["--backend=".len()..])?;
+            }
+            _ if arg.starts_with("-b=") => {
+                backend = Backend::parse(&arg["-b=".len()..])?;
+            }
+            // Repeatable and comma-separated both work, matching cargo's own
+            // `--features` so muscle memory carries over.
+            "--features" | "-F" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| "--features requires a value".to_owned())?;
+                features.extend(split_features(v));
+            }
+            _ if arg.starts_with("--features=") => {
+                features.extend(split_features(&arg["--features=".len()..]));
+            }
+            _ if arg.starts_with("-F=") => {
+                features.extend(split_features(&arg["-F=".len()..]));
+            }
             "--template" | "-t" => {
                 let v = iter
                     .next()
@@ -286,6 +490,9 @@ fn parse_new_args(args: &[String]) -> Result<NewArgs, String> {
             _ if arg.starts_with("--rustango-path=") => {
                 rustango_path = Some(arg["--rustango-path=".len()..].to_owned());
             }
+            // Consumed by the caller, which decides before parsing whether a
+            // terminal is available; accepted here so it isn't "unknown".
+            "--interactive" | "-i" => {}
             "--help" | "-h" => {
                 print_help();
                 std::process::exit(0);
@@ -301,13 +508,43 @@ fn parse_new_args(args: &[String]) -> Result<NewArgs, String> {
             }
         }
     }
-    let name =
-        name.ok_or_else(|| "missing project name (e.g. `cargo rustango new myapp`)".to_owned())?;
+    let name = match name {
+        Some(n) => n,
+        None if interactive => String::new(),
+        None => {
+            return Err(
+                "missing project name (e.g. `cargo rustango new myapp`, or `new` alone \
+                 for the interactive wizard)"
+                    .to_owned(),
+            )
+        }
+    };
+    // Repeated flags can name the same feature twice; keep first mention.
+    let mut seen = Vec::new();
+    features.retain(|f| {
+        let fresh = !seen.contains(f);
+        seen.push(f.clone());
+        fresh
+    });
+    validate_features(&features, template)?;
     Ok(NewArgs {
         name,
         template,
+        backend,
+        features,
         rustango_path,
+        interactive,
     })
+}
+
+/// `"a, b,,c"` → `["a", "b", "c"]`. Cargo accepts commas or spaces in one
+/// `--features` value; so do we.
+fn split_features(raw: &str) -> Vec<String> {
+    raw.split([',', ' '])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
 }
 
 fn validate_name(name: &str) -> Result<(), String> {
@@ -330,18 +567,33 @@ fn validate_name(name: &str) -> Result<(), String> {
 fn write_project(root: &Path, args: &NewArgs) -> Result<(), String> {
     let name = &args.name;
     let template = args.template;
+    let backend = args.backend;
 
     write(
         root,
         "Cargo.toml",
-        &templates::cargo_toml(name, template, args.rustango_path.as_deref()),
+        &templates::cargo_toml(
+            name,
+            template,
+            backend,
+            &args.features,
+            args.rustango_path.as_deref(),
+        ),
     )?;
-    write(root, ".env.example", &templates::env_example(name))?;
+    write(root, ".env.example", &templates::env_example(name, backend))?;
     write(root, ".gitignore", templates::GITIGNORE)?;
     write(root, "rust-toolchain.toml", templates::RUST_TOOLCHAIN)?;
-    write(root, "docker-compose.yml", &templates::docker_compose(name))?;
+    write(
+        root,
+        "docker-compose.yml",
+        &templates::docker_compose(name, backend),
+    )?;
     write(root, "Dockerfile", templates::dockerfile())?;
-    write(root, "README.md", &templates::readme(name, template))?;
+    write(
+        root,
+        "README.md",
+        &templates::readme(name, template, backend),
+    )?;
 
     // Tiered settings (#87) — config/default.toml for shared knobs +
     // one <env>_settings.toml per tier. Runtime picks the tier from
@@ -350,17 +602,17 @@ fn write_project(root: &Path, args: &NewArgs) -> Result<(), String> {
     write(
         root,
         "config/default.toml",
-        &templates::config_default_toml(name),
+        &templates::config_default_toml(name, backend),
     )?;
     write(
         root,
         "config/dev_settings.toml",
-        &templates::config_dev_settings_toml(name),
+        &templates::config_dev_settings_toml(name, backend),
     )?;
     write(
         root,
         "config/staging_settings.toml",
-        &templates::config_staging_settings_toml(name),
+        &templates::config_staging_settings_toml(name, backend),
     )?;
     write(
         root,
@@ -430,7 +682,7 @@ mod tests {
         let mm = mm_version();
         let needle = format!("\"{mm}\"");
         for template in [Template::Api, Template::Fullstack, Template::Tenant] {
-            let dep = template.rustango_features();
+            let dep = template.rustango_dep(None, &[]);
             assert!(
                 dep.contains(&needle),
                 "template {template:?} dep `{dep}` does not pin v{mm}"
@@ -447,17 +699,17 @@ mod tests {
         // Test the rendered bodies, not the on-disk write — keeps
         // this a pure-string regression that doesn't need a tempdir.
         for name in ["acme", "demo_app"] {
-            let default_body = templates::config_default_toml(name);
+            let default_body = templates::config_default_toml(name, Backend::Postgres);
             assert!(
                 default_body.contains(name),
                 "config_default_toml({name}) must mention the project name; got: {default_body}"
             );
-            let dev = templates::config_dev_settings_toml(name);
+            let dev = templates::config_dev_settings_toml(name, Backend::Postgres);
             assert!(
                 dev.contains("(dev)") || dev.contains("dev_settings"),
                 "dev tier should be visually distinguishable; got: {dev}"
             );
-            let staging = templates::config_staging_settings_toml(name);
+            let staging = templates::config_staging_settings_toml(name, Backend::Postgres);
             assert!(
                 staging.contains("staging") && staging.contains("retention_days"),
                 "staging tier missing retention_days; got: {staging}"
@@ -478,7 +730,7 @@ mod tests {
         // ^0.23.0 was yanked, breaking `rustango = "0.23"` resolution).
         const YANKED: &[&str] = &["0.23"];
         for template in [Template::Api, Template::Fullstack, Template::Tenant] {
-            let dep = template.rustango_features();
+            let dep = template.rustango_dep(None, &[]);
             for ver in YANKED {
                 let needle = format!("\"{ver}\"");
                 assert!(
@@ -518,7 +770,7 @@ mod tests {
     /// volumes that preserve incremental build state.
     #[test]
     fn docker_compose_bundles_rust_service_with_cargo_watch() {
-        let body = templates::docker_compose("myapp");
+        let body = templates::docker_compose("myapp", Backend::Postgres);
         // Postgres half (regression guard — don't lose the original
         // service when adding the rust one).
         assert!(body.contains("image: postgres:"), "{body}");
@@ -565,12 +817,143 @@ mod tests {
         }
     }
 
+    // ---- #1345 — `--backend` and `--features` ----
+
+    fn parse(argv: &[&str]) -> Result<NewArgs, String> {
+        let owned: Vec<String> = argv.iter().map(|s| (*s).to_owned()).collect();
+        parse_new_args(&owned, false)
+    }
+
+    /// `--backend` moves `default`, and only `default` — all three forwards
+    /// stay so the project can still be built the other two ways.
+    #[test]
+    fn backend_picks_the_default_feature_only() {
+        for (flag, feature) in [
+            ("postgres", "postgres"),
+            ("sqlite", "sqlite"),
+            ("mysql", "mysql"),
+            ("pg", "postgres"),
+            ("mariadb", "mysql"),
+        ] {
+            let args = parse(&["app", "--backend", flag]).expect(flag);
+            let toml = templates::cargo_toml("app", args.template, args.backend, &[], None);
+            assert!(
+                toml.contains(&format!(r#"default = ["{feature}"]"#)),
+                "--backend {flag} should default to {feature}:\n{toml}"
+            );
+            for other in ["postgres", "sqlite", "mysql"] {
+                assert!(
+                    toml.contains(&format!(r#"{other} = ["rustango/{other}"]"#)),
+                    "the `{other}` forward must survive --backend {flag}:\n{toml}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn backend_accepts_both_flag_forms() {
+        for argv in [
+            vec!["app", "--backend", "sqlite"],
+            vec!["app", "--backend=sqlite"],
+            vec!["app", "-b", "sqlite"],
+            vec!["app", "-b=sqlite"],
+        ] {
+            let args = parse(&argv).unwrap_or_else(|e| panic!("{argv:?}: {e}"));
+            assert_eq!(args.backend, Backend::Sqlite, "{argv:?}");
+        }
+        assert!(parse(&["app", "--backend", "oracle"]).is_err());
+    }
+
+    /// Comma-separated, space-separated, and repeated all mean the same thing
+    /// — and a feature named twice lands once.
+    #[test]
+    fn features_accumulate_without_duplicates() {
+        for argv in [
+            vec!["app", "--features", "csrf,sso"],
+            vec!["app", "--features=csrf,sso"],
+            vec!["app", "--features", "csrf sso"],
+            vec!["app", "-F", "csrf", "-F", "sso"],
+            vec!["app", "--features", "csrf,sso,csrf"],
+        ] {
+            let args = parse(&argv).unwrap_or_else(|e| panic!("{argv:?}: {e}"));
+            assert_eq!(args.features, vec!["csrf", "sso"], "{argv:?}");
+        }
+    }
+
+    /// Extras join the template's own list rather than replacing it.
+    #[test]
+    fn features_extend_the_template_list() {
+        let args = parse(&["app", "--template", "tenant", "--features", "csrf"]).expect("parse");
+        let dep = args.template.rustango_dep(None, &args.features);
+        assert!(
+            dep.contains(r#"features = ["batteries", "tenancy", "csrf"]"#),
+            "extras must append to the template's own: {dep}"
+        );
+    }
+
+    /// A backend named in `--features` would pin `rustango/<backend>` while
+    /// the project's own feature stayed off — exactly the mismatch #1211 fixed.
+    #[test]
+    fn features_rejects_backends_and_points_at_the_flag() {
+        for backend in ["postgres", "sqlite", "mysql"] {
+            let err = parse(&["app", "--features", backend]).expect_err(backend);
+            assert!(
+                err.contains(&format!("--backend {backend}")),
+                "should redirect to --backend: {err}"
+            );
+        }
+    }
+
+    /// Caught at parse time, where the message can name the flag — not at
+    /// dependency resolution, where it names the framework.
+    #[test]
+    fn features_rejects_unknown_names() {
+        let err = parse(&["app", "--features", "cache-redis,nosuchthing"]).expect_err("unknown");
+        assert!(err.contains("nosuchthing"), "{err}");
+        assert!(
+            err.contains("cache-redis"),
+            "should list what is valid: {err}"
+        );
+        // A feature the template already turns on is a harmless no-op.
+        assert!(parse(&["app", "--features", "batteries"]).is_ok());
+    }
+
+    /// The flags shape more than `Cargo.toml`: a project generated for one
+    /// backend must not tell the user to connect to another.
+    #[test]
+    fn backend_reaches_env_compose_and_settings() {
+        let name = "app";
+        for (backend, needle) in [
+            (Backend::Postgres, "postgres://"),
+            (Backend::Mysql, "mysql://"),
+            (Backend::Sqlite, "sqlite://"),
+        ] {
+            let env = templates::env_example(name, backend);
+            assert!(env.contains(needle), "{backend:?} .env.example: {env}");
+            let dev = templates::config_dev_settings_toml(name, backend);
+            assert!(dev.contains(needle), "{backend:?} dev tier: {dev}");
+        }
+        // SQLite is a file — compose must not invent a server for it.
+        let lite = templates::docker_compose(name, Backend::Sqlite);
+        assert!(!lite.contains("image: "), "no db image for sqlite:\n{lite}");
+        assert!(
+            !lite.contains("depends_on:"),
+            "nothing to depend on:\n{lite}"
+        );
+        assert!(lite.contains("rust:"), "the dev container stays:\n{lite}");
+
+        let my = templates::docker_compose(name, Backend::Mysql);
+        assert!(my.contains("image: mysql:8"), "{my}");
+        assert!(my.contains("MYSQL_DATABASE: app_dev"), "{my}");
+        assert!(my.contains("depends_on:"), "{my}");
+    }
+
     /// `.env.example` defaults must work out-of-box for `docker
     /// compose up -d` (host = `postgres`, bind = `0.0.0.0`). Users
     /// running cargo on the host edit `postgres` -> `localhost`.
     #[test]
     fn env_example_defaults_to_docker_friendly_values() {
-        let body = templates::env_example("myapp");
+        let body = templates::env_example("myapp", Backend::Postgres);
         assert!(
             body.contains("@postgres:5432/"),
             "DATABASE_URL host must default to `postgres` (compose service name), \

--- a/crates/cargo-rustango/src/templates.rs
+++ b/crates/cargo-rustango/src/templates.rs
@@ -6,12 +6,19 @@
 //! ships everything in one artifact. CI snapshot-tests the generated
 //! output by running `cargo check` on each template.
 
-use super::Template;
+use super::{Backend, Template};
 
 // ---------------- Cargo.toml ----------------
 
-pub fn cargo_toml(name: &str, template: Template, rustango_path: Option<&str>) -> String {
-    let rustango_dep = template.rustango_dep(rustango_path);
+pub fn cargo_toml(
+    name: &str,
+    template: Template,
+    backend: Backend,
+    features: &[String],
+    rustango_path: Option<&str>,
+) -> String {
+    let rustango_dep = template.rustango_dep(rustango_path, features);
+    let default_backend = backend.feature();
     format!(
         r#"[package]
 name = "{name}"
@@ -50,7 +57,7 @@ tokio = {{ version = "1", features = ["macros", "rt-multi-thread"] }}
 # one `cargo run` uses; switch with e.g.
 # `cargo run --no-default-features --features sqlite`.
 [features]
-default = ["postgres"]
+default = ["{default_backend}"]
 postgres = ["rustango/postgres"]
 sqlite = ["rustango/sqlite"]
 mysql = ["rustango/mysql"]
@@ -60,18 +67,28 @@ mysql = ["rustango/mysql"]
 
 // ---------------- .env.example ----------------
 
-pub fn env_example(name: &str) -> String {
+pub fn env_example(name: &str, backend: Backend) -> String {
+    let url = backend.compose_url(name);
+    // SQLite is a file in the bind mount, so there is no host to swap.
+    let host_note = match backend.service() {
+        Some(svc) => format!(
+            "# Defaults are Docker-friendly (`{svc}` host, `0.0.0.0` bind) so
+# `docker compose up -d` boots a working stack without any edits.
+# If you run cargo on the host instead of in the rust container,
+# change `{svc}` -> `localhost` in DATABASE_URL.
+#
+# Database name matches docker-compose.yml ({name}_dev)."
+        ),
+        None => "# SQLite needs no database server — the file lives beside the
+# project and is created on first `cargo run -- migrate`."
+            .to_owned(),
+    };
     format!(
         "# Copy this file to .env and edit the values for your environment.
 # `dotenvy::dotenv()` in src/main.rs picks it up at startup.
 #
-# Defaults are Docker-friendly (`postgres` host, `0.0.0.0` bind) so
-# `docker compose up -d` boots a working stack without any edits.
-# If you run cargo on the host instead of in the rust container,
-# change `postgres` -> `localhost` in DATABASE_URL.
-#
-# Database name matches docker-compose.yml's POSTGRES_DB ({name}_dev).
-DATABASE_URL=postgres://rustango:rustango@postgres:5432/{name}_dev
+{host_note}
+DATABASE_URL={url}
 RUSTANGO_BIND=0.0.0.0:8080
 
 # Tenancy template only — apex domain + signing secret.
@@ -140,10 +157,10 @@ components = [\"rustfmt\", \"clippy\", \"rust-analyzer\"]
 /// Users who prefer running cargo on the host can simply ignore the
 /// `rust` service and run the postgres service standalone with
 /// `docker compose up -d postgres`.
-pub fn docker_compose(name: &str) -> String {
-    format!(
-        r#"services:
-  postgres:
+pub fn docker_compose(name: &str, backend: Backend) -> String {
+    let db_service = match backend {
+        Backend::Postgres => format!(
+            r#"  postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: rustango
@@ -157,17 +174,53 @@ pub fn docker_compose(name: &str) -> String {
       timeout: 2s
       retries: 20
 
-  # Hot-reload Rust dev container. `cargo watch -x run` rebuilds and
-  # restarts the binary on every source edit. Skip this service (run
-  # cargo on the host) by passing `--no-deps postgres` to
-  # `docker compose up`, or remove it entirely if you don't want the
-  # Docker-based dev loop.
+"#
+        ),
+        Backend::Mysql => format!(
+            r#"  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: rustango
+      MYSQL_DATABASE: {name}_dev
+      MYSQL_USER: rustango
+      MYSQL_PASSWORD: rustango
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u rustango -prustango"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+"#
+        ),
+        // A file in the bind mount — nothing to run.
+        Backend::Sqlite => String::new(),
+    };
+    let (skip_hint, depends_on) = match backend.service() {
+        Some(svc) => (
+            format!(
+                "  # Skip it and run cargo on the host with\n  \
+                 # `docker compose up -d --no-deps {svc}`."
+            ),
+            format!("    depends_on:\n      {svc}:\n        condition: service_healthy\n"),
+        ),
+        // Nothing else to boot, so skipping it means not using compose.
+        None => (
+            "  # Skip it by running `cargo run` on the host — with SQLite\n  \
+             # there is nothing else compose needs to start."
+                .to_owned(),
+            String::new(),
+        ),
+    };
+    format!(
+        r#"services:
+{db_service}  # Hot-reload Rust dev container. `cargo watch -x run` rebuilds and
+  # restarts the binary on every source edit.
+{skip_hint}
   rust:
     build: .
-    depends_on:
-      postgres:
-        condition: service_healthy
-    env_file:
+{depends_on}    env_file:
       - .env
     volumes:
       - ./:/app
@@ -210,16 +263,48 @@ pub fn dockerfile() -> &'static str {
 
 // ---------------- README.md ----------------
 
-pub fn readme(name: &str, template: Template) -> String {
+pub fn readme(name: &str, template: Template, backend: Backend) -> String {
     let template_label = match template {
         Template::Api => "api (bare ORM + axum, no admin)",
         Template::Fullstack => "fullstack (ORM + auto-admin)",
         Template::Tenant => "tenant (multi-tenancy + operator console)",
     };
+    let backend_label = backend.feature();
+    let (up_line, host_path) = match backend.service() {
+        Some(svc) => (
+            format!("docker compose up -d                 # boots {svc} + rust + cargo-watch"),
+            format!(
+                r#"### B. Cargo on the host (Docker just for {svc})
+
+```sh
+cp .env.example .env                 # then change `{svc}` -> `localhost` in DATABASE_URL
+docker compose up -d {svc}        # only the DB
+cargo run -- migrate                 # apply pending migrations
+cargo run                            # boot the HTTP server
+cargo run -- --help                  # full verb list (makemigrations, startapp, etc.)
+```"#
+            ),
+        ),
+        None => (
+            "docker compose up -d                 # boots rust + cargo-watch".to_owned(),
+            r#"### B. Cargo on the host (no Docker at all)
+
+SQLite is a file next to the project, so nothing else has to be running.
+
+```sh
+cp .env.example .env
+cargo run -- migrate                 # creates the database file and applies migrations
+cargo run                            # boot the HTTP server
+cargo run -- --help                  # full verb list (makemigrations, startapp, etc.)
+```"#
+                .to_owned(),
+        ),
+    };
     format!(
         r#"# {name}
 
-Generated with `cargo rustango new {name}` — template `{template_label}`.
+Generated with `cargo rustango new {name}` — template `{template_label}`,
+backend `{backend_label}`.
 
 ## Run locally — two paths
 
@@ -227,7 +312,7 @@ Generated with `cargo rustango new {name}` — template `{template_label}`.
 
 ```sh
 cp .env.example .env
-docker compose up -d                 # boots postgres + rust + cargo-watch
+{up_line}
 docker compose run --rm rust cargo run -- migrate
 # server lives at http://localhost:8080 — edits to src/ trigger rebuild
 ```
@@ -237,15 +322,7 @@ source tree. Three named volumes preserve incremental build state
 across container restarts so a fresh `up` doesn't recompile from
 scratch.
 
-### B. Cargo on the host (Docker just for postgres)
-
-```sh
-cp .env.example .env                 # then change `postgres` -> `localhost` in DATABASE_URL
-docker compose up -d postgres        # only the DB
-cargo run -- migrate                 # apply pending migrations
-cargo run                            # boot the HTTP server
-cargo run -- --help                  # full verb list (makemigrations, startapp, etc.)
-```
+{host_path}
 
 Either way: `cargo run` (no args) is `runserver`. Every other
 Django-style verb flows through the same binary via
@@ -554,7 +631,8 @@ pub fn api() -> Router<()> {
 /// `config/default.toml` — shared values that don't depend on tier.
 /// Intentionally sparse — every section is optional and defaults to
 /// the section's `Default` impl. Tier files override here.
-pub fn config_default_toml(name: &str) -> String {
+pub fn config_default_toml(name: &str, backend: Backend) -> String {
+    let example_url = backend.host_url(name);
     format!(
         r##"# {name} — shared defaults across every tier
 # (`config/default.toml` is loaded first; `config/<RUSTANGO_ENV>_settings.toml`
@@ -562,7 +640,7 @@ pub fn config_default_toml(name: &str) -> String {
 # what you need.
 
 # [database]
-# url           = "postgres://localhost/{name}"
+# url           = "{example_url}"
 # pool_min_size = 2
 # pool_max_size = 20
 
@@ -620,19 +698,18 @@ pub fn config_default_toml(name: &str) -> String {
 /// short JWT TTLs (so token-rotation bugs surface early), no HSTS
 /// (so http→https rebinds don't lock the browser), debug-friendly
 /// settings.
-pub fn config_dev_settings_toml(name: &str) -> String {
+pub fn config_dev_settings_toml(name: &str, backend: Backend) -> String {
+    let url = backend.host_url(name);
     format!(
         r##"# {name} — local development tier
 # Loaded when RUSTANGO_ENV=dev (the default when unset).
 
 [database]
-# Matches the credentials in the generated docker-compose.yml and
-# .env.example. These three used to disagree — dev_settings said
-# postgres:postgres@localhost while compose created rustango:rustango, so the
-# first `cargo run -- migrate` failed to authenticate (#1211). Host is
-# `localhost` (not the compose service name) because this tier is for running
-# the app on the host against the containerised database.
-url = "postgres://rustango:rustango@localhost:5432/{name}_dev"
+# Matches docker-compose.yml and .env.example. The three used to
+# disagree and the first `cargo run -- migrate` failed to
+# authenticate (#1211). Host is `localhost`, not the compose service
+# name: this tier runs the app on the host against the container.
+url = "{url}"
 
 [server]
 bind = "127.0.0.1:8080"
@@ -652,7 +729,12 @@ tagline = "(dev)"
 
 /// `config/staging_settings.toml` — production-like but pointed at
 /// a separate database, with shorter retention.
-pub fn config_staging_settings_toml(name: &str) -> String {
+pub fn config_staging_settings_toml(name: &str, backend: Backend) -> String {
+    let staging_url = match backend {
+        Backend::Postgres => format!("postgres://staging-host/{name}_staging"),
+        Backend::Mysql => format!("mysql://staging-host/{name}_staging"),
+        Backend::Sqlite => format!("sqlite://./{name}_staging.db?mode=rwc"),
+    };
     format!(
         r##"# {name} — staging tier
 # Loaded when RUSTANGO_ENV=staging. Production-shape security
@@ -660,7 +742,7 @@ pub fn config_staging_settings_toml(name: &str) -> String {
 # so QA volume doesn't bleed into prod analytics.
 
 # [database]
-# url = "postgres://staging-host/{name}_staging"
+# url = "{staging_url}"
 
 [server]
 bind = "0.0.0.0:8080"

--- a/crates/cargo-rustango/src/wizard.rs
+++ b/crates/cargo-rustango/src/wizard.rs
@@ -1,0 +1,288 @@
+//! Interactive `cargo rustango new` — numbered menus instead of flags.
+//!
+//! The wizard decides nothing on its own: every answer sets a field the
+//! flags already set, and it prints the equivalent one-line command before
+//! creating anything. So there is one code path deciding what a project
+//! contains, and using the wizard once teaches the flags for next time.
+
+use std::io::{self, IsTerminal, Write};
+
+use crate::{Backend, NewArgs, Template, OPTIONAL_FEATURES};
+
+const TEMPLATES: &[(&str, Template, &str)] = &[
+    (
+        "fullstack",
+        Template::Fullstack,
+        "ORM + auto-admin + forms — the usual starting point",
+    ),
+    (
+        "api",
+        Template::Api,
+        "bare ORM + axum, no admin UI — for JSON-only services",
+    ),
+    (
+        "tenant",
+        Template::Tenant,
+        "multi-tenancy: tenant registry + operator console",
+    ),
+];
+
+const BACKENDS: &[(&str, Backend, &str)] = &[
+    (
+        "postgres",
+        Backend::Postgres,
+        "every feature, including schema-mode tenancy",
+    ),
+    (
+        "sqlite",
+        Backend::Sqlite,
+        "a file beside the project — no server to run",
+    ),
+    ("mysql", Backend::Mysql, "MySQL 8.0+ / MariaDB"),
+];
+
+/// Ask for anything the flags did not already answer, then confirm.
+///
+/// `given` carries what was parsed from the command line; the wizard only
+/// asks about the rest, so `new myapp -i` skips straight to the menus.
+pub fn run(given: NewArgs, name_was_given: bool) -> Result<NewArgs, String> {
+    if !io::stdin().is_terminal() {
+        return Err(
+            "--interactive needs a terminal — pass --template / --backend / --features instead"
+                .to_owned(),
+        );
+    }
+
+    println!();
+    println!("  rustango — new project");
+    println!("  (enter accepts the default; ctrl-c aborts)");
+
+    let name = if name_was_given {
+        given.name
+    } else {
+        ask_name()?
+    };
+
+    let template = choose("Template", TEMPLATES.iter().map(|(n, _, a)| (*n, *a)), 0)
+        .map(|ix| TEMPLATES[ix].1)?;
+
+    let backend = choose("Database", BACKENDS.iter().map(|(n, _, a)| (*n, *a)), 0)
+        .map(|ix| BACKENDS[ix].1)?;
+
+    let features = ask_features(template, &given.features)?;
+
+    let args = NewArgs {
+        name,
+        template,
+        backend,
+        features,
+        rustango_path: given.rustango_path,
+        interactive: false,
+    };
+
+    println!();
+    println!("  Same thing without the wizard:");
+    println!("    {}", equivalent_command(&args));
+    println!();
+    if !confirm("Create it?")? {
+        return Err("cancelled".to_owned());
+    }
+    Ok(args)
+}
+
+/// The non-interactive command line that produces `args`.
+fn equivalent_command(args: &NewArgs) -> String {
+    let mut cmd = format!(
+        "cargo rustango new {} --template {} --backend {}",
+        args.name,
+        args.template.name(),
+        args.backend.feature()
+    );
+    if !args.features.is_empty() {
+        cmd.push_str(&format!(" --features {}", args.features.join(",")));
+    }
+    cmd
+}
+
+fn ask_name() -> Result<String, String> {
+    loop {
+        let raw = prompt("\n  Project name: ")?;
+        let name = raw.trim();
+        if name.is_empty() {
+            println!("  a name is required");
+            continue;
+        }
+        match crate::validate_name(name) {
+            Ok(()) => return Ok(name.to_owned()),
+            Err(e) => println!("  {e}"),
+        }
+    }
+}
+
+/// One-of-N. Returns the index into `options`.
+fn choose<'a>(
+    title: &str,
+    options: impl Iterator<Item = (&'a str, &'a str)>,
+    default_ix: usize,
+) -> Result<usize, String> {
+    let options: Vec<(&str, &str)> = options.collect();
+    let width = options.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    let iw = options.len().to_string().len();
+    println!();
+    println!("  {title}");
+    for (i, (name, about)) in options.iter().enumerate() {
+        let marker = if i == default_ix { "  (default)" } else { "" };
+        println!("    {:>iw$}) {name:<width$}  {about}{marker}", i + 1);
+    }
+    loop {
+        let raw = prompt("  > ")?;
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Ok(default_ix);
+        }
+        match raw.parse::<usize>() {
+            Ok(n) if n >= 1 && n <= options.len() => return Ok(n - 1),
+            // Typing the name works too — it is right there on screen.
+            _ => match options.iter().position(|(n, _)| *n == raw) {
+                Some(ix) => return Ok(ix),
+                None => println!("  pick 1-{}", options.len()),
+            },
+        }
+    }
+}
+
+/// Any-of-N, by number. Features the template already turns on are left out.
+fn ask_features(template: Template, preselected: &[String]) -> Result<Vec<String>, String> {
+    let base = template.base_features();
+    let menu: Vec<(&str, &str)> = OPTIONAL_FEATURES
+        .iter()
+        .filter(|(n, _)| !base.contains(n))
+        .map(|(n, a)| (*n, *a))
+        .collect();
+    if menu.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let width = menu.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    let iw = menu.len().to_string().len();
+    println!();
+    println!("  Extra features  (numbers, e.g. `1 3 4` — enter for none)");
+    for (i, (name, about)) in menu.iter().enumerate() {
+        let on = if preselected.iter().any(|p| p == name) {
+            "*"
+        } else {
+            " "
+        };
+        println!("  {on} {:>iw$}) {name:<width$}  {about}", i + 1);
+    }
+    if !preselected.is_empty() {
+        println!("    (* already set by --features; enter keeps them)");
+    }
+
+    loop {
+        let raw = prompt("  > ")?;
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Ok(preselected.to_vec());
+        }
+        let mut picked = Vec::new();
+        let mut bad = None;
+        for tok in raw.split([',', ' ']).filter(|t| !t.is_empty()) {
+            match tok.parse::<usize>() {
+                Ok(n) if n >= 1 && n <= menu.len() => {
+                    let name = menu[n - 1].0.to_owned();
+                    if !picked.contains(&name) {
+                        picked.push(name);
+                    }
+                }
+                _ => {
+                    bad = Some(tok.to_owned());
+                    break;
+                }
+            }
+        }
+        match bad {
+            Some(t) => println!("  `{t}` is not one of 1-{}", menu.len()),
+            None => return Ok(picked),
+        }
+    }
+}
+
+fn confirm(question: &str) -> Result<bool, String> {
+    loop {
+        let raw = prompt(&format!("  {question} [Y/n] "))?;
+        return Ok(match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "y" | "yes" => true,
+            "n" | "no" => false,
+            _ => continue,
+        });
+    }
+}
+
+/// Print without a newline, then read one line. EOF (ctrl-d) aborts rather
+/// than looping forever on an empty read.
+fn prompt(label: &str) -> Result<String, String> {
+    print!("{label}");
+    io::stdout().flush().map_err(|e| e.to_string())?;
+    let mut buf = String::new();
+    match io::stdin().read_line(&mut buf) {
+        Ok(0) => Err("cancelled".to_owned()),
+        Ok(_) => Ok(buf),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The line the wizard prints must re-create the same project.
+    ///
+    /// This is what keeps the wizard a front-end over the flags rather than a
+    /// second code path: if it could produce a selection the flags cannot
+    /// express, the two would drift.
+    #[test]
+    fn the_echoed_command_round_trips() {
+        let cases = [
+            (Template::Tenant, Backend::Sqlite, vec!["sso", "cache-page"]),
+            (Template::Api, Backend::Mysql, vec![]),
+            (Template::Fullstack, Backend::Postgres, vec!["tenancy"]),
+        ];
+        for (template, backend, features) in cases {
+            let features: Vec<String> = features.iter().map(|s| (*s).to_owned()).collect();
+            let args = NewArgs {
+                name: "probe".to_owned(),
+                template,
+                backend,
+                features: features.clone(),
+                rustango_path: None,
+                interactive: false,
+            };
+            let cmd = equivalent_command(&args);
+            // Re-parse it exactly as a user retyping the line would.
+            let argv: Vec<String> = cmd
+                .split_whitespace()
+                .skip(3) // `cargo rustango new`
+                .map(str::to_owned)
+                .collect();
+            let back = crate::parse_new_args(&argv, false)
+                .unwrap_or_else(|e| panic!("`{cmd}` does not parse: {e}"));
+            assert_eq!(back.name, "probe", "{cmd}");
+            assert_eq!(back.template.name(), template.name(), "{cmd}");
+            assert_eq!(back.backend, backend, "{cmd}");
+            assert_eq!(back.features, features, "{cmd}");
+        }
+    }
+
+    /// Every menu entry must map onto a value the flags accept, so a wizard
+    /// answer is never something `--template` / `--backend` cannot say.
+    #[test]
+    fn every_menu_label_is_a_valid_flag_value() {
+        for (label, template, _) in TEMPLATES {
+            assert_eq!(Template::parse(label).expect(label).name(), template.name());
+        }
+        for (label, backend, _) in BACKENDS {
+            assert_eq!(&Backend::parse(label).expect(label), backend);
+        }
+    }
+}

--- a/crates/cargo-rustango/tests/generated_project_compiles.rs
+++ b/crates/cargo-rustango/tests/generated_project_compiles.rs
@@ -55,24 +55,21 @@ fn scratch(tag: &str) -> PathBuf {
 }
 
 /// Generate `template` into a fresh directory and return the project root.
-fn generate(template: &str, tag: &str) -> (PathBuf, PathBuf) {
+///
+/// `flags` are extra scaffolder arguments — `--backend`, `--features`.
+fn generate(template: &str, flags: &[&str], tag: &str) -> (PathBuf, PathBuf) {
     let work = scratch(tag);
     let out = Command::new(env!("CARGO_BIN_EXE_cargo-rustango"))
         .current_dir(&work)
-        .args([
-            "rustango",
-            "new",
-            "probe",
-            "--template",
-            template,
-            "--rustango-path",
-        ])
+        .args(["rustango", "new", "probe", "--template", template])
+        .args(flags)
+        .arg("--rustango-path")
         .arg(rustango_crate())
         .output()
         .expect("run the scaffolder");
     assert!(
         out.status.success(),
-        "scaffolding {template} failed:\n{}",
+        "scaffolding {template} {flags:?} failed:\n{}",
         String::from_utf8_lossy(&out.stderr),
     );
     let root = work.join("probe");
@@ -126,11 +123,16 @@ fn check(root: &Path, extra: &[&str]) -> (bool, usize, String) {
 }
 
 fn assert_compiles(template: &str, extra: &[&str], label: &str) {
+    assert_compiles_with(template, &[], extra, label);
+}
+
+/// As [`assert_compiles`], but `scaffold` flags shape the project first.
+fn assert_compiles_with(template: &str, scaffold: &[&str], extra: &[&str], label: &str) {
     if !in_repo() {
         eprintln!("skipping: crates/rustango not alongside — not a repo checkout");
         return;
     }
-    let (work, root) = generate(template, label);
+    let (work, root) = generate(template, scaffold, label);
     let (ok, warnings, log) = check(&root, extra);
     let _ = std::fs::remove_dir_all(&work);
     assert!(ok, "`{template}` {label} did not compile:\n{log}");
@@ -207,5 +209,56 @@ fn tenant_template_compiles_on_sqlite() {
         "tenant",
         &["--no-default-features", "--features", "sqlite"],
         "sqlite",
+    );
+}
+
+// -------------------------------------------------------- `--backend` (#1345)
+//
+// The switch above is what a project can *reach*; these are what it is
+// *generated as*. `--backend sqlite` has to compile with a bare `cargo check`,
+// no flags — otherwise the flag only rewrote a comment.
+
+#[test]
+#[ignore = "compiles rustango; run with --ignored"]
+fn backend_sqlite_compiles_as_generated() {
+    assert_compiles_with("fullstack", &["--backend", "sqlite"], &[], "backend-sqlite");
+}
+
+#[test]
+#[ignore = "compiles rustango; run with --ignored"]
+fn backend_mysql_compiles_as_generated() {
+    assert_compiles_with("fullstack", &["--backend", "mysql"], &[], "backend-mysql");
+}
+
+#[test]
+#[ignore = "compiles rustango; run with --ignored"]
+fn tenant_on_sqlite_backend_compiles_as_generated() {
+    assert_compiles_with("tenant", &["--backend", "sqlite"], &[], "tenant-sqlite");
+}
+
+// ------------------------------------------------------- `--features` (#1345)
+
+/// Opt-ins no template reaches — the reason the flag exists.
+#[test]
+#[ignore = "compiles rustango; run with --ignored"]
+fn selected_features_compile() {
+    assert_compiles_with(
+        "fullstack",
+        &["--features", "csrf,cache-page,testkit"],
+        &[],
+        "features",
+    );
+}
+
+/// `--features tenancy` on a non-tenant template: the feature is additive, so
+/// it must not break a project whose `main.rs` never calls into it.
+#[test]
+#[ignore = "compiles rustango; run with --ignored"]
+fn tenancy_feature_on_fullstack_compiles() {
+    assert_compiles_with(
+        "fullstack",
+        &["--features", "tenancy"],
+        &[],
+        "features-tenancy",
     );
 }

--- a/crates/cargo-rustango/tests/templates_name_real_features.rs
+++ b/crates/cargo-rustango/tests/templates_name_real_features.rs
@@ -102,6 +102,53 @@ fn requested_features(generated: &str) -> Vec<String> {
     out
 }
 
+/// Members of one feature's list — `batteries = ["manage", "admin", …]`.
+fn members_of(manifest: &str, feature: &str) -> Vec<String> {
+    let needle = format!("{feature} = [");
+    for line in manifest.lines() {
+        let t = line.trim_end();
+        let Some(rest) = t.strip_prefix(&needle) else {
+            continue;
+        };
+        let Some(end) = rest.find(']') else { continue };
+        return rest[..end]
+            .split(',')
+            .map(|f| f.trim().trim_matches('"').trim().to_owned())
+            .filter(|f| !f.is_empty())
+            .collect();
+    }
+    Vec::new()
+}
+
+/// The `--features` menu, scraped from `main.rs` rather than imported: this is
+/// a binary crate, so the const is not reachable from an integration test.
+fn optional_features_menu() -> Vec<String> {
+    let src = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("main.rs"),
+    )
+    .expect("read main.rs");
+    let start = src
+        .find("pub const OPTIONAL_FEATURES")
+        .expect("OPTIONAL_FEATURES is gone — update this test with it");
+    let body = &src[start..];
+    let end = body.find("];").expect("unterminated OPTIONAL_FEATURES");
+    // Entries are `("name", "about")`, which rustfmt may split across lines.
+    // The name is the first string after each `(` — the description follows.
+    body[..end]
+        .split_once('[')
+        .expect("OPTIONAL_FEATURES has no list")
+        .1
+        .split('(')
+        .skip(1)
+        .filter_map(|entry| {
+            let rest = entry.split_once('"')?.1;
+            Some(rest.split_once('"')?.0.to_owned())
+        })
+        .collect()
+}
+
 fn generate_manifest(template: &str) -> String {
     let work = std::env::temp_dir().join(format!(
         "rustango-featcheck-{}-{template}-{}",
@@ -160,6 +207,68 @@ fn every_template_names_only_features_the_framework_defines() {
                  Defined features: {defined:?}"
             );
         }
+    }
+}
+
+/// The `--features` menu may only offer features that exist (#1345).
+///
+/// Same trap as the templates above, one flag further out: a typo here fails
+/// at dependency resolution in the user's fresh project, naming the framework
+/// rather than the flag that caused it.
+#[test]
+fn the_features_menu_names_only_real_features() {
+    let manifest_path = rustango_manifest();
+    if !manifest_path.is_file() {
+        return;
+    }
+    let defined = framework_features(&std::fs::read_to_string(&manifest_path).expect("read"));
+    let menu = optional_features_menu();
+    assert!(!menu.is_empty(), "the OPTIONAL_FEATURES scan found nothing");
+    for feat in &menu {
+        assert!(
+            defined.contains(feat),
+            "`--features {feat}` is offered but crates/rustango/Cargo.toml does \
+             not define it.\nDefined: {defined:?}"
+        );
+    }
+}
+
+/// …and must offer every opt-in no template already reaches (#1345).
+///
+/// A feature outside `batteries` that the menu omits is unreachable from the
+/// scaffolder entirely — which is the gap the flag was added to close, so it
+/// should not quietly reopen when a new feature lands.
+#[test]
+fn the_features_menu_covers_every_opt_in() {
+    let manifest_path = rustango_manifest();
+    if !manifest_path.is_file() {
+        return;
+    }
+    let manifest = std::fs::read_to_string(&manifest_path).expect("read");
+    let batteries = members_of(&manifest, "batteries");
+    assert!(
+        batteries.contains(&"admin".to_owned()),
+        "sanity: the `batteries` scan found nothing useful ({batteries:?})"
+    );
+    let menu = optional_features_menu();
+
+    for feat in framework_features(&manifest) {
+        // Internal capability features (#1208) carry a leading underscore;
+        // `runtime` is plumbing `manage` already pulls in; backends have their
+        // own flag; the rest are reached through a template.
+        if feat.starts_with('_')
+            || matches!(feat.as_str(), "default" | "batteries" | "runtime")
+            || ["postgres", "sqlite", "mysql"].contains(&feat.as_str())
+            || batteries.contains(&feat)
+        {
+            continue;
+        }
+        assert!(
+            menu.contains(&feat),
+            "rustango defines `{feat}`, which no template turns on and \
+             `--features` does not offer — so no generated project can reach \
+             it. Add it to OPTIONAL_FEATURES in src/main.rs (#1345)."
+        );
     }
 }
 

--- a/crates/cargo-rustango/tests/wizard_cli.rs
+++ b/crates/cargo-rustango/tests/wizard_cli.rs
@@ -1,0 +1,88 @@
+//! The interactive wizard must never block a non-interactive caller (#1345).
+//!
+//! `cargo rustango new` with no arguments opens a wizard on a terminal. Run
+//! from a script, a CI job, or a `Command` with a piped stdin, the same
+//! invocation must fail with a message instead of waiting forever for an
+//! answer nobody is there to give.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run the scaffolder with stdin closed, returning (success, stderr).
+fn run_piped(args: &[&str]) -> (bool, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cargo-rustango"))
+        .args(["rustango"])
+        .args(args)
+        .current_dir(std::env::temp_dir())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the scaffolder");
+    // Close stdin immediately: a prompt would read EOF, not hang.
+    drop(child.stdin.take().expect("stdin").write_all(b""));
+    let out = child.wait_with_output().expect("wait");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn bare_new_without_a_terminal_asks_for_a_name() {
+    let (ok, err) = run_piped(&["new"]);
+    assert!(!ok, "should not have scaffolded anything: {err}");
+    assert!(
+        err.contains("missing project name"),
+        "expected the non-interactive error, got: {err}"
+    );
+}
+
+#[test]
+fn interactive_without_a_terminal_says_so() {
+    let (ok, err) = run_piped(&["new", "--interactive"]);
+    assert!(!ok, "{err}");
+    assert!(
+        err.contains("needs a terminal"),
+        "expected a clear refusal, got: {err}"
+    );
+}
+
+/// `-i` alongside a full set of flags still refuses rather than silently
+/// falling back — the user asked for prompts and cannot have them.
+#[test]
+fn interactive_with_flags_still_refuses_without_a_terminal() {
+    let (ok, err) = run_piped(&["new", "probe", "-i", "--backend", "sqlite"]);
+    assert!(!ok, "{err}");
+    assert!(err.contains("needs a terminal"), "{err}");
+}
+
+/// The flags path must stay non-interactive: fully specified, stdin closed,
+/// it scaffolds without asking anything.
+#[test]
+fn fully_specified_flags_never_prompt() {
+    let work = std::env::temp_dir().join(format!("rustango-wizard-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&work).expect("scratch");
+    let out = Command::new(env!("CARGO_BIN_EXE_cargo-rustango"))
+        .args([
+            "rustango",
+            "new",
+            "probe",
+            "--template",
+            "api",
+            "--backend",
+            "sqlite",
+        ])
+        .current_dir(&work)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(work.join("probe").join("Cargo.toml").is_file());
+    let _ = std::fs::remove_dir_all(&work);
+}


### PR DESCRIPTION
Part of #1345. Stacked on `feat/provisioning-webhook` (#1329).

`cargo rustango new` could not reach eleven of the framework's features, and every project it wrote defaulted to Postgres — with `.env.example`, `docker-compose.yml` and all three settings tiers written to match. So `--no-default-features --features sqlite`, which the generated manifest advertises in a comment, gave you a project still pointed at a Postgres URL.

Three axes now, independent:

| flag | what it decides |
|---|---|
| `--template` | which files get written (unchanged) |
| `--backend` | `postgres` \| `sqlite` \| `mysql` |
| `--features` | rustango opt-ins no template turns on |

`--backend` moves `default` in the project's own `[features]` **and** shapes the connection URL, the compose services and each settings tier together. All three forwards stay defined, so switching later is still one flag away. SQLite gets no database service at all — it is a file the first migrate creates, so compose, the README and the "next steps" stop telling you to boot a server that does not exist.

`--features` is validated at parse time, where the message can name the flag rather than the framework. Naming a backend there is refused with a pointer to `--backend`: it would pin `rustango/postgres` while the project's own feature stayed off, which is exactly the mismatch #1211 fixed.

### The wizard

`cargo rustango new` with no arguments on a terminal opens numbered menus, then prints the equivalent command line before creating anything. It sets the same fields the flags do — the flags landing first is why there is one code path deciding what a project contains, not two. Off a terminal it fails with a message instead of blocking on a prompt nobody can answer, and CI runs that case.

```
  Same thing without the wizard:
    cargo rustango new edge --template fullstack --backend sqlite --features tenancy,testkit
```

Generating from the wizard and from that line produces byte-identical trees.

### Tests

- Five more generated-project compiles: each `--backend` **as generated, with no flags**. Otherwise the flag would only have rewritten a comment.
- The echoed wizard command round-trips through the parser.
- Two guards on the feature menu: it may only offer features the framework defines, and it must offer every opt-in outside `batteries` — so the gap this closes cannot quietly reopen when a new feature lands.
