### PR TITLE
feat(tenancy): hostname verbs, so routing is not console-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,11 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,config,email --test setting_changed_signal
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_ipaddress_field
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_filepath_field
+      # Audit retention now sweeps the registry's own log, not just tenants.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test audit_cleanup_sqlite_live
+      # #1344 — the hostname verbs, and that they write the table the
+      # operator console writes rather than a parallel one.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_hosts_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test serializer_cross_validate
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_exclude_sqlite_live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,21 @@ jobs:
       # #1344 — the hostname verbs, and that they write the table the
       # operator console writes rather than a parallel one.
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_hosts_sqlite_live
+      # The operator console and the provisioning engines under it. These ran
+      # only in the all-features job, which always has Postgres available —
+      # so a PG-ism in the console (a `::`-cast, an `ON CONFLICT` spelling,
+      # `SET search_path`) would pass CI and break every SQLite/MySQL
+      # deployment. This job is the one that would have caught it.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_provisioning_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_operators_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_hosts_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_audit_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_migrate_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_decommission_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test provision_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test provision_store_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,testkit --test org_hosts_sqlite_live
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,testkit --test tenant_sweep_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,serializer --test serializer_cross_validate
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_none
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test queryset_exclude_sqlite_live

--- a/crates/rustango/src/tenancy/manage/hosts.rs
+++ b/crates/rustango/src/tenancy/manage/hosts.rs
@@ -1,0 +1,222 @@
+//! Hostname verbs — `list-hosts`, `add-host`, `remove-host`,
+//! `set-host-enabled`.
+//!
+//! The operator console has bound extra hostnames since #1318; the CLI could
+//! not, so the action could not run in a deploy hook or on a box with no
+//! browser (#1344). These are argv over [`crate::tenancy::org_host`], the
+//! same engine the console posts to.
+//!
+//! No `rename-host`: [`org_host::generation`] fingerprints the table by row
+//! count, enabled count, max id and enabled-id sum, so an in-place rename
+//! would not move it and other pods would keep routing the old name until
+//! the TTL expired. Remove and add instead.
+
+use std::io::Write;
+
+use sqlx::Database;
+
+use crate::manage_interactive;
+use crate::tenancy::error::TenancyError;
+use crate::tenancy::org_host::{self, HostError};
+use crate::tenancy::pools::TenantPools;
+
+use super::args::next_value;
+
+/// Host errors carry the operator-facing wording already; keep it.
+fn explain(e: HostError) -> TenancyError {
+    match e {
+        HostError::Driver(d) => TenancyError::from(d),
+        other => TenancyError::Validation(other.to_string()),
+    }
+}
+
+/// A positional argument, or the answer to a prompt on a terminal.
+///
+/// Same shape as `create-tenant` and `create-operator`: scripted callers see
+/// the validation error they always did, and a person gets asked. It is also
+/// what lets the menu offer these verbs without re-listing their positionals.
+fn positional_or_ask(
+    given: Option<&String>,
+    prompt: &str,
+    missing: &str,
+) -> Result<String, TenancyError> {
+    match given {
+        Some(v) => Ok(v.clone()),
+        None => manage_interactive::ask(prompt)
+            .map_err(TenancyError::Io)?
+            .ok_or_else(|| TenancyError::Validation(missing.to_owned())),
+    }
+}
+
+/// The slug and hostname every host verb needs. Flags may sit anywhere.
+fn slug_and_host(args: &[String], verb: &str) -> Result<(String, String), TenancyError> {
+    let mut positional = args.iter().filter(|a| !a.starts_with("--"));
+    let slug = positional_or_ask(
+        positional.next(),
+        "Tenant slug: ",
+        &format!("{verb} requires a tenant slug"),
+    )?;
+    let host = positional_or_ask(
+        positional.next(),
+        "Hostname: ",
+        &format!("{verb} requires a hostname"),
+    )?;
+    Ok((slug, host))
+}
+
+pub(super) async fn list_hosts<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let slug = positional_or_ask(
+        args.iter().find(|a| !a.starts_with("--")),
+        "Tenant slug: ",
+        "list-hosts requires a tenant slug",
+    )?;
+
+    let hosts = org_host::list_for_org(&pools.registry_pool(), &slug)
+        .await
+        .map_err(explain)?;
+    if hosts.is_empty() {
+        writeln!(
+            w,
+            "(no hostnames — `{slug}` is reachable by subdomain only)"
+        )?;
+        return Ok(());
+    }
+    writeln!(w, "{:<48} {:<8} source", "hostname", "enabled")?;
+    writeln!(w, "{}", "-".repeat(70))?;
+    for h in &hosts {
+        writeln!(
+            w,
+            "{:<48} {:<8} {}",
+            h.hostname,
+            h.enabled,
+            if h.is_base { "base" } else { "extra" }
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) async fn add_host<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, host) = slug_and_host(args, "add-host")?;
+    let row = org_host::add_host(&pools.registry_pool(), &slug, &host)
+        .await
+        .map_err(explain)?;
+    // The engine normalizes; echo what was stored, not what was typed.
+    writeln!(w, "bound {} -> {slug}", row.hostname)?;
+    if !row.enabled {
+        writeln!(w, "  (parked — enable with `set-host-enabled`)")?;
+    }
+    Ok(())
+}
+
+pub(super) async fn remove_host<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, host) = slug_and_host(args, "remove-host")?;
+    org_host::remove_host(&pools.registry_pool(), &slug, &host)
+        .await
+        .map_err(explain)?;
+    writeln!(w, "unbound {host} from {slug}")?;
+    Ok(())
+}
+
+pub(super) async fn set_host_enabled<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, host) = slug_and_host(args, "set-host-enabled")?;
+
+    let mut enabled: Option<bool> = None;
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--on" => enabled = Some(true),
+            "--off" => enabled = Some(false),
+            "--enabled" => {
+                let raw = next_value(&mut iter, "--enabled")?;
+                enabled = Some(matches!(raw.as_str(), "1" | "true" | "yes" | "on"));
+            }
+            other if other.starts_with("--") => {
+                return Err(TenancyError::Validation(format!(
+                    "unknown flag `{other}` — set-host-enabled takes --on or --off"
+                )))
+            }
+            _ => {}
+        }
+    }
+    // No default: "which way?" has no safe guess, and silently picking one
+    // would park a live host or serve a parked one.
+    let enabled = enabled.ok_or_else(|| {
+        TenancyError::Validation("set-host-enabled requires --on or --off".into())
+    })?;
+
+    org_host::set_host_enabled(&pools.registry_pool(), &slug, &host, enabled)
+        .await
+        .map_err(explain)?;
+    writeln!(
+        w,
+        "{host} is now {} for {slug}",
+        if enabled { "served" } else { "parked" }
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_slug_or_host_is_named_in_the_error() {
+        let none: Vec<String> = Vec::new();
+        let err = slug_and_host(&none, "add-host").expect_err("no slug");
+        assert!(err.to_string().contains("slug"), "{err}");
+
+        let only_slug = vec!["acme".to_owned()];
+        let err = slug_and_host(&only_slug, "add-host").expect_err("no host");
+        assert!(err.to_string().contains("hostname"), "{err}");
+
+        let both = vec!["acme".to_owned(), "shop.test".to_owned()];
+        assert_eq!(
+            slug_and_host(&both, "add-host").expect("ok"),
+            ("acme".to_owned(), "shop.test".to_owned())
+        );
+    }
+
+    /// Flags may precede or follow the positionals without being mistaken
+    /// for one — `set-host-enabled acme x.test --off` and
+    /// `set-host-enabled --off acme x.test` mean the same thing.
+    #[test]
+    fn flags_are_not_mistaken_for_positionals() {
+        let args = vec![
+            "--off".to_owned(),
+            "acme".to_owned(),
+            "shop.test".to_owned(),
+        ];
+        assert_eq!(
+            slug_and_host(&args, "set-host-enabled").expect("ok"),
+            ("acme".to_owned(), "shop.test".to_owned())
+        );
+    }
+}

--- a/crates/rustango/src/tenancy/manage/menu.rs
+++ b/crates/rustango/src/tenancy/manage/menu.rs
@@ -39,6 +39,13 @@ enum Ask {
         flag: &'static str,
         question: &'static str,
     },
+    /// One of two flags, always appended — for a verb that refuses to guess
+    /// a direction, where "no answer" is not a valid argv.
+    Either {
+        question: &'static str,
+        yes: &'static str,
+        no: &'static str,
+    },
 }
 
 struct Action {
@@ -99,6 +106,35 @@ const GROUPS: &[Group] = &[
                 verb: "test-tenant-connection",
                 about: "check a database URL before using it",
                 asks: &[],
+            },
+        ],
+    },
+    Group {
+        title: "HOSTNAMES",
+        actions: &[
+            Action {
+                verb: "list-hosts",
+                about: "every hostname a tenant answers on",
+                asks: &[],
+            },
+            Action {
+                verb: "add-host",
+                about: "bind an extra hostname to a tenant",
+                asks: &[],
+            },
+            Action {
+                verb: "remove-host",
+                about: "unbind one",
+                asks: &[],
+            },
+            Action {
+                verb: "set-host-enabled",
+                about: "park or serve a bound hostname",
+                asks: &[Ask::Either {
+                    question: "serve it? (no parks it)",
+                    yes: "--on",
+                    no: "--off",
+                }],
             },
         ],
     },
@@ -362,6 +398,10 @@ fn build_argv<R: BufRead, W: Write>(
                 if prompt_yes_no(reader, writer, &format!("  {question}"), false)? {
                     argv.push((*flag).to_owned());
                 }
+            }
+            Ask::Either { question, yes, no } => {
+                let pick = prompt_yes_no(reader, writer, &format!("  {question}"), true)?;
+                argv.push((*if pick { yes } else { no }).to_owned());
             }
         }
     }

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -44,6 +44,7 @@
 mod agents;
 mod args;
 mod audit;
+mod hosts;
 mod menu;
 #[cfg(feature = "postgres")]
 mod migrate_storage;
@@ -200,6 +201,12 @@ where
         "drop-tenant" => tenants::drop_tenant(pools, &args[1..], writer).await,
         "purge-tenant" => tenants::purge_tenant(pools, &args[1..], writer).await,
         "list-tenants" => tenants::list_tenants(pools, writer).await,
+        // #1344 — the console has bound extra hostnames since #1318; these
+        // give a deploy hook and a browser-less box the same reach.
+        "list-hosts" => hosts::list_hosts(pools, &args[1..], writer).await,
+        "add-host" => hosts::add_host(pools, &args[1..], writer).await,
+        "remove-host" => hosts::remove_host(pools, &args[1..], writer).await,
+        "set-host-enabled" => hosts::set_host_enabled(pools, &args[1..], writer).await,
         "prewarm-pools" => {
             // v0.27.7 (#60) — eagerly build pools for every active
             // database-mode tenant. Useful as a post-deploy hook
@@ -414,6 +421,30 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
         w,
         "  list-tenants         Print every Org row in the registry."
     )?;
+    writeln!(w)?;
+    writeln!(w, "HOSTNAMES:")?;
+    writeln!(
+        w,
+        "  list-hosts <slug>    Every hostname the tenant answers on, base first."
+    )?;
+    writeln!(w, "  add-host <slug> <hostname>")?;
+    writeln!(
+        w,
+        "                       Bind an extra hostname. Rejected if another tenant"
+    )?;
+    writeln!(w, "                       already claims it.")?;
+    writeln!(w, "  remove-host <slug> <hostname>")?;
+    writeln!(
+        w,
+        "                       Unbind one. The base host cannot be removed here —"
+    )?;
+    writeln!(w, "                       change --host-pattern instead.")?;
+    writeln!(w, "  set-host-enabled <slug> <hostname> --on|--off")?;
+    writeln!(
+        w,
+        "                       Park a host without losing the record (DNS in flight,"
+    )?;
+    writeln!(w, "                       domain being retired).")?;
     writeln!(w)?;
     writeln!(w, "USER / OPERATOR MANAGEMENT:")?;
     writeln!(

--- a/crates/rustango/tests/manage_hosts_sqlite_live.rs
+++ b/crates/rustango/tests/manage_hosts_sqlite_live.rs
@@ -1,0 +1,266 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Hostname verbs, and that they write what the console writes (#1344).
+//!
+//! Binding an extra hostname was console-only, so it could not run in a
+//! deploy hook, in CI, or on a box where nobody can open a browser. These
+//! verbs call `tenancy::org_host` — the same engine the console posts to —
+//! and this asserts the two really do land on one table rather than two
+//! code paths that merely look alike.
+
+use std::sync::Arc;
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::{org_host, TenantPools};
+
+struct Booted {
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry: Pool,
+    url: String,
+    _tmp: tempfile::TempDir,
+    migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    Booted {
+        pools,
+        registry,
+        url,
+        _tmp: tmp,
+        migrations,
+    }
+}
+
+impl Booted {
+    async fn run(&self, args: &[&str]) -> Result<String, String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+        rustango::tenancy::manage::run_with_writer(
+            self.pools.as_ref(),
+            &self.url,
+            self.migrations.path(),
+            argv,
+            &mut buf,
+        )
+        .await
+        .map(|()| String::from_utf8_lossy(&buf).into_owned())
+        .map_err(|e| e.to_string())
+    }
+
+    /// A tenant with no storage to provision — the host table is in the
+    /// registry, so routing can be set up without a tenant database.
+    async fn tenant(&self, slug: &str) -> String {
+        let db = self._tmp.path().join(format!("{slug}.db"));
+        self.run(&[
+            "create-tenant",
+            slug,
+            "--mode",
+            "database",
+            "--backend",
+            "sqlite",
+            "--database-url",
+            &format!("sqlite://{}?mode=rwc", db.display()),
+            "--no-migrate",
+        ])
+        .await
+        .expect("create the tenant");
+        slug.to_owned()
+    }
+}
+
+#[tokio::test]
+async fn add_list_and_remove_round_trip() {
+    let b = boot().await;
+    let slug = b.tenant("acme").await;
+
+    let out = b
+        .run(&["add-host", &slug, "shop.example.com"])
+        .await
+        .expect("add");
+    assert!(out.contains("shop.example.com"), "{out}");
+
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(listed.contains("shop.example.com"), "{listed}");
+
+    b.run(&["remove-host", &slug, "shop.example.com"])
+        .await
+        .expect("remove");
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(
+        !listed.contains("shop.example.com"),
+        "should be gone: {listed}"
+    );
+}
+
+/// The point of the slice: the verb and the console write the same rows.
+#[tokio::test]
+async fn the_verb_and_the_engine_see_one_table() {
+    let b = boot().await;
+    let slug = b.tenant("acme").await;
+
+    // Written through the CLI…
+    b.run(&["add-host", &slug, "a.example.com"])
+        .await
+        .expect("add");
+    // …read through the engine the console calls.
+    let via_engine = org_host::list_for_org(&b.registry, &slug)
+        .await
+        .expect("list_for_org");
+    assert!(
+        via_engine.iter().any(|h| h.hostname == "a.example.com"),
+        "the console would not see the CLI's host: {via_engine:?}"
+    );
+
+    // And the other direction.
+    org_host::add_host(&b.registry, &slug, "b.example.com")
+        .await
+        .expect("engine add");
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(
+        listed.contains("b.example.com"),
+        "the CLI would not see the console's host: {listed}"
+    );
+}
+
+/// Hostnames are normalized before storage, so the stored value matches the
+/// `Host` header byte-for-byte. The verb must echo what was stored.
+#[tokio::test]
+async fn a_hostname_is_normalized_not_stored_as_typed() {
+    let b = boot().await;
+    let slug = b.tenant("acme").await;
+
+    let out = b
+        .run(&["add-host", &slug, "  SHOP.Example.COM  "])
+        .await
+        .expect("add");
+    assert!(
+        out.contains("shop.example.com"),
+        "should echo the stored form: {out}"
+    );
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(listed.contains("shop.example.com"), "{listed}");
+}
+
+/// One hostname routes to one tenant, so the second claim must lose.
+#[tokio::test]
+async fn a_host_claimed_by_another_tenant_is_refused() {
+    let b = boot().await;
+    let one = b.tenant("acme").await;
+    let two = b.tenant("globex").await;
+
+    b.run(&["add-host", &one, "shared.example.com"])
+        .await
+        .expect("first claim");
+    let err = b
+        .run(&["add-host", &two, "shared.example.com"])
+        .await
+        .expect_err("second claim");
+    assert!(err.contains("already registered"), "{err}");
+}
+
+#[tokio::test]
+async fn parking_a_host_keeps_the_row() {
+    let b = boot().await;
+    let slug = b.tenant("acme").await;
+    b.run(&["add-host", &slug, "shop.example.com"])
+        .await
+        .expect("add");
+
+    let out = b
+        .run(&["set-host-enabled", &slug, "shop.example.com", "--off"])
+        .await
+        .expect("park");
+    assert!(out.contains("parked"), "{out}");
+
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(
+        listed.contains("shop.example.com") && listed.contains("false"),
+        "the row should survive, disabled: {listed}"
+    );
+
+    b.run(&["set-host-enabled", &slug, "shop.example.com", "--on"])
+        .await
+        .expect("serve");
+    let listed = b.run(&["list-hosts", &slug]).await.expect("list");
+    assert!(listed.contains("true"), "{listed}");
+}
+
+/// Neither direction given is refused rather than guessed: picking one would
+/// park a live host or serve a parked one.
+#[tokio::test]
+async fn set_host_enabled_refuses_to_guess_a_direction() {
+    let b = boot().await;
+    let slug = b.tenant("acme").await;
+    b.run(&["add-host", &slug, "shop.example.com"])
+        .await
+        .expect("add");
+
+    let err = b
+        .run(&["set-host-enabled", &slug, "shop.example.com"])
+        .await
+        .expect_err("no direction");
+    assert!(err.contains("--on") && err.contains("--off"), "{err}");
+}
+
+/// The base host lives on `Org.host_pattern`, not in this table — removing
+/// it here would silently do nothing, so it is refused with the reason.
+#[tokio::test]
+async fn the_base_host_cannot_be_removed_here() {
+    let b = boot().await;
+    let slug = "acme";
+    let db = b._tmp.path().join("acme.db");
+    b.run(&[
+        "create-tenant",
+        slug,
+        "--mode",
+        "database",
+        "--backend",
+        "sqlite",
+        "--database-url",
+        &format!("sqlite://{}?mode=rwc", db.display()),
+        "--host-pattern",
+        "acme.example.com",
+        "--no-migrate",
+    ])
+    .await
+    .expect("create with a base host");
+
+    let listed = b.run(&["list-hosts", slug]).await.expect("list");
+    assert!(
+        listed.contains("acme.example.com") && listed.contains("base"),
+        "the base host should be listed and labelled: {listed}"
+    );
+
+    let err = b
+        .run(&["remove-host", slug, "acme.example.com"])
+        .await
+        .expect_err("base host");
+    assert!(err.contains("base host"), "{err}");
+}
+
+#[tokio::test]
+async fn an_unknown_tenant_is_named() {
+    let b = boot().await;
+    let err = b
+        .run(&["list-hosts", "nosuchtenant"])
+        .await
+        .expect_err("unknown tenant");
+    assert!(!err.is_empty(), "should have explained itself");
+}


### PR DESCRIPTION
Part of #1344. Stacked on #1345's menu slice.

Binding an extra hostname has been a console action since #1318. That made it unavailable to a deploy hook, a CI job, or anyone on a box without a browser — and an action that exists on only one surface cannot be automated.

```
list-hosts <slug>
add-host <slug> <hostname>
remove-host <slug> <hostname>
set-host-enabled <slug> <hostname> --on|--off
```

All four go through `tenancy::org_host`, the same engine the console posts to. A test writes through the verb and reads through the engine, and the other way round, so "same engine" is asserted rather than asserted-in-a-comment.

### No `rename-host`

`org_host::generation` fingerprints the table by row count, enabled count, max id and enabled-id sum — the cross-pod cache invalidation everything else rides on. An in-place rename moves none of them, so other pods would keep routing the old name until the TTL expired. The module says so where someone would go to add it.

### Small decisions

- `set-host-enabled` refuses to default a direction. Guessing would either park a live host or serve a parked one.
- The verbs prompt for a missing slug or hostname on a terminal, matching `create-tenant` and `create-operator`, so a scripted caller still gets its validation error and the menu can offer them without re-listing positionals.
- Hostnames are normalized on the way in and the verb echoes what was **stored**, since the value is compared byte-for-byte against the `Host` header.

### CI

Also puts ten console suites into the no-default-features `sqlite,tenancy` job. They had only ever run in the all-features job, which always has Postgres — so a PG-ism in console or provisioning code (a `::` cast, an `ON CONFLICT` spelling, a `SET search_path`) would have passed CI and broken every SQLite and MySQL deployment. All ten pass there today, so this pins the current state rather than announcing a fix.
