### PR TITLE
feat(tenancy): operator verbs, with the lockout rules shared not copied

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,9 @@ jobs:
       # #1344 — the hostname verbs, and that they write the table the
       # operator console writes rather than a parallel one.
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_hosts_sqlite_live
+      # #1344 — and that the CLI enforces the same operator lockout rules the
+      # console does, now that both call one engine.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_operators_sqlite_live
       # The operator console and the provisioning engines under it. These ran
       # only in the all-features job, which always has Postgres available —
       # so a PG-ism in the console (a `::`-cast, an `ON CONFLICT` spelling,

--- a/crates/rustango/src/tenancy/manage/menu.rs
+++ b/crates/rustango/src/tenancy/manage/menu.rs
@@ -142,11 +142,25 @@ const GROUPS: &[Group] = &[
         title: "OPERATORS AND USERS",
         actions: &[
             Action {
+                verb: "list-operators",
+                about: "every operator and whether they are active",
+                asks: &[],
+            },
+            Action {
                 verb: "create-operator",
                 about: "an apex-level account for the operator console",
                 asks: &[Ask::Toggle {
                     flag: "--generate",
                     question: "generate a password instead of choosing one?",
+                }],
+            },
+            Action {
+                verb: "set-operator-active",
+                about: "turn an operator's access off or back on",
+                asks: &[Ask::Either {
+                    question: "activate them? (no deactivates)",
+                    yes: "--on",
+                    no: "--off",
                 }],
             },
             Action {

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -49,6 +49,7 @@ mod menu;
 #[cfg(feature = "postgres")]
 mod migrate_storage;
 mod migrations;
+mod operators;
 mod roles;
 mod scaffold;
 mod server;
@@ -248,6 +249,9 @@ where
                 .into(),
         )),
         "create-operator" => users::create_operator_cmd(pools, &args[1..], writer).await,
+        // #1344 — seeing who exists, and turning one off, were console-only.
+        "list-operators" => operators::list_operators(pools, writer).await,
+        "set-operator-active" => operators::set_operator_active(pools, &args[1..], writer).await,
         "create-user" => users::create_user_cmd(pools, registry_url, &args[1..], writer).await,
         "create-superuser" => {
             users::create_superuser_cmd(pools, registry_url, &args[1..], writer).await
@@ -455,6 +459,20 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
         w,
         "                       Operator-level account; signs into the apex /login."
     )?;
+    writeln!(
+        w,
+        "  list-operators       Every operator, with active state and creation date."
+    )?;
+    writeln!(w, "  set-operator-active <username> --on|--off")?;
+    writeln!(
+        w,
+        "                       Turn an operator's access off or back on. Refuses to"
+    )?;
+    writeln!(
+        w,
+        "                       deactivate the last active one — that would lock"
+    )?;
+    writeln!(w, "                       everyone out of the console.")?;
     writeln!(
         w,
         "  create-user <slug> <username> [--password <p> | --generate] [--superuser]"

--- a/crates/rustango/src/tenancy/manage/operators.rs
+++ b/crates/rustango/src/tenancy/manage/operators.rs
@@ -1,0 +1,114 @@
+//! Operator inspection and activation — `list-operators`,
+//! `set-operator-active`.
+//!
+//! `create-operator` and `reset-operator-password` already existed; seeing
+//! who exists and turning one off did not, so an operator who left the
+//! company could only be disabled through the console (#1344).
+//!
+//! Both verbs go through [`crate::tenancy::operators`], the engine the
+//! console calls, so the lockout rules are enforced once rather than
+//! restated here.
+
+use std::io::Write;
+
+use sqlx::Database;
+
+use crate::manage_interactive;
+use crate::tenancy::error::TenancyError;
+use crate::tenancy::operators::{self as ops, Outcome};
+use crate::tenancy::pools::TenantPools;
+
+fn explain(e: ops::OperatorError) -> TenancyError {
+    match e {
+        ops::OperatorError::Driver(d) => TenancyError::from(d),
+        other => TenancyError::Validation(other.to_string()),
+    }
+}
+
+pub(super) async fn list_operators<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let rows = ops::list(&pools.registry_pool()).await.map_err(explain)?;
+    if rows.is_empty() {
+        writeln!(w, "(no operators — create one with `create-operator`)")?;
+        return Ok(());
+    }
+    writeln!(w, "{:<32} {:<8} created_at", "username", "active")?;
+    writeln!(w, "{}", "-".repeat(64))?;
+    for o in &rows {
+        writeln!(
+            w,
+            "{:<32} {:<8} {}",
+            o.username,
+            o.active,
+            o.created_at.format("%Y-%m-%d %H:%M:%SZ"),
+        )?;
+    }
+    let active = rows.iter().filter(|o| o.active).count();
+    writeln!(w, "\n{} operator(s), {active} active", rows.len())?;
+    Ok(())
+}
+
+pub(super) async fn set_operator_active<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let username = match args.iter().find(|a| !a.starts_with("--")) {
+        Some(u) => u.clone(),
+        None => manage_interactive::ask("Operator username: ")
+            .map_err(TenancyError::Io)?
+            .ok_or_else(|| {
+                TenancyError::Validation("set-operator-active requires a username".into())
+            })?,
+    };
+
+    let mut active: Option<bool> = None;
+    for flag in args {
+        match flag.as_str() {
+            "--on" => active = Some(true),
+            "--off" => active = Some(false),
+            other if other.starts_with("--") => {
+                return Err(TenancyError::Validation(format!(
+                    "unknown flag `{other}` — set-operator-active takes --on or --off"
+                )))
+            }
+            _ => {}
+        }
+    }
+    let active = active.ok_or_else(|| {
+        TenancyError::Validation("set-operator-active requires --on or --off".into())
+    })?;
+
+    let registry = pools.registry_pool();
+    let mut target = ops::by_username(&registry, &username)
+        .await
+        .map_err(explain)?;
+
+    // `actor: None` — a shell has no session to lock itself out of. The
+    // last-active rule still applies: it is the invariant, and `--on` is
+    // always allowed, so the CLI can never paint itself into a corner.
+    match ops::set_active(&registry, &mut target, active, None)
+        .await
+        .map_err(explain)?
+    {
+        Outcome::AlreadySo => writeln!(
+            w,
+            "`{username}` was already {}",
+            if active { "active" } else { "inactive" }
+        )?,
+        Outcome::Changed => writeln!(
+            w,
+            "{} `{username}`",
+            if active { "activated" } else { "deactivated" }
+        )?,
+    }
+    Ok(())
+}

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -96,6 +96,7 @@ pub mod migrate;
 /// Tenant migrations against a recorded, streamable run.
 pub mod migrate_run;
 pub mod operator_console;
+pub mod operators;
 mod org;
 pub mod org_host;
 pub mod password;

--- a/crates/rustango/src/tenancy/operator_console/operators.rs
+++ b/crates/rustango/src/tenancy/operator_console/operators.rs
@@ -47,8 +47,9 @@ use tera::Context;
 use super::super::auth;
 use super::super::password;
 use super::{inject_op_brand, render, ConsoleState};
-use crate::core::{Column as _, Model as _};
+use crate::core::Column as _;
 use crate::sql::{Auto, FetcherPool as _};
+use crate::tenancy::operators as ops;
 
 /// The column's limit. A longer username is truncated by some backends
 /// and rejected by others; neither is a good way to find out.
@@ -303,59 +304,19 @@ pub(super) async fn operator_set_active(
         Err(e) => return back_err(&state, &op, &e).await,
     };
 
-    // Before the guards, not after: deactivating an already-inactive
-    // operator changes nothing, and running the lockout check on it
-    // answered "this is the last active operator" about an operator who
-    // was not active at all.
-    if target.active == activate {
-        return back_ok(&format!(
-            "`{}` was already {}",
-            target.username,
-            if activate { "active" } else { "inactive" }
-        ));
-    }
-
-    if !activate {
-        if id == id_of(&op) {
-            return back_err(
-                &state,
-                &op,
-                "You cannot deactivate yourself — your next request would be rejected. Ask \
-                 another operator to do it.",
-            )
-            .await;
+    // The rules — no-op first, then self-deactivation, then last-active —
+    // live in `tenancy::operators` so the CLI enforces the same ones (#1344).
+    // Ordering is load-bearing and documented there.
+    match ops::set_active(&state.registry, &mut target, activate, Some(id_of(&op))).await {
+        Ok(ops::Outcome::AlreadySo) => {
+            return back_ok(&format!(
+                "`{}` was already {}",
+                target.username,
+                if activate { "active" } else { "inactive" }
+            ));
         }
-        // Everyone active *except* the target. With the self-check
-        // above this is unreachable single-handed; it covers two
-        // operators deactivating each other at once, where both read
-        // "two active". A narrow window, not a closed one.
-        let others = super::count_where(
-            &state.registry,
-            auth::Operator::SCHEMA,
-            auth::Operator::active
-                .eq(true)
-                .and(auth::Operator::id.ne(id))
-                .into(),
-        )
-        .await;
-        match others {
-            Ok(0) => {
-                return back_err(
-                    &state,
-                    &op,
-                    "This is the last active operator. Deactivating it would lock everyone out \
-                     of the console, and only a shell on the registry could undo it.",
-                )
-                .await;
-            }
-            Ok(_) => {}
-            Err(e) => return back_err(&state, &op, &e.to_string()).await,
-        }
-    }
-
-    target.active = activate;
-    if let Err(e) = target.save_pool(&state.registry).await {
-        return back_err(&state, &op, &format!("Could not save: {e}")).await;
+        Ok(ops::Outcome::Changed) => {}
+        Err(e) => return back_err(&state, &op, &sentence(&e.to_string())).await,
     }
 
     let verb = if activate {
@@ -451,6 +412,16 @@ async fn one_operator(state: &ConsoleState, id: i64) -> Result<Option<auth::Oper
 
 fn id_of(op: &auth::Operator) -> i64 {
     op.id.get().copied().unwrap_or_default()
+}
+
+/// Capitalize an engine message so it reads as a sentence in the flash bar.
+/// The engine wording is shared with the CLI, which prints it lowercase
+/// after a `error: ` prefix.
+fn sentence(msg: &str) -> String {
+    let mut chars = msg.chars();
+    chars.next().map_or_else(String::new, |c| {
+        c.to_uppercase().to_string() + chars.as_str()
+    })
 }
 
 /// Post/Redirect/Get on success, so a reload does not repeat the write.

--- a/crates/rustango/src/tenancy/operators.rs
+++ b/crates/rustango/src/tenancy/operators.rs
@@ -1,0 +1,142 @@
+//! Operator account state, shared by the console and the CLI (#1344).
+//!
+//! Activating and deactivating an operator carries rules that are not
+//! obvious from the column: you cannot deactivate yourself, and you cannot
+//! deactivate the last active operator. Both were written inside the console
+//! handler, so a CLI verb would have had to restate them — and the copy that
+//! drifted would be the one that locked everybody out of the console with
+//! only a shell on the registry to undo it.
+//!
+//! So the rules live here and both surfaces call in. The console passes the
+//! signed-in operator as `actor`; the CLI passes `None`, because a shell has
+//! no session to lock itself out of. The last-active rule applies to both:
+//! it is the invariant, not a UI courtesy.
+
+use crate::core::Column as _;
+use crate::sql::{CounterPool as _, FetcherPool as _, Pool};
+use crate::tenancy::auth::Operator;
+
+/// Why an activation change was refused.
+#[derive(Debug)]
+pub enum OperatorError {
+    NotFound(String),
+    /// The signed-in operator tried to deactivate themselves.
+    SelfDeactivation,
+    /// Deactivating this one would leave no active operator at all.
+    LastActive,
+    Driver(crate::sql::ExecError),
+}
+
+impl std::fmt::Display for OperatorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(u) => write!(f, "no operator named `{u}`"),
+            Self::SelfDeactivation => write!(
+                f,
+                "you cannot deactivate yourself — your next request would be rejected. \
+                 Ask another operator to do it."
+            ),
+            Self::LastActive => write!(
+                f,
+                "this is the last active operator. Deactivating it would lock everyone \
+                 out of the console, and only a shell on the registry could undo it."
+            ),
+            Self::Driver(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for OperatorError {}
+
+impl From<crate::sql::ExecError> for OperatorError {
+    fn from(e: crate::sql::ExecError) -> Self {
+        Self::Driver(e)
+    }
+}
+
+/// What [`set_active`] did.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Changed,
+    /// Already in the requested state — reported, not an error, so a retried
+    /// request or a re-run script is not a failure.
+    AlreadySo,
+}
+
+/// Look an operator up by username.
+///
+/// # Errors
+/// [`OperatorError::NotFound`] when there is no such operator; driver errors
+/// otherwise.
+pub async fn by_username(registry: &Pool, username: &str) -> Result<Operator, OperatorError> {
+    Operator::objects()
+        .where_(Operator::username.eq(username.to_owned()))
+        .fetch(registry)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| OperatorError::NotFound(username.to_owned()))
+}
+
+/// Every operator, username order — the console's list and the CLI's.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn list(registry: &Pool) -> Result<Vec<Operator>, OperatorError> {
+    Ok(Operator::objects()
+        .order_by(&[("username", false)])
+        .fetch(registry)
+        .await?)
+}
+
+/// How many operators are active, ignoring `except`.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn active_count(registry: &Pool, except: Option<i64>) -> Result<i64, OperatorError> {
+    let mut q = Operator::objects().where_(Operator::active.eq(true));
+    if let Some(id) = except {
+        q = q.where_(Operator::id.ne(id));
+    }
+    Ok(q.count(registry).await?)
+}
+
+/// Activate or deactivate `target`, enforcing both lockout rules.
+///
+/// `actor` is the operator performing the change, when there is one — the
+/// console has a session, a shell does not.
+///
+/// # Errors
+/// [`OperatorError::SelfDeactivation`], [`OperatorError::LastActive`], or a
+/// driver error. Ordering matters: the no-op check runs first, so
+/// deactivating an already-inactive operator reports "already so" instead of
+/// claiming a lockout about an operator who was not active to begin with.
+pub async fn set_active(
+    registry: &Pool,
+    target: &mut Operator,
+    active: bool,
+    actor: Option<i64>,
+) -> Result<Outcome, OperatorError> {
+    let id = target.id.get().copied().unwrap_or_default();
+
+    if target.active == active {
+        return Ok(Outcome::AlreadySo);
+    }
+
+    if !active {
+        if actor == Some(id) {
+            return Err(OperatorError::SelfDeactivation);
+        }
+        // Everyone active *except* the target. With the self-check above this
+        // is unreachable single-handed; it covers two operators deactivating
+        // each other at once, where both read "two active". A narrow window,
+        // not a closed one.
+        if active_count(registry, Some(id)).await? == 0 {
+            return Err(OperatorError::LastActive);
+        }
+    }
+
+    target.active = active;
+    target.save_pool(registry).await?;
+    Ok(Outcome::Changed)
+}

--- a/crates/rustango/tests/manage_operators_sqlite_live.rs
+++ b/crates/rustango/tests/manage_operators_sqlite_live.rs
@@ -1,0 +1,215 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! `list-operators` and `set-operator-active` (#1344).
+//!
+//! Disabling a departed operator was a console-only action. The rules that
+//! make it safe — no self-deactivation, never the last active one — lived in
+//! the console handler, so a CLI verb would have restated them and the copy
+//! that drifted would be the one that locked everybody out.
+//!
+//! These assert the CLI enforces the same rules, because it calls the same
+//! `tenancy::operators` engine the console now calls.
+
+use std::sync::Arc;
+
+use rustango::sql::{sqlx, Pool};
+use rustango::tenancy::{operators as ops, TenantPools};
+
+struct Booted {
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry: Pool,
+    url: String,
+    _tmp: tempfile::TempDir,
+    migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    Booted {
+        pools,
+        registry,
+        url,
+        _tmp: tmp,
+        migrations,
+    }
+}
+
+impl Booted {
+    async fn run(&self, args: &[&str]) -> Result<String, String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+        rustango::tenancy::manage::run_with_writer(
+            self.pools.as_ref(),
+            &self.url,
+            self.migrations.path(),
+            argv,
+            &mut buf,
+        )
+        .await
+        .map(|()| String::from_utf8_lossy(&buf).into_owned())
+        .map_err(|e| e.to_string())
+    }
+
+    async fn operator(&self, username: &str) {
+        self.run(&[
+            "create-operator",
+            username,
+            "--password",
+            "correct-horse-42",
+        ])
+        .await
+        .unwrap_or_else(|e| panic!("create {username}: {e}"));
+    }
+}
+
+#[tokio::test]
+async fn list_shows_who_exists_and_who_is_active() {
+    let b = boot().await;
+    b.operator("ada").await;
+    b.operator("grace").await;
+
+    let out = b.run(&["list-operators"]).await.expect("list");
+    assert!(out.contains("ada") && out.contains("grace"), "{out}");
+    assert!(out.contains("2 operator(s), 2 active"), "{out}");
+}
+
+#[tokio::test]
+async fn an_empty_registry_says_so_rather_than_printing_a_bare_header() {
+    let b = boot().await;
+    let out = b.run(&["list-operators"]).await.expect("list");
+    assert!(out.contains("no operators"), "{out}");
+    assert!(
+        out.contains("create-operator"),
+        "should say what to do: {out}"
+    );
+}
+
+#[tokio::test]
+async fn deactivating_and_reactivating_round_trip() {
+    let b = boot().await;
+    b.operator("ada").await;
+    b.operator("grace").await;
+
+    let out = b
+        .run(&["set-operator-active", "grace", "--off"])
+        .await
+        .expect("deactivate");
+    assert!(out.contains("deactivated"), "{out}");
+
+    let listed = b.run(&["list-operators"]).await.expect("list");
+    assert!(listed.contains("2 operator(s), 1 active"), "{listed}");
+
+    b.run(&["set-operator-active", "grace", "--on"])
+        .await
+        .expect("reactivate");
+    let listed = b.run(&["list-operators"]).await.expect("list");
+    assert!(listed.contains("2 operator(s), 2 active"), "{listed}");
+}
+
+/// The rule that matters: the CLI must not be a way around the lockout
+/// guard the console enforces.
+#[tokio::test]
+async fn the_last_active_operator_cannot_be_deactivated() {
+    let b = boot().await;
+    b.operator("ada").await;
+
+    let err = b
+        .run(&["set-operator-active", "ada", "--off"])
+        .await
+        .expect_err("lockout");
+    assert!(err.contains("last active operator"), "{err}");
+
+    // And nothing was written.
+    let still = ops::by_username(&b.registry, "ada").await.expect("read");
+    assert!(still.active, "the operator must still be active");
+}
+
+/// …including when the others are already off, which is the state a
+/// one-at-a-time deactivation walks into.
+#[tokio::test]
+async fn deactivating_down_to_the_last_one_stops_at_one() {
+    let b = boot().await;
+    b.operator("ada").await;
+    b.operator("grace").await;
+
+    b.run(&["set-operator-active", "grace", "--off"])
+        .await
+        .expect("first");
+    let err = b
+        .run(&["set-operator-active", "ada", "--off"])
+        .await
+        .expect_err("second should be refused");
+    assert!(err.contains("last active operator"), "{err}");
+}
+
+/// A no-op is reported, not failed — a re-run script should not go red.
+#[tokio::test]
+async fn setting_the_state_it_already_has_is_not_an_error() {
+    let b = boot().await;
+    b.operator("ada").await;
+
+    let out = b
+        .run(&["set-operator-active", "ada", "--on"])
+        .await
+        .expect("already active");
+    assert!(out.contains("already active"), "{out}");
+}
+
+#[tokio::test]
+async fn a_direction_is_required_and_an_unknown_operator_is_named() {
+    let b = boot().await;
+    b.operator("ada").await;
+
+    let err = b
+        .run(&["set-operator-active", "ada"])
+        .await
+        .expect_err("no direction");
+    assert!(err.contains("--on") && err.contains("--off"), "{err}");
+
+    let err = b
+        .run(&["set-operator-active", "nobody", "--off"])
+        .await
+        .expect_err("unknown");
+    assert!(err.contains("nobody"), "{err}");
+}
+
+/// The CLI and the console call one engine, so a change through either is
+/// visible to the other.
+#[tokio::test]
+async fn the_verb_and_the_engine_agree() {
+    let b = boot().await;
+    b.operator("ada").await;
+    b.operator("grace").await;
+
+    b.run(&["set-operator-active", "grace", "--off"])
+        .await
+        .expect("deactivate");
+    let via_engine = ops::by_username(&b.registry, "grace").await.expect("read");
+    assert!(
+        !via_engine.active,
+        "the console would still show them active"
+    );
+
+    let mut target = via_engine;
+    ops::set_active(&b.registry, &mut target, true, None)
+        .await
+        .expect("engine reactivate");
+    let listed = b.run(&["list-operators"]).await.expect("list");
+    assert!(listed.contains("2 operator(s), 2 active"), "{listed}");
+}


### PR DESCRIPTION
Part of #1344. Stacked on the hostname-verbs slice.

Seeing who can sign in, and turning one of them off, were console-only actions — so removing a departed colleague's access needed a browser, and could not run from a deploy hook or an offboarding script.

```
list-operators
set-operator-active <username> --on|--off
```

### The obstacle was never the column

Activation carries two rules: you cannot deactivate yourself, and you cannot deactivate the last active operator. Both were written inside the console handler, so a verb would have restated them — and the copy that drifted would be the one that locked everybody out of the console, with only a shell on the registry to undo it.

They now live in `tenancy::operators`, and the console handler calls it. **The console's ten existing tests pass unchanged**, which is the point: these are the same rules, not new ones.

The console passes the signed-in operator as the actor; the CLI passes `None`, because a shell has no session to lock itself out of. The last-active rule applies to both — it is the invariant, not a UI courtesy — and `--on` is never blocked, so the CLI cannot paint itself into a corner either.

### Naming

`set-operator-active` rather than the `deactivate-operator` the issue sketched, for symmetry with `set-superuser` and `set-host-enabled`. `--on` is how you undo it, and a verb pair that only spells one direction hides that.

### Small decisions

- A no-op reports rather than fails, so re-running a provisioning script does not go red.
- The direction is required: guessing would either revoke access or restore it, and both are wrong to do silently.
