### PR TITLE
feat(tenancy): edit-tenant, closing the console/CLI gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,9 @@ jobs:
       # #1344 — run history and the audit trail, printable without a browser,
       # including that a CLI provision is recorded at all.
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_inspect_sqlite_live
+      # #1344 — tenant routing config, editable without a browser, and the
+      # cache/pool invalidation that has to follow the write.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test manage_edit_tenant_sqlite_live
       # The operator console and the provisioning engines under it. These ran
       # only in the all-features job, which always has Postgres available —
       # so a PG-ism in the console (a `::`-cast, an `ON CONFLICT` spelling,

--- a/crates/rustango/src/tenancy/manage/edit.rs
+++ b/crates/rustango/src/tenancy/manage/edit.rs
@@ -1,0 +1,169 @@
+//! `edit-tenant` — change a tenant's routing and display config (#1344).
+//!
+//! The console has edited these since v0.25; the CLI could not, so moving
+//! a tenant to a new hostname or rotating its credential meant a browser.
+//!
+//! The work is in [`crate::tenancy::org_edit`], which both surfaces call:
+//! the write has to be followed by dropping the cached `Org` and, only on
+//! a real URL change, evicting the pool. Leaving out the cache drop is
+//! invisible in testing and reports success while the next request still
+//! uses the old row.
+
+use std::io::Write;
+
+use sqlx::Database;
+
+use crate::manage_interactive;
+use crate::tenancy::error::TenancyError;
+use crate::tenancy::org_edit::{apply, OrgPatch};
+use crate::tenancy::pools::TenantPools;
+
+use super::args::next_value;
+
+/// The slug and the patch, from argv.
+fn parse_args(args: &[String]) -> Result<(Option<String>, OrgPatch), TenancyError> {
+    let mut patch = OrgPatch::default();
+    let mut slug: Option<String> = None;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--display-name" => patch.display_name = Some(next_value(&mut iter, arg)?),
+            "--host-pattern" => patch.host_pattern = Some(next_value(&mut iter, arg)?),
+            "--path-prefix" => patch.path_prefix = Some(next_value(&mut iter, arg)?),
+            "--port" => patch.port = Some(next_value(&mut iter, arg)?),
+            "--database-url" => patch.database_url = Some(next_value(&mut iter, arg)?),
+            "--activate" => patch.active = Some(true),
+            "--deactivate" => patch.active = Some(false),
+            // An explicit empty value is how you clear an optional column;
+            // `--clear <field>` says so without relying on `--x ""`, which
+            // some shells and CI runners eat.
+            "--clear" => {
+                let field = next_value(&mut iter, "--clear")?;
+                match field.as_str() {
+                    "host-pattern" => patch.host_pattern = Some(String::new()),
+                    "path-prefix" => patch.path_prefix = Some(String::new()),
+                    "port" => patch.port = Some(String::new()),
+                    // `display_name` is NOT NULL, so there is no "cleared"
+                    // state to ask for — `--display-name ""` is the whole
+                    // of what clearing it could mean.
+                    other => {
+                        return Err(TenancyError::Validation(format!(
+                            "cannot clear `{other}` — the clearable fields are host-pattern, \
+                             path-prefix, port"
+                        )))
+                    }
+                }
+            }
+            other if other.starts_with("--") => {
+                return Err(TenancyError::Validation(format!(
+                    "unknown flag `{other}` — run `edit-tenant --help`"
+                )))
+            }
+            positional => {
+                if slug.is_some() {
+                    return Err(TenancyError::Validation(format!(
+                        "unexpected argument `{positional}`"
+                    )));
+                }
+                slug = Some(positional.to_owned());
+            }
+        }
+    }
+    Ok((slug, patch))
+}
+
+pub(super) async fn edit_tenant<W: Write + Send, DB: Database>(
+    pools: &TenantPools<DB>,
+    args: &[String],
+    w: &mut W,
+) -> Result<(), TenancyError>
+where
+    crate::sql::Pool: From<sqlx::Pool<DB>>,
+{
+    let (slug, patch) = parse_args(args)?;
+
+    let slug = match slug {
+        Some(s) => s,
+        None => manage_interactive::ask("Tenant slug: ")
+            .map_err(TenancyError::Io)?
+            .ok_or_else(|| TenancyError::Validation("edit-tenant requires a slug".into()))?,
+    };
+
+    let registry = pools.registry_pool();
+    let applied = apply(&registry, &slug, &patch).await?;
+
+    // Only on a real change — evicting for a display name throws away warm
+    // connections for nothing.
+    if applied.database_url_rotated {
+        pools.invalidate(&slug).await;
+    }
+
+    writeln!(w, "updated `{slug}`: {}", applied.touched.join(", "))?;
+    if applied.database_url_rotated {
+        writeln!(
+            w,
+            "  pool evicted — the next request rebuilds with the new URL"
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> Result<(Option<String>, OrgPatch), TenancyError> {
+        let args: Vec<String> = argv.iter().map(|s| (*s).to_owned()).collect();
+        parse_args(&args)
+    }
+
+    fn patch(argv: &[&str]) -> OrgPatch {
+        parse(argv).expect("parse").1
+    }
+
+    /// "Leave alone" and "clear it" are different instructions, and a patch
+    /// that cannot tell them apart would wipe fields on every edit.
+    #[test]
+    fn unmentioned_is_not_the_same_as_cleared() {
+        let only_name = patch(&["acme", "--display-name", "Acme"]);
+        assert!(only_name.host_pattern.is_none(), "not mentioned");
+
+        let cleared = patch(&["acme", "--clear", "host-pattern"]);
+        assert_eq!(cleared.host_pattern.as_deref(), Some(""), "cleared");
+        assert!(cleared.display_name.is_none());
+    }
+
+    #[test]
+    fn activate_and_deactivate_are_opposite_flags() {
+        assert_eq!(patch(&["acme", "--activate"]).active, Some(true));
+        assert_eq!(patch(&["acme", "--deactivate"]).active, Some(false));
+        assert_eq!(patch(&["acme", "--display-name", "x"]).active, None);
+    }
+
+    #[test]
+    fn the_slug_is_the_only_positional() {
+        let (slug, _) = parse(&["acme", "--activate"]).expect("parse");
+        assert_eq!(slug.as_deref(), Some("acme"));
+
+        // Flags before the slug still work.
+        let (slug, _) = parse(&["--activate", "acme"]).expect("parse");
+        assert_eq!(slug.as_deref(), Some("acme"));
+
+        let err = parse(&["acme", "globex"]).expect_err("two slugs");
+        assert!(err.to_string().contains("globex"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_flag_or_clear_target_is_named() {
+        let err = parse(&["acme", "--nope"]).expect_err("unknown flag");
+        assert!(err.to_string().contains("--nope"), "{err}");
+
+        let err = parse(&["acme", "--clear", "slug"]).expect_err("not clearable");
+        assert!(err.to_string().contains("slug"), "{err}");
+        assert!(
+            err.to_string().contains("host-pattern"),
+            "should list what is: {err}"
+        );
+    }
+}

--- a/crates/rustango/src/tenancy/manage/menu.rs
+++ b/crates/rustango/src/tenancy/manage/menu.rs
@@ -90,6 +90,22 @@ const GROUPS: &[Group] = &[
                 ],
             },
             Action {
+                verb: "edit-tenant",
+                about: "change routing and display config",
+                asks: &[
+                    Ask::Value {
+                        flag: "--display-name",
+                        label: "display name (blank to leave alone)",
+                        default: None,
+                    },
+                    Ask::Value {
+                        flag: "--host-pattern",
+                        label: "host pattern (blank to leave alone)",
+                        default: None,
+                    },
+                ],
+            },
+            Action {
                 verb: "drop-tenant",
                 about: "soft-delete a tenant; data preserved",
                 asks: &[],

--- a/crates/rustango/src/tenancy/manage/mod.rs
+++ b/crates/rustango/src/tenancy/manage/mod.rs
@@ -44,6 +44,7 @@
 mod agents;
 mod args;
 mod audit;
+mod edit;
 mod hosts;
 mod inspect;
 mod menu;
@@ -203,6 +204,8 @@ where
         "drop-tenant" => tenants::drop_tenant(pools, &args[1..], writer).await,
         "purge-tenant" => tenants::purge_tenant(pools, &args[1..], writer).await,
         "list-tenants" => tenants::list_tenants(pools, writer).await,
+        // #1344 — routing and display config were console-only to change.
+        "edit-tenant" => edit::edit_tenant(pools, &args[1..], writer).await,
         // #1344 — the console has bound extra hostnames since #1318; these
         // give a deploy hook and a browser-less box the same reach.
         "list-hosts" => hosts::list_hosts(pools, &args[1..], writer).await,
@@ -431,6 +434,27 @@ pub fn write_help<W: Write>(w: &mut W) -> Result<(), TenancyError> {
         w,
         "  list-tenants         Print every Org row in the registry."
     )?;
+    writeln!(
+        w,
+        "  edit-tenant <slug> [--display-name <s>] [--host-pattern <h>]"
+    )?;
+    writeln!(
+        w,
+        "                     [--path-prefix <p>] [--port <n>] [--database-url <u>]"
+    )?;
+    writeln!(
+        w,
+        "                     [--activate | --deactivate] [--clear <field>]"
+    )?;
+    writeln!(
+        w,
+        "                       Change routing and display config. Only the fields you"
+    )?;
+    writeln!(
+        w,
+        "                       name are touched; --clear empties one. Rotating the URL"
+    )?;
+    writeln!(w, "                       evicts the tenant's pool.")?;
     writeln!(w)?;
     writeln!(w, "INSPECTION (read-only):")?;
     writeln!(

--- a/crates/rustango/src/tenancy/mod.rs
+++ b/crates/rustango/src/tenancy/mod.rs
@@ -98,6 +98,7 @@ pub mod migrate_run;
 pub mod operator_console;
 pub mod operators;
 mod org;
+pub mod org_edit;
 pub mod org_host;
 pub mod password;
 pub mod permissions;

--- a/crates/rustango/src/tenancy/org_edit.rs
+++ b/crates/rustango/src/tenancy/org_edit.rs
@@ -1,0 +1,260 @@
+//! Changing a tenant's routing and display config, from either surface.
+//!
+//! The console has edited these since v0.25. The CLI could not, so a
+//! host-pattern change or a credential rotation meant a browser (#1344).
+//!
+//! ## Why this is not just an UPDATE
+//!
+//! Three things have to happen together, and the order matters:
+//!
+//! 1. Write the row.
+//! 2. Drop the cached `Org`. Resolution serves from that cache, so
+//!    without this the pool is evicted and immediately rebuilt from the
+//!    stale row — a rotation reports success while the next request
+//!    reconnects with the old credential, and `active = false` keeps
+//!    serving.
+//! 3. Evict the tenant's pool, but only when the URL actually changed —
+//!    evicting on every edit throws away warm connections for a display
+//!    name.
+//!
+//! Step 2 is the one that is easy to leave out and impossible to notice
+//! in testing, because the stale read only shows up on another request.
+//! So both surfaces call [`apply`] rather than each remembering.
+
+use crate::core::{Column as _, Model as _};
+use crate::sql::{FetcherPool as _, Pool};
+use crate::tenancy::error::TenancyError;
+use crate::tenancy::Org;
+
+/// Which fields an edit touches. `None` means "leave alone" — distinct
+/// from `Some("")`, which clears an optional column.
+#[derive(Debug, Default, Clone)]
+pub struct OrgPatch {
+    pub display_name: Option<String>,
+    pub host_pattern: Option<String>,
+    pub path_prefix: Option<String>,
+    pub port: Option<String>,
+    pub active: Option<bool>,
+    pub database_url: Option<String>,
+}
+
+impl OrgPatch {
+    /// Nothing to do — the caller should say so rather than run an UPDATE
+    /// with an empty SET, which is a SQL error on some backends and a
+    /// silent no-op on others.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.display_name.is_none()
+            && self.host_pattern.is_none()
+            && self.path_prefix.is_none()
+            && self.port.is_none()
+            && self.active.is_none()
+            && self.database_url.is_none()
+    }
+
+    /// Column names this patch touches, for the audit trail.
+    ///
+    /// `database_url` is named but its value never is: the fact of a
+    /// rotation belongs in the log, the credential does not.
+    #[must_use]
+    pub fn touched(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if self.display_name.is_some() {
+            out.push("display_name");
+        }
+        if self.host_pattern.is_some() {
+            out.push("host_pattern");
+        }
+        if self.path_prefix.is_some() {
+            out.push("path_prefix");
+        }
+        if self.port.is_some() {
+            out.push("port");
+        }
+        if self.active.is_some() {
+            out.push("active");
+        }
+        if self.database_url.is_some() {
+            out.push("database_url");
+        }
+        out
+    }
+}
+
+/// What [`apply`] changed, so the caller can word its own message.
+#[derive(Debug)]
+pub struct Applied {
+    pub touched: Vec<&'static str>,
+    /// True only when the URL is genuinely different from the stored one.
+    pub database_url_rotated: bool,
+}
+
+/// Validate, write, and drop the cached `Org` — in that order.
+///
+/// Evicting the tenant's *pool* is the caller's, because `TenantPools` is
+/// generic over the backend and this module is not: do it when
+/// [`Applied::database_url_rotated`] is true, and not otherwise.
+///
+/// # Errors
+/// [`TenancyError::Validation`] for a bad host pattern, port, or path
+/// prefix, or when the tenant does not exist; driver errors otherwise.
+pub async fn apply(registry: &Pool, slug: &str, patch: &OrgPatch) -> Result<Applied, TenancyError> {
+    if patch.is_empty() {
+        return Err(TenancyError::Validation(
+            "nothing to change — pass at least one field".into(),
+        ));
+    }
+
+    let existing = Org::objects()
+        .where_(Org::slug.eq(slug.to_owned()))
+        .fetch(registry)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| TenancyError::Validation(format!("tenant `{slug}` not found")))?;
+
+    // The same validators provisioning uses, so a value the console or
+    // the CLI can set is a value `create-tenant` would have accepted.
+    let mut set: Vec<crate::core::Assignment> = Vec::new();
+    if let Some(v) = patch.display_name.as_deref() {
+        // NOT NULL, unlike the routing columns below — an empty display
+        // name is the empty string, and writing NULL would be a constraint
+        // violation rather than a clear.
+        set.push(assign(
+            "display_name",
+            crate::core::SqlValue::String(v.trim().to_owned()),
+        ));
+    }
+    if let Some(v) = patch.host_pattern.as_deref() {
+        // Returns the normalized (lowercased) form — store that, not what
+        // was typed, so it can match a `Host` header byte-for-byte.
+        let normalized = if v.trim().is_empty() {
+            None
+        } else {
+            Some(
+                crate::tenancy::provision::validate_host_pattern(v)
+                    .map_err(TenancyError::Validation)?,
+            )
+        };
+        set.push(assign("host_pattern", string_or_null(normalized)));
+    }
+    if let Some(v) = patch.path_prefix.as_deref() {
+        let cleaned = if v.trim().is_empty() {
+            None
+        } else {
+            crate::tenancy::provision::validate_path_prefix(v).map_err(TenancyError::Validation)?;
+            Some(v.trim().to_owned())
+        };
+        set.push(assign("path_prefix", string_or_null(cleaned)));
+    }
+    if let Some(v) = patch.port.as_deref() {
+        let p = if v.trim().is_empty() {
+            None
+        } else {
+            let n = v
+                .trim()
+                .parse::<i32>()
+                .map_err(|_| TenancyError::Validation(format!("port `{v}` is not a number")))?;
+            crate::tenancy::provision::validate_port(n).map_err(TenancyError::Validation)?;
+            Some(n)
+        };
+        set.push(assign(
+            "port",
+            p.map_or(crate::core::SqlValue::Null, crate::core::SqlValue::I32),
+        ));
+    }
+    if let Some(v) = patch.active {
+        set.push(assign("active", crate::core::SqlValue::Bool(v)));
+    }
+    let database_url_rotated = patch
+        .database_url
+        .as_deref()
+        .filter(|u| !u.trim().is_empty())
+        .is_some_and(|new| existing.database_url.as_deref() != Some(new));
+    if let Some(v) = patch
+        .database_url
+        .as_deref()
+        .filter(|u| !u.trim().is_empty())
+    {
+        set.push(assign(
+            "database_url",
+            crate::core::SqlValue::String(v.to_owned()),
+        ));
+    }
+
+    if set.is_empty() {
+        return Err(TenancyError::Validation(
+            "nothing to change — pass at least one field".into(),
+        ));
+    }
+
+    let update = crate::core::UpdateQuery {
+        model: Org::SCHEMA,
+        set,
+        where_clause: crate::core::WhereExpr::and_predicates(vec![crate::core::Filter {
+            column: "slug",
+            op: crate::core::Op::Eq,
+            value: crate::core::SqlValue::String(slug.to_owned()),
+        }]),
+    };
+    crate::sql::update_pool(registry, &update).await?;
+
+    // Before anything else acts on the write — see the module docs.
+    crate::tenancy::invalidate_org_cache();
+
+    Ok(Applied {
+        touched: patch.touched(),
+        database_url_rotated,
+    })
+}
+
+fn assign(column: &'static str, value: crate::core::SqlValue) -> crate::core::Assignment {
+    crate::core::Assignment {
+        column,
+        value: value.into(),
+    }
+}
+
+/// The nullable routing columns: absent means NULL, not "".
+fn string_or_null(v: Option<String>) -> crate::core::SqlValue {
+    v.map_or(crate::core::SqlValue::Null, crate::core::SqlValue::String)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_patch_is_refused_rather_than_run() {
+        assert!(OrgPatch::default().is_empty());
+        let p = OrgPatch {
+            display_name: Some("Acme".into()),
+            ..OrgPatch::default()
+        };
+        assert!(!p.is_empty());
+    }
+
+    /// The audit trail names the column, and the blank-clears-it case is
+    /// still a change worth recording.
+    #[test]
+    fn touched_lists_every_supplied_field() {
+        let p = OrgPatch {
+            display_name: Some(String::new()),
+            host_pattern: Some("shop.test".into()),
+            active: Some(false),
+            ..OrgPatch::default()
+        };
+        assert_eq!(p.touched(), vec!["display_name", "host_pattern", "active"]);
+    }
+
+    /// The routing columns are nullable, so clearing one means NULL — an
+    /// empty string there would be a value the resolver compares against.
+    #[test]
+    fn a_cleared_routing_column_becomes_null() {
+        assert!(matches!(string_or_null(None), crate::core::SqlValue::Null));
+        assert!(matches!(
+            string_or_null(Some("shop.test".into())),
+            crate::core::SqlValue::String(_)
+        ));
+    }
+}

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -935,7 +935,7 @@ fn validate_schema_name(name: &str) -> Result<(), String> {
 /// in doubt. The other two are refused: they mean the operator wants
 /// something this matcher does not do, and quietly storing a value that
 /// cannot match would be the worse answer.
-fn validate_host_pattern(pattern: &str) -> Result<String, String> {
+pub(crate) fn validate_host_pattern(pattern: &str) -> Result<String, String> {
     if pattern.contains(':') {
         return Err(format!(
             "host pattern `{pattern}` carries a port — the `Host` header is matched with the \
@@ -991,7 +991,7 @@ fn validate_host_pattern(pattern: &str) -> Result<String, String> {
 /// `"/<segment>"`. So a stored prefix that is not exactly one
 /// leading-slash segment — no slash, a second segment, a trailing slash
 /// — cannot be produced by that lookup and never matches.
-fn validate_path_prefix(prefix: &str) -> Result<(), String> {
+pub(crate) fn validate_path_prefix(prefix: &str) -> Result<(), String> {
     let Some(segment) = prefix.strip_prefix('/') else {
         return Err(format!(
             "path prefix `{prefix}` must start with `/` — the resolver looks up `/<segment>`"
@@ -1027,7 +1027,7 @@ fn validate_path_prefix(prefix: &str) -> Result<(), String> {
 /// `i32` is the column's type, not the range of a port. `-1` and
 /// `999999` both parsed and both stored, producing a tenant matched
 /// against a port no listener can ever have.
-fn validate_port(port: i32) -> Result<(), String> {
+pub(crate) fn validate_port(port: i32) -> Result<(), String> {
     if !(1..=65535).contains(&port) {
         return Err(format!(
             "port {port} is outside the 1–65535 a TCP port can be"

--- a/crates/rustango/tests/manage_edit_tenant_sqlite_live.rs
+++ b/crates/rustango/tests/manage_edit_tenant_sqlite_live.rs
@@ -1,0 +1,259 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! `edit-tenant` (#1344).
+//!
+//! Changing a tenant's routing was console-only, so moving one to a new
+//! hostname or rotating its credential meant a browser pointed at
+//! production.
+//!
+//! The risk in doing it from a second surface is not the UPDATE — it is
+//! forgetting what has to follow it. `tenancy::org_edit::apply` drops the
+//! cached `Org` after the write, because resolution serves from that
+//! cache and a stale read reports success while the next request still
+//! uses the old row.
+
+use std::sync::Arc;
+
+use rustango::core::Column as _;
+use rustango::sql::{sqlx, FetcherPool as _, Pool};
+use rustango::tenancy::{Org, TenantPools};
+
+struct Booted {
+    pools: Arc<TenantPools<sqlx::Sqlite>>,
+    registry: Pool,
+    url: String,
+    _tmp: tempfile::TempDir,
+    migrations: tempfile::TempDir,
+}
+
+async fn boot() -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    Booted {
+        pools,
+        registry,
+        url,
+        _tmp: tmp,
+        migrations,
+    }
+}
+
+impl Booted {
+    async fn run(&self, args: &[&str]) -> Result<String, String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+        rustango::tenancy::manage::run_with_writer(
+            self.pools.as_ref(),
+            &self.url,
+            self.migrations.path(),
+            argv,
+            &mut buf,
+        )
+        .await
+        .map(|()| String::from_utf8_lossy(&buf).into_owned())
+        .map_err(|e| e.to_string())
+    }
+
+    async fn tenant(&self, slug: &str) {
+        let db = self._tmp.path().join(format!("{slug}.db"));
+        self.run(&[
+            "create-tenant",
+            slug,
+            "--mode",
+            "database",
+            "--backend",
+            "sqlite",
+            "--database-url",
+            &format!("sqlite://{}?mode=rwc", db.display()),
+            "--display-name",
+            "Original",
+            "--no-migrate",
+        ])
+        .await
+        .unwrap_or_else(|e| panic!("create {slug}: {e}"));
+    }
+
+    async fn org(&self, slug: &str) -> Org {
+        Org::objects()
+            .where_(Org::slug.eq(slug.to_owned()))
+            .fetch(&self.registry)
+            .await
+            .expect("read org")
+            .into_iter()
+            .next()
+            .expect("the org")
+    }
+}
+
+#[tokio::test]
+async fn editing_one_field_leaves_the_others_alone() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let out = b
+        .run(&["edit-tenant", "acme", "--host-pattern", "shop.example.com"])
+        .await
+        .expect("edit");
+    assert!(
+        out.contains("host_pattern"),
+        "should name what changed: {out}"
+    );
+
+    let org = b.org("acme").await;
+    assert_eq!(org.host_pattern.as_deref(), Some("shop.example.com"));
+    assert_eq!(
+        org.display_name, "Original",
+        "an unmentioned field must not be wiped"
+    );
+}
+
+/// The stored value has to match a `Host` header byte-for-byte, so it is
+/// normalized on the way in rather than as typed.
+#[tokio::test]
+async fn a_host_pattern_is_normalized() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    b.run(&["edit-tenant", "acme", "--host-pattern", "SHOP.Example.COM"])
+        .await
+        .expect("edit");
+    assert_eq!(
+        b.org("acme").await.host_pattern.as_deref(),
+        Some("shop.example.com")
+    );
+}
+
+#[tokio::test]
+async fn a_value_the_resolver_could_never_match_is_refused() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    // A port in the pattern: the header is matched with the port stripped.
+    let err = b
+        .run(&["edit-tenant", "acme", "--host-pattern", "shop.test:8443"])
+        .await
+        .expect_err("port in pattern");
+    assert!(err.contains("port"), "{err}");
+
+    // A path prefix the PathPrefixResolver cannot produce.
+    let err = b
+        .run(&["edit-tenant", "acme", "--path-prefix", "no-leading-slash"])
+        .await
+        .expect_err("bad prefix");
+    assert!(err.contains('/'), "{err}");
+
+    let err = b
+        .run(&["edit-tenant", "acme", "--port", "70000"])
+        .await
+        .expect_err("out of range");
+    assert!(err.contains("65535"), "{err}");
+
+    // And none of it was written.
+    let org = b.org("acme").await;
+    assert!(org.host_pattern.is_none(), "nothing should have landed");
+}
+
+#[tokio::test]
+async fn clear_empties_a_field_that_was_set() {
+    let b = boot().await;
+    b.tenant("acme").await;
+    b.run(&["edit-tenant", "acme", "--host-pattern", "shop.example.com"])
+        .await
+        .expect("set");
+
+    b.run(&["edit-tenant", "acme", "--clear", "host-pattern"])
+        .await
+        .expect("clear");
+    assert!(
+        b.org("acme").await.host_pattern.is_none(),
+        "should be NULL, not an empty string"
+    );
+}
+
+#[tokio::test]
+async fn activate_and_deactivate_flip_the_column() {
+    let b = boot().await;
+    b.tenant("acme").await;
+    assert!(b.org("acme").await.active);
+
+    b.run(&["edit-tenant", "acme", "--deactivate"])
+        .await
+        .expect("deactivate");
+    assert!(!b.org("acme").await.active);
+
+    b.run(&["edit-tenant", "acme", "--activate"])
+        .await
+        .expect("activate");
+    assert!(b.org("acme").await.active);
+}
+
+/// Rotating the URL says the pool was evicted; changing a display name
+/// must not, or every edit would throw away warm connections.
+#[tokio::test]
+async fn only_a_real_url_change_evicts_the_pool() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let out = b
+        .run(&["edit-tenant", "acme", "--display-name", "Acme Inc"])
+        .await
+        .expect("rename");
+    assert!(!out.contains("evicted"), "{out}");
+
+    let fresh = b._tmp.path().join("acme2.db");
+    let out = b
+        .run(&[
+            "edit-tenant",
+            "acme",
+            "--database-url",
+            &format!("sqlite://{}?mode=rwc", fresh.display()),
+        ])
+        .await
+        .expect("rotate");
+    assert!(out.contains("evicted"), "{out}");
+
+    // Re-supplying the same URL is not a rotation.
+    let same = b.org("acme").await.database_url.expect("a url");
+    let out = b
+        .run(&["edit-tenant", "acme", "--database-url", &same])
+        .await
+        .expect("no-op rotate");
+    assert!(
+        !out.contains("evicted"),
+        "unchanged is not a rotation: {out}"
+    );
+}
+
+#[tokio::test]
+async fn an_edit_with_nothing_to_change_is_refused() {
+    let b = boot().await;
+    b.tenant("acme").await;
+
+    let err = b.run(&["edit-tenant", "acme"]).await.expect_err("empty");
+    assert!(err.contains("at least one field"), "{err}");
+}
+
+#[tokio::test]
+async fn an_unknown_tenant_is_named() {
+    let b = boot().await;
+    let err = b
+        .run(&["edit-tenant", "nosuchtenant", "--activate"])
+        .await
+        .expect_err("unknown");
+    assert!(err.contains("nosuchtenant"), "{err}");
+}


### PR DESCRIPTION
Part of #1344. Stacked on the inspection slice. Completes #1344's four items.

Routing and display config have been editable from the console since v0.25 and from nowhere else, so moving a tenant to a new hostname or rotating its credential meant a browser pointed at production.

```
edit-tenant <slug> [--display-name|--host-pattern|--path-prefix|--port|--database-url <v>]
                   [--activate|--deactivate] [--clear <field>]
```

Only named fields are touched. That distinction is the whole design: *leave alone* and *clear it* are different instructions, and a patch that cannot tell them apart wipes columns on every edit. `--clear` spells the second without relying on `--x ""`, which shells and CI runners eat.

### The risk is not the UPDATE

It is what has to follow it. `tenancy::org_edit::apply` writes, then drops the cached `Org` — resolution serves from that cache, so skipping it makes a rotation report success while the next request reconnects on the old credential, and `--deactivate` keeps serving. That step is invisible in testing, because the stale read only appears on *another* request. So it lives in the engine rather than in each caller.

Pool eviction stays with the caller: `TenantPools` is generic over the backend, and it must fire only on a real URL change or every rename would throw away warm connections. Re-supplying the same URL is not a rotation.

### Validation

Reuses the provisioning validators (now `pub(crate)`), so a value `edit-tenant` accepts is one `create-tenant` would have accepted — a host pattern carrying a port, or a path prefix the resolver cannot produce, is refused rather than stored to never match.

`display_name` is NOT NULL where the routing columns are nullable, so it takes the empty string rather than NULL and is not in `--clear`'s list.
