### PR TITLE
feat(tenancy): print run history and the audit trail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,9 @@ jobs:
       # #1344 — and that the CLI enforces the same operator lockout rules the
       # console does, now that both call one engine.
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_operators_sqlite_live
+      # #1344 — run history and the audit trail, printable without a browser,
+      # including that a CLI provision is recorded at all.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_inspect_sqlite_live
       # The operator console and the provisioning engines under it. These ran
       # only in the all-features job, which always has Postgres available —
       # so a PG-ism in the console (a `::`-cast, an `ON CONFLICT` spelling,

--- a/crates/rustango/src/tenancy/manage/inspect.rs
+++ b/crates/rustango/src/tenancy/manage/inspect.rs
@@ -1,0 +1,283 @@
+//! Read-only inspection — `list-runs`, `show-run`, `audit-log` (#1344).
+//!
+//! The console renders all three. Nothing printed them, so the questions
+//! asked during an incident — "did that provision finish?", "who
+//! deactivated this tenant?" — needed a browser pointed at production, or
+//! a SQL client on the registry.
+//!
+//! No new queries: `provision_store` and `crate::audit` already answer
+//! these for the console pages, and these verbs render the same rows.
+
+use std::io::Write;
+
+use sqlx::Database;
+
+use crate::tenancy::error::TenancyError;
+use crate::tenancy::pools::TenantPools;
+use crate::tenancy::provision_store;
+
+use super::args::next_value;
+
+/// Rows a page-less terminal can still scroll back through.
+const DEFAULT_LIMIT: i64 = 20;
+
+fn parse_limit<'a, I: Iterator<Item = &'a String>>(
+    iter: &mut I,
+    flag: &str,
+) -> Result<i64, TenancyError> {
+    let raw = next_value(iter, flag)?;
+    raw.parse::<i64>()
+        .ok()
+        .filter(|n| *n > 0)
+        .ok_or_else(|| TenancyError::Validation(format!("{flag} expects a positive integer")))
+}
+
+/// `Auto<DateTime>` is unset until the row round-trips; a run read back
+/// always has one, so an empty cell means something is wrong, not missing.
+fn stamp(t: &crate::sql::Auto<chrono::DateTime<chrono::Utc>>) -> String {
+    t.get().map_or_else(
+        || "-".to_owned(),
+        |d| d.format("%Y-%m-%d %H:%M:%SZ").to_string(),
+    )
+}
+
+/// Shorten for a column without hiding that it was shortened.
+fn clip(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        return s.to_owned();
+    }
+    let head: String = s.chars().take(n.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+pub(super) async fn list_runs<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let mut limit = DEFAULT_LIMIT;
+    let mut kind: Option<String> = None;
+    let mut state: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--limit" => limit = parse_limit(&mut iter, "--limit")?,
+            "--kind" => kind = Some(next_value(&mut iter, "--kind")?),
+            "--state" => state = Some(next_value(&mut iter, "--state")?),
+            other => {
+                return Err(TenancyError::Validation(format!(
+                    "unknown flag `{other}` — list-runs takes --limit, --kind, --state"
+                )))
+            }
+        }
+    }
+
+    // Filtered in the query, not on the page: filtering the newest N would
+    // report "none" whenever the newest N happen to be a different kind.
+    let runs = provision_store::recent_runs_filtered(
+        &pools.registry_pool(),
+        kind.as_deref(),
+        state.as_deref(),
+        limit,
+        0,
+    )
+    .await?;
+
+    if runs.is_empty() {
+        writeln!(w, "(no runs)")?;
+        return Ok(());
+    }
+    writeln!(
+        w,
+        "{:<8} {:<10} {:<24} {:<10} started",
+        "id", "kind", "slug", "state"
+    )?;
+    writeln!(w, "{}", "-".repeat(76))?;
+    for r in &runs {
+        let id = r.id.get().copied().unwrap_or_default();
+        writeln!(
+            w,
+            "{:<8} {:<10} {:<24} {:<10} {}",
+            id,
+            clip(&r.kind, 10),
+            // A batch migration stores an empty slug — it spans tenants.
+            clip(if r.slug.is_empty() { "(all)" } else { &r.slug }, 24),
+            clip(&r.state, 10),
+            stamp(&r.started_at),
+        )?;
+    }
+    writeln!(w, "\n`show-run <id>` for the steps of one")?;
+    Ok(())
+}
+
+pub(super) async fn show_run<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let raw = args
+        .iter()
+        .find(|a| !a.starts_with("--"))
+        .ok_or_else(|| TenancyError::Validation("show-run requires a run id".into()))?;
+    let run_id = raw
+        .parse::<i64>()
+        .map_err(|_| TenancyError::Validation(format!("`{raw}` is not a run id")))?;
+
+    let registry = pools.registry_pool();
+    let run = provision_store::run_by_id(&registry, run_id)
+        .await?
+        .ok_or_else(|| TenancyError::Validation(format!("no run {run_id}")))?;
+
+    writeln!(w, "run {run_id}  {}  {}", run.kind, run.state)?;
+    writeln!(
+        w,
+        "  tenant:     {}",
+        if run.slug.is_empty() {
+            "(every active tenant)"
+        } else {
+            &run.slug
+        }
+    )?;
+    if !run.storage_mode.is_empty() {
+        writeln!(
+            w,
+            "  storage:    {} / {}",
+            run.storage_mode, run.backend_kind
+        )?;
+    }
+    if let Some(by) = run.requested_by.as_deref() {
+        writeln!(w, "  requested:  {by}")?;
+    }
+    writeln!(w, "  started:    {}", stamp(&run.started_at))?;
+    if let Some(f) = run.finished_at {
+        writeln!(w, "  finished:   {}", f.format("%Y-%m-%d %H:%M:%SZ"))?;
+    }
+    if let Some(e) = run.error.as_deref() {
+        writeln!(w, "  error:      {e}")?;
+    }
+
+    // `0` means from the beginning — the same call the SSE stream makes to
+    // replay a run for a client that reconnected.
+    let events = provision_store::events_since(&registry, run_id, 0).await?;
+    if events.is_empty() {
+        writeln!(w, "\n(no steps recorded)")?;
+        return Ok(());
+    }
+    writeln!(w, "\n{:<5} {:<22} {:<9} message", "seq", "step", "status")?;
+    writeln!(w, "{}", "-".repeat(76))?;
+    for e in &events {
+        writeln!(
+            w,
+            "{:<5} {:<22} {:<9} {}",
+            e.seq,
+            clip(&e.step, 22),
+            clip(&e.status, 9),
+            e.message
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) async fn audit_log<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let mut limit = DEFAULT_LIMIT;
+    let mut filter = crate::audit::AuditFilter {
+        entity_table: None,
+        entity_pk: None,
+        operation: None,
+        source: None,
+    };
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--limit" => limit = parse_limit(&mut iter, "--limit")?,
+            "--table" => filter.entity_table = Some(next_value(&mut iter, "--table")?),
+            "--pk" => filter.entity_pk = Some(next_value(&mut iter, "--pk")?),
+            "--operation" => filter.operation = Some(next_value(&mut iter, "--operation")?),
+            "--source" => filter.source = Some(next_value(&mut iter, "--source")?),
+            other => {
+                return Err(TenancyError::Validation(format!(
+                    "unknown flag `{other}` — audit-log takes --limit, --table, --pk, \
+                     --operation, --source"
+                )))
+            }
+        }
+    }
+
+    // The registry's log, matching the console page: tenant-side rows are
+    // the tenant's own history and have their own viewer.
+    let registry = pools.registry_pool();
+    let total = crate::audit::count(&registry, &filter)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+    let rows = crate::audit::list(&registry, &filter, limit, 0)
+        .await
+        .map_err(|e| TenancyError::Validation(e.to_string()))?;
+
+    if rows.is_empty() {
+        writeln!(w, "(no audit entries)")?;
+        return Ok(());
+    }
+    writeln!(
+        w,
+        "{:<20} {:<22} {:<14} {:<12} source",
+        "when", "table", "pk", "operation"
+    )?;
+    writeln!(w, "{}", "-".repeat(92))?;
+    for e in &rows {
+        writeln!(
+            w,
+            "{:<20} {:<22} {:<14} {:<12} {}",
+            e.occurred_at.format("%Y-%m-%d %H:%M:%SZ"),
+            clip(&e.entity_table, 22),
+            clip(&e.entity_pk, 14),
+            clip(&e.operation, 12),
+            if e.source.is_empty() { "-" } else { &e.source },
+        )?;
+    }
+    if total > limit {
+        writeln!(w, "\nshowing {} of {total} — raise --limit", rows.len())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clip_marks_what_it_shortened() {
+        assert_eq!(clip("short", 10), "short");
+        assert_eq!(clip("exactlyten", 10), "exactlyten");
+        assert_eq!(clip("elevenchars", 10), "elevencha…");
+        // Multi-byte input must not be sliced mid-character.
+        assert_eq!(clip("ünïcödé-is-long", 6), "ünïcö…");
+    }
+
+    #[test]
+    fn a_limit_must_be_a_positive_integer() {
+        for bad in ["0", "-1", "lots"] {
+            let args = vec![bad.to_owned()];
+            let mut it = args.iter();
+            assert!(
+                parse_limit(&mut it, "--limit").is_err(),
+                "`{bad}` should be refused"
+            );
+        }
+        let args = vec!["50".to_owned()];
+        let mut it = args.iter();
+        assert_eq!(parse_limit(&mut it, "--limit").expect("ok"), 50);
+    }
+}

--- a/crates/rustango/src/tenancy/manage/menu.rs
+++ b/crates/rustango/src/tenancy/manage/menu.rs
@@ -110,6 +110,34 @@ const GROUPS: &[Group] = &[
         ],
     },
     Group {
+        title: "INSPECTION",
+        actions: &[
+            Action {
+                verb: "list-runs",
+                about: "recent provisioning and migration runs",
+                asks: &[Ask::Value {
+                    flag: "--kind",
+                    label: "kind (provision|migrate, blank for both)",
+                    default: None,
+                }],
+            },
+            Action {
+                verb: "show-run",
+                about: "one run's steps, from the recorded events",
+                asks: &[],
+            },
+            Action {
+                verb: "audit-log",
+                about: "who changed what in the registry, and when",
+                asks: &[Ask::Value {
+                    flag: "--table",
+                    label: "table (blank for all)",
+                    default: None,
+                }],
+            },
+        ],
+    },
+    Group {
         title: "HOSTNAMES",
         actions: &[
             Action {

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -45,6 +45,7 @@ mod agents;
 mod args;
 mod audit;
 mod hosts;
+mod inspect;
 mod menu;
 #[cfg(feature = "postgres")]
 mod migrate_storage;
@@ -252,6 +253,11 @@ where
         // #1344 — seeing who exists, and turning one off, were console-only.
         "list-operators" => operators::list_operators(pools, writer).await,
         "set-operator-active" => operators::set_operator_active(pools, &args[1..], writer).await,
+        // #1344 — the console renders all three; nothing printed them, so an
+        // incident question needed a browser or a SQL client.
+        "list-runs" => inspect::list_runs(pools, &args[1..], writer).await,
+        "show-run" => inspect::show_run(pools, &args[1..], writer).await,
+        "audit-log" => inspect::audit_log(pools, &args[1..], writer).await,
         "create-user" => users::create_user_cmd(pools, registry_url, &args[1..], writer).await,
         "create-superuser" => {
             users::create_superuser_cmd(pools, registry_url, &args[1..], writer).await
@@ -424,6 +430,28 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
     writeln!(
         w,
         "  list-tenants         Print every Org row in the registry."
+    )?;
+    writeln!(w)?;
+    writeln!(w, "INSPECTION (read-only):")?;
+    writeln!(
+        w,
+        "  list-runs [--limit N] [--kind provision|migrate] [--state <s>]"
+    )?;
+    writeln!(
+        w,
+        "                       Recent provisioning and migration runs, newest first."
+    )?;
+    writeln!(
+        w,
+        "  show-run <id>        One run's header and every step it recorded."
+    )?;
+    writeln!(
+        w,
+        "  audit-log [--limit N] [--table <t>] [--pk <v>] [--operation <o>] [--source <s>]"
+    )?;
+    writeln!(
+        w,
+        "                       The registry's audit trail — who changed what, and when."
     )?;
     writeln!(w)?;
     writeln!(w, "HOSTNAMES:")?;

--- a/crates/rustango/src/tenancy/manage/tenants.rs
+++ b/crates/rustango/src/tenancy/manage/tenants.rs
@@ -46,8 +46,22 @@ where
         slug: request.slug.clone(),
         mode: request.mode,
     };
-    let outcome =
-        provision::provision_tenant(pools, registry_url, dir, &request, Some(&progress)).await?;
+    // Recorded, like the console's provisioning (#1344). A tenant created
+    // from a shell used to leave no run at all, so the run history — and
+    // `list-runs` — described only what the console had done, and a CLI
+    // provision that died halfway left nothing to find. Recording is
+    // best-effort inside `provision_tenant_recorded`: bookkeeping must not
+    // be what fails a tenant creation.
+    let (_run, outcome) = provision::provision_tenant_recorded(
+        pools,
+        registry_url,
+        dir,
+        &request,
+        Some(&progress),
+        Some("cli"),
+        None,
+    )
+    .await?;
 
     let w = progress.into_inner();
     match &outcome.migrations {

--- a/crates/rustango/src/tenancy/provision_store.rs
+++ b/crates/rustango/src/tenancy/provision_store.rs
@@ -431,7 +431,33 @@ pub async fn recent_runs(
     limit: i64,
     offset: i64,
 ) -> Result<Vec<ProvisioningRun>, TenancyError> {
-    Ok(ProvisioningRun::objects()
+    recent_runs_filtered(registry, None, None, limit, offset).await
+}
+
+/// As [`recent_runs`], narrowed to one `kind` and/or `state`.
+///
+/// The filter belongs in the query, not in a `.filter()` on the result:
+/// filtering a page of the newest N reports "none" whenever the newest N
+/// happen to be a different kind, which is exactly the answer nobody wants
+/// while looking for the migration run that failed last week.
+///
+/// # Errors
+/// Driver / query failures.
+pub async fn recent_runs_filtered(
+    registry: &Pool,
+    kind: Option<&str>,
+    state: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<ProvisioningRun>, TenancyError> {
+    let mut q = ProvisioningRun::objects();
+    if let Some(k) = kind {
+        q = q.where_(ProvisioningRun::kind.eq(k.to_owned()));
+    }
+    if let Some(s) = state {
+        q = q.where_(ProvisioningRun::state.eq(s.to_owned()));
+    }
+    Ok(q
         // Descending — the bool is `desc`, and "recent" means the run
         // somebody just started is the one at the top.
         .order_by(&[("id", true)])

--- a/crates/rustango/tests/manage_inspect_sqlite_live.rs
+++ b/crates/rustango/tests/manage_inspect_sqlite_live.rs
@@ -1,0 +1,302 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! `list-runs`, `show-run`, `audit-log` (#1344).
+//!
+//! The console renders all three. Nothing printed them, so "did that
+//! provision finish?" and "who deactivated this tenant?" — the questions
+//! asked during an incident — needed a browser pointed at production or a
+//! SQL client on the registry.
+
+use std::sync::Arc;
+
+use rustango::audit::AuditLog;
+use rustango::sql::{sqlx, Auto, Pool};
+use rustango::tenancy::TenantPools;
+
+struct Booted {
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry: Pool,
+    url: String,
+    _tmp: tempfile::TempDir,
+    migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    Booted {
+        pools,
+        registry,
+        url,
+        _tmp: tmp,
+        migrations,
+    }
+}
+
+impl Booted {
+    async fn run(&self, args: &[&str]) -> Result<String, String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+        rustango::tenancy::manage::run_with_writer(
+            self.pools.as_ref(),
+            &self.url,
+            self.migrations.path(),
+            argv,
+            &mut buf,
+        )
+        .await
+        .map(|()| String::from_utf8_lossy(&buf).into_owned())
+        .map_err(|e| e.to_string())
+    }
+
+    /// Provisioning a tenant is what opens a run, so this is the fixture.
+    async fn tenant(&self, slug: &str) {
+        let db = self._tmp.path().join(format!("{slug}.db"));
+        self.run(&[
+            "create-tenant",
+            slug,
+            "--mode",
+            "database",
+            "--backend",
+            "sqlite",
+            "--database-url",
+            &format!("sqlite://{}?mode=rwc", db.display()),
+            "--no-migrate",
+        ])
+        .await
+        .unwrap_or_else(|e| panic!("create {slug}: {e}"));
+    }
+
+    async fn audit_row(&self, pk: &str, operation: &str, source: &str) {
+        let mut row = AuditLog {
+            id: Auto::default(),
+            entity_table: "rustango_orgs".into(),
+            entity_pk: pk.to_owned(),
+            operation: operation.to_owned(),
+            source: source.to_owned(),
+            changes: serde_json::json!({}),
+            occurred_at: chrono::Utc::now(),
+        };
+        row.insert_pool(&self.registry).await.expect("seed audit");
+    }
+}
+
+#[tokio::test]
+async fn provisioning_a_tenant_shows_up_in_list_runs() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let out = b.run(&["list-runs"]).await.expect("list-runs");
+    assert!(
+        out.contains("acme"),
+        "the run should name the tenant: {out}"
+    );
+    assert!(
+        out.contains("show-run"),
+        "should point at the detail verb: {out}"
+    );
+}
+
+/// A tenant created from a shell used to leave no run at all, so the run
+/// history described only what the console had done — and a CLI provision
+/// that died halfway left nothing to find.
+#[tokio::test]
+async fn a_cli_provision_is_recorded_and_says_it_came_from_the_cli() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let listed = b.run(&["list-runs"]).await.expect("list");
+    let id = listed
+        .lines()
+        .find(|l| l.contains("acme"))
+        .and_then(|l| l.split_whitespace().next())
+        .expect("a run id")
+        .to_owned();
+
+    let out = b.run(&["show-run", &id]).await.expect("show-run");
+    assert!(
+        out.contains("requested:  cli"),
+        "the run should say where it came from: {out}"
+    );
+    assert!(
+        out.contains("succeeded") || out.contains("ok"),
+        "and that it finished: {out}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_registry_reports_no_runs() {
+    let b = boot().await;
+    let out = b.run(&["list-runs"]).await.expect("list-runs");
+    assert!(out.contains("(no runs)"), "{out}");
+}
+
+/// The detail view is the reason to have the list: it prints the steps a
+/// run recorded, which is what says where a failure happened.
+#[tokio::test]
+async fn show_run_prints_the_recorded_steps() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    // The list is newest-first, so the run just opened is the first id.
+    let listed = b.run(&["list-runs"]).await.expect("list");
+    let id = listed
+        .lines()
+        .find(|l| l.contains("acme"))
+        .and_then(|l| l.split_whitespace().next())
+        .expect("a run id in the listing")
+        .to_owned();
+
+    let out = b.run(&["show-run", &id]).await.expect("show-run");
+    assert!(out.contains(&format!("run {id}")), "{out}");
+    assert!(out.contains("acme"), "{out}");
+    assert!(out.contains("seq"), "should print the step table: {out}");
+}
+
+#[tokio::test]
+async fn show_run_refuses_a_non_id_and_names_a_missing_one() {
+    let b = boot().await;
+
+    let err = b.run(&["show-run", "banana"]).await.expect_err("not an id");
+    assert!(err.contains("banana"), "{err}");
+
+    let err = b.run(&["show-run", "4242"]).await.expect_err("no such run");
+    assert!(err.contains("4242"), "{err}");
+
+    let err = b.run(&["show-run"]).await.expect_err("no id at all");
+    assert!(err.contains("run id"), "{err}");
+}
+
+#[tokio::test]
+async fn list_runs_filters_by_kind_and_validates_its_limit() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let out = b
+        .run(&["list-runs", "--kind", "provision"])
+        .await
+        .expect("by kind");
+    assert!(out.contains("acme"), "{out}");
+
+    // No migration runs exist, so filtering to them is empty, not wrong.
+    let out = b
+        .run(&["list-runs", "--kind", "migrate"])
+        .await
+        .expect("by kind");
+    assert!(out.contains("(no runs)"), "{out}");
+
+    let err = b
+        .run(&["list-runs", "--limit", "0"])
+        .await
+        .expect_err("zero");
+    assert!(err.contains("--limit"), "{err}");
+}
+
+/// The filter runs in the query, not over the page. Filtering the newest N
+/// reports "none" whenever the newest N happen to be a different kind —
+/// which is exactly the wrong answer while hunting the run that failed.
+#[tokio::test]
+async fn a_kind_filter_reaches_past_a_page_of_the_other_kind() {
+    let b = boot().await;
+    // One migration run, then enough provisions to bury it.
+    rustango::tenancy::provision_store::open_migrate_run(&b.registry, Some("acme"), Some("cli"))
+        .await
+        .expect("open a migrate run");
+    for i in 0..4 {
+        b.tenant(&format!("t{i}")).await;
+    }
+
+    // A window smaller than the number of provisions above it.
+    let out = b
+        .run(&["list-runs", "--kind", "migrate", "--limit", "2"])
+        .await
+        .expect("by kind");
+    assert!(
+        out.contains("acme"),
+        "the migration run is older than the window but still the match: {out}"
+    );
+}
+
+#[tokio::test]
+async fn audit_log_prints_the_registry_trail() {
+    let b = boot().await;
+    b.audit_row("acme", "action", "operator:1:tenant_deactivate")
+        .await;
+    b.audit_row("globex", "update", "operator:2:tenant_edit")
+        .await;
+
+    let out = b.run(&["audit-log"]).await.expect("audit-log");
+    assert!(out.contains("acme") && out.contains("globex"), "{out}");
+    assert!(out.contains("tenant_deactivate"), "source column: {out}");
+}
+
+#[tokio::test]
+async fn audit_log_filters() {
+    let b = boot().await;
+    b.audit_row("acme", "action", "operator:1:tenant_deactivate")
+        .await;
+    b.audit_row("globex", "update", "operator:2:tenant_edit")
+        .await;
+
+    let out = b.run(&["audit-log", "--pk", "acme"]).await.expect("by pk");
+    assert!(out.contains("acme"), "{out}");
+    assert!(
+        !out.contains("globex"),
+        "the filter should exclude it: {out}"
+    );
+
+    let out = b
+        .run(&["audit-log", "--operation", "update"])
+        .await
+        .expect("by operation");
+    assert!(out.contains("globex") && !out.contains("acme"), "{out}");
+}
+
+#[tokio::test]
+async fn audit_log_says_when_it_truncated() {
+    let b = boot().await;
+    for i in 0..5 {
+        b.audit_row(&format!("t{i}"), "action", "operator:1:x")
+            .await;
+    }
+    let out = b
+        .run(&["audit-log", "--limit", "2"])
+        .await
+        .expect("limited");
+    assert!(
+        out.contains("showing 2 of 5"),
+        "a truncated view must say so: {out}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_trail_reports_rather_than_printing_a_bare_header() {
+    let b = boot().await;
+    let out = b.run(&["audit-log"]).await.expect("audit-log");
+    assert!(out.contains("(no audit entries)"), "{out}");
+}
+
+#[tokio::test]
+async fn unknown_flags_are_named_with_what_is_accepted() {
+    let b = boot().await;
+    let err = b
+        .run(&["audit-log", "--tenant", "acme"])
+        .await
+        .expect_err("not a flag here");
+    assert!(err.contains("--tenant") && err.contains("--table"), "{err}");
+}


### PR DESCRIPTION
Part of #1344. Stacked on the operator-verbs slice.

The console renders run history and the audit trail. Nothing printed them, so the two questions asked during an incident — *did that provision finish, and where did it stop?* and *who deactivated this tenant?* — needed a browser pointed at production or a SQL client on the registry.

```
list-runs [--limit N] [--kind provision|migrate] [--state <s>]
show-run <id>
audit-log [--limit N] [--table <t>] [--pk <v>] [--operation <o>] [--source <s>]
```

No new queries — `provision_store` and `crate::audit` already answer these for the console pages.

### A gap the issue had not listed

`create-tenant` called `provision_tenant`, not `provision_tenant_recorded`, so **a tenant created from a shell left no run at all**. Run history described only what the console had done, and a CLI provision that died halfway left nothing to find. It now records, with `requested_by = cli` so the two sources are distinguishable.

### A bug in the first version of this PR

`--kind` originally filtered the fetched page. That reports "no runs" whenever the newest N happen to be a different kind — the wrong answer precisely when someone is hunting an older failed run. The filter is in the query now; `recent_runs` delegates to a filtered variant so both orderings stay one. There is a test that buries a migration run under four provisions and asks for it with `--limit 2`.
