### PR TITLE
feat(tenancy): pre-warm pools from the console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,8 @@ jobs:
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_audit_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_migrate_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_decommission_sqlite_live
+      # #1341 — pre-warming pools from the console, which was CLI-only.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test operator_console_prewarm_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test provision_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test provision_store_sqlite_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy,testkit --test org_hosts_sqlite_live

--- a/crates/rustango/src/tenancy/operator_console/mod.rs
+++ b/crates/rustango/src/tenancy/operator_console/mod.rs
@@ -635,6 +635,15 @@ fn router_inner(
             // things, and creating an operator is emphatically the
             // latter.
             .route("/operators", post(operators::operator_create))
+            // #1341 — opening every tenant's pool up front was CLI-only,
+            // so the one thing worth doing right after a deploy, a
+            // registry restart, or a credential rotation needed shell
+            // access. Gated on pools rather than on the provisioner:
+            // warming them needs no migrations directory.
+            .route(
+                "/orgs/prewarm",
+                get(orgs_post_only_redirect).post(prewarm_pools),
+            )
             .route(
                 "/operators/{id}/active",
                 get(op_post_only_redirect).post(operators::operator_set_active),
@@ -1036,6 +1045,69 @@ async fn org_post_only_redirect(
 /// rather than slug and land back on the one list page.
 async fn op_post_only_redirect() -> Redirect {
     Redirect::to("/operators")
+}
+
+async fn orgs_post_only_redirect() -> Redirect {
+    Redirect::to("/orgs")
+}
+
+/// Open a pool for every active database-mode tenant (#1341).
+///
+/// Worth doing right after a deploy or a registry restart, and after a
+/// credential rotation — it turns "the first request to each tenant pays
+/// the connect" into one deliberate wait, and surfaces an unreachable
+/// tenant before a user finds it.
+///
+/// The report is a notice rather than a page: there is nothing to browse,
+/// and PRG keeps a reload from re-opening every pool.
+async fn prewarm_pools(
+    State(state): State<ConsoleState>,
+    Extension(op): Extension<auth::Operator>,
+) -> Response<Body> {
+    let Some(pools) = state.pools.as_ref() else {
+        return orgs_notice("pool management is not available on this console", true);
+    };
+    let report = match pools.prewarm().await {
+        Ok(r) => r,
+        Err(e) => return orgs_notice(&format!("pre-warm failed: {e}"), true),
+    };
+
+    let mut detail = serde_json::Map::new();
+    detail.insert("action".into(), serde_json::json!("pools.prewarm"));
+    detail.insert("warmed".into(), serde_json::json!(report.warmed));
+    detail.insert("failed".into(), serde_json::json!(report.failed));
+    emit_registry_audit(
+        &state.registry,
+        "rustango_orgs",
+        "*",
+        op.id.get().copied().unwrap_or(0),
+        "prewarm",
+        detail,
+    )
+    .await;
+
+    // A failure here is per-tenant and already logged by the pool layer;
+    // say how many so the operator knows to go looking.
+    let mut msg = format!(
+        "warmed {} of {} active database-mode tenant(s)",
+        report.warmed, report.total_active
+    );
+    if report.failed > 0 {
+        msg.push_str(&format!(" — {} failed, see the logs", report.failed));
+    }
+    if report.skipped_cap > 0 {
+        msg.push_str(&format!(
+            " — {} skipped, the pool cache is at its cap",
+            report.skipped_cap
+        ));
+    }
+    orgs_notice(&msg, report.failed > 0)
+}
+
+/// PRG back to the tenant list with a message.
+fn orgs_notice(msg: &str, is_error: bool) -> Response<Body> {
+    let key = if is_error { "error" } else { "notice" };
+    Redirect::to(&format!("/orgs?{key}={}", urlencoding_lite(msg))).into_response()
 }
 
 /// v0.27.10 (#68) — when an unauthenticated non-GET request

--- a/crates/rustango/src/tenancy/pools.rs
+++ b/crates/rustango/src/tenancy/pools.rs
@@ -560,6 +560,22 @@ pub trait TenantPoolInvalidator: Send + Sync {
                 + 'a,
         >,
     >;
+
+    /// Open a pool for every active database-mode tenant, up front.
+    ///
+    /// Here for the same reason as `decommission`: it is the same
+    /// erasure, and a surface that can invalidate pools is one that can
+    /// warm them. Without it `prewarm-pools` stays command-line only,
+    /// which is the gap #1341 is about.
+    fn prewarm<'a>(
+        &'a self,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<PrewarmReport, super::error::TenancyError>>
+                + Send
+                + 'a,
+        >,
+    >;
 }
 
 impl<DB: Database> TenantPoolInvalidator for TenantPools<DB>
@@ -599,6 +615,18 @@ where
         >,
     > {
         Box::pin(async move { super::decommission::decommission(self, slug, action).await })
+    }
+
+    fn prewarm<'a>(
+        &'a self,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<PrewarmReport, super::error::TenancyError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move { TenantPools::<DB>::prewarm_database_tenants(self).await })
     }
 }
 

--- a/crates/rustango/src/tenancy/templates/op_orgs.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs.html
@@ -8,15 +8,18 @@
 {% if error %}<div class="alert alert-error">{{ error }}</div>{% endif %}
 {% if notice %}<div class="alert alert-notice">{{ notice }}</div>{% endif %}
 
+{#- A div, not a p: `<form>` is not phrasing content, so the HTML parser
+    closes an open `<p>` when it meets one — the actions row split in two
+    and left stray empty paragraphs on the page. -#}
 {% if provisioning_enabled %}
-<p class="page-actions">
+<div class="page-actions">
   <a href="/orgs/new" class="btn btn-primary">+ New tenant</a>
   <a href="/orgs/provision" class="btn btn-secondary">Runs</a>
   <form method="post" action="/orgs/migrate" class="inline-form"
         onsubmit="return confirm('Run migrations for every active tenant?');">
     <button type="submit" class="btn btn-secondary">Migrate all tenants</button>
   </form>
-</p>
+</div>
 <p>Tenants the registry knows about. Create one here, or from the CLI
 with <code>cargo run -- create-tenant</code>; removal is
 <code>cargo run -- drop-tenant</code>.</p>
@@ -27,6 +30,17 @@ with <code>cargo run -- create-tenant</code>; removal is
 <code>rustango::manage::Cli</code>). To create tenants from here, add
 <code>.with_tenant_provisioning("migrations")</code> to the
 <code>Cli</code> builder.</p>
+{% endif %}
+
+{#- Pre-warming needs pools, not a provisioner, so it is its own block:
+    a console wired for edits but not provisioning still gets it. -#}
+{% if edit_enabled %}
+<div class="page-actions">
+  <form method="post" action="/orgs/prewarm" class="inline-form"
+        onsubmit="return confirm('Open a connection for every active database-mode tenant? This can take a moment.');">
+    <button type="submit" class="btn btn-secondary">Pre-warm pools</button>
+  </form>
+</div>
 {% endif %}
 {% if orgs | length == 0 %}
   {% if provisioning_enabled %}

--- a/crates/rustango/src/tenancy/templates/op_orgs_edit.html
+++ b/crates/rustango/src/tenancy/templates/op_orgs_edit.html
@@ -27,7 +27,8 @@
     field. The extra hostnames it can also answer on are a collection
     with their own verbs, so they live on their own page — which needs
     a link from here, or nothing reaches it. -#}
-<p class="page-actions">
+{#- A div, not a p — see op_orgs.html: a `<form>` closes an open `<p>`. -#}
+<div class="page-actions">
   <a href="/orgs/{{ slug }}/hosts" class="btn btn-secondary">Hostnames →</a>
   <button type="button" class="btn btn-secondary" id="test-connection">Test connection</button>
   <span id="probe-result"></span>
@@ -37,7 +38,7 @@
     <button type="submit" class="btn btn-secondary">Run migrations</button>
   </form>
   {% endif %}
-</p>
+</div>
 
 <form method="post" action="/orgs/{{ slug }}/edit" class="edit-form">
 

--- a/crates/rustango/tests/operator_console_prewarm_sqlite_live.rs
+++ b/crates/rustango/tests/operator_console_prewarm_sqlite_live.rs
@@ -1,0 +1,278 @@
+#![cfg(all(feature = "sqlite", feature = "tenancy"))]
+//! Pre-warming tenant pools from the operator console (#1341).
+//!
+//! `prewarm-pools` was command-line only, so the one thing worth doing
+//! right after a deploy, a registry restart, or a credential rotation
+//! needed shell access to the production host.
+//!
+//! End to end through the real router, because the failure this guards
+//! against is not the engine — `TenantPools::prewarm_database_tenants`
+//! shipped in v0.27.7 — it is the surface: no route, no button, no link.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rustango::sql::{sqlx, Auto};
+use rustango::tenancy::operator_console::{router, router_with_pools, SessionSecret};
+use rustango::tenancy::{Org, TenantPools};
+use tower::ServiceExt;
+
+static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}-{}",
+        std::process::id(),
+        UNIQ.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+struct Booted {
+    app: axum::Router,
+    cookie: String,
+    _tmp: tempfile::TempDir,
+    _migrations: tempfile::TempDir,
+}
+
+/// `edit` decides whether the console gets pool-holding routes at all.
+async fn boot(edit: bool) -> Booted {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().join("reg.db").display());
+    let pool = sqlx::SqlitePool::connect(&url).await.expect("connect");
+    let pools = Arc::new(TenantPools::<sqlx::Sqlite>::new(pool));
+    let migrations = tempfile::tempdir().expect("migrations dir");
+
+    let mut buf: Vec<u8> = Vec::new();
+    rustango::tenancy::manage::run_with_writer(
+        pools.as_ref(),
+        &url,
+        migrations.path(),
+        vec!["migrate-registry".to_owned()],
+        &mut buf,
+    )
+    .await
+    .expect("migrate-registry");
+
+    let registry = pools.registry_pool();
+    let username = unique("op");
+    let password = "letmein";
+    let mut op = rustango::tenancy::Operator {
+        id: Auto::default(),
+        username: username.clone(),
+        password_hash: rustango::tenancy::password::hash(password).unwrap(),
+        active: true,
+        created_at: chrono::Utc::now(),
+        password_changed_at: None,
+    };
+    op.insert_pool(&registry).await.expect("seed operator");
+
+    // Two database-mode tenants with reachable files — pre-warm only
+    // walks database-mode, and these are what it should open.
+    for i in 0..2 {
+        let slug = unique(&format!("t{i}"));
+        let db = tmp.path().join(format!("{slug}.db"));
+        let mut org = Org {
+            id: Auto::default(),
+            slug: slug.clone(),
+            display_name: slug.clone(),
+            storage_mode: "database".into(),
+            backend_kind: "sqlite".into(),
+            database_url: Some(format!("sqlite://{}?mode=rwc", db.display())),
+            schema_name: None,
+            host_pattern: None,
+            port: None,
+            path_prefix: None,
+            active: true,
+            created_at: chrono::Utc::now(),
+            brand_name: None,
+            brand_tagline: None,
+            logo_path: None,
+            favicon_path: None,
+            primary_color: None,
+            theme_mode: None,
+        };
+        org.insert_pool(&registry).await.expect("seed org");
+    }
+
+    let app = if edit {
+        router_with_pools(
+            registry.clone(),
+            pools.clone(),
+            SessionSecret::from_env_or_random(),
+        )
+    } else {
+        router(registry.clone(), SessionSecret::from_env_or_random())
+    };
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(format!(
+                    "username={username}&password={password}"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie")
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_owned();
+
+    Booted {
+        app,
+        cookie,
+        _tmp: tmp,
+        _migrations: migrations,
+    }
+}
+
+async fn body_of(resp: axum::response::Response) -> String {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+impl Booted {
+    async fn get(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn post(&self, uri: &str) -> axum::response::Response {
+        self.app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("cookie", &self.cookie)
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+}
+
+/// The gap was a missing surface, not a missing engine — so the button
+/// being on the page is the assertion that matters.
+#[tokio::test]
+async fn the_tenant_list_offers_a_prewarm_button() {
+    let b = boot(true).await;
+    let html = body_of(b.get("/orgs").await).await;
+    assert!(
+        html.contains(r#"action="/orgs/prewarm""#),
+        "the orgs page should post to the prewarm route: {html}"
+    );
+    assert!(html.contains("Pre-warm pools"), "{html}");
+}
+
+#[tokio::test]
+async fn prewarming_reports_how_many_it_opened() {
+    let b = boot(true).await;
+    let resp = b.post("/orgs/prewarm").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::SEE_OTHER,
+        "should redirect, so a reload does not re-open every pool"
+    );
+    let location = resp
+        .headers()
+        .get("location")
+        .expect("a redirect")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(location.starts_with("/orgs?notice="), "{location}");
+    assert!(
+        location.contains("warmed") && location.contains('2'),
+        "both tenants should have been warmed: {location}"
+    );
+}
+
+/// A read-only console holds no pools, so it must not offer the button
+/// or accept the POST.
+#[tokio::test]
+async fn a_read_only_console_neither_shows_nor_accepts_it() {
+    let b = boot(false).await;
+
+    let html = body_of(b.get("/orgs").await).await;
+    assert!(
+        !html.contains("/orgs/prewarm"),
+        "a read-only console should not offer it: {html}"
+    );
+
+    let resp = b.post("/orgs/prewarm").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "the route should not be mounted at all"
+    );
+}
+
+/// The write routes are behind a session like everything else.
+#[tokio::test]
+async fn prewarm_requires_a_session() {
+    let b = boot(true).await;
+    let resp = b
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/orgs/prewarm")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // The session middleware also answers with a 303, so the status alone
+    // proves nothing — where it points is the difference between "sign in"
+    // and "pre-warmed every pool for you".
+    let location = resp
+        .headers()
+        .get("location")
+        .map(|v| v.to_str().unwrap().to_owned())
+        .unwrap_or_default();
+    assert!(
+        location.starts_with("/login"),
+        "an unauthenticated POST should bounce to login, got `{location}` \
+         with status {}",
+        resp.status()
+    );
+}
+
+/// A stray GET bounces back instead of 405ing — the same treatment the
+/// other POST-only console routes get after a session-expiry replay.
+#[tokio::test]
+async fn a_get_bounces_back_to_the_list() {
+    let b = boot(true).await;
+    let resp = b.get("/orgs/prewarm").await;
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get("location").unwrap().to_str().unwrap(),
+        "/orgs"
+    );
+}


### PR DESCRIPTION
Part of #1341. Stacked on #1344's edit-tenant slice.

`prewarm-pools` was command-line only, so the one thing worth doing right after a deploy, a registry restart, or a credential rotation needed shell access to the production host.

The engine shipped in v0.27.7. What was missing was a route, a button and a link — so the test goes through the real router and asserts the **button is on the page**, not just that the handler works.

`prewarm` joins `TenantPoolInvalidator` next to `decommission`: same erasure, same capability, and a surface that can invalidate pools is one that can warm them. Gated on pools rather than on the provisioner, because warming needs no migrations directory — a console wired for edits but not provisioning still gets it.

POST behind the edit gate, PRG so a reload does not re-open every pool, and the report lands as a notice since there is nothing to browse.

Verified against a real Postgres registry with four tenants, two of them schema-mode:

> warmed 2 of 2 active database-mode tenant(s)

…with an audit row for it.

### Also: invalid markup the button sat in

`<form>` is not phrasing content, so the HTML parser closes an open `<p>` when it meets one. The actions row on both the tenant list and the tenant edit page was splitting in two and leaving stray empty paragraphs — visible in an accessibility snapshot of the live page. Both are `<div>`s now; `.page-actions` only sets a margin, so nothing else changes.

### Not in this PR

`migrate-tenant-storage` is the one #1341 item still open. It shells out to `pg_dump | psql`, moves tenant data and then rewrites `storage_mode`/`database_url`/`schema_name` — a partial failure is split-brain. Those client tools are not installed on the machine this was developed on, so the data move could not be exercised end to end, and a destructive operation newly reachable from a web button is the last thing to ship on unit tests alone. Reasoning and a concrete plan are on #1341.
