### PR TITLE
docs: point the translated tables of contents at the translated headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,55 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   user-app migration only ever claims user tables. `make_migrations_system` is
   deliberately unchanged: there the `rustango_*` tables *are* the subject.
 
+- **`manage menu` hung forever on every verb that prompts for its own values**
+  (#1360). The menu held `io::stdin().lock()` while dispatching, and the verbs
+  it dispatches to call `io::stdin()` themselves — the second lock waited on the
+  first, which the menu would not release until the verb returned. Every
+  interactive verb was unreachable from the menu that exists to reach them.
+  Prompting now goes through a `LineSource`, and `SharedStdin` takes the lock
+  per read rather than for the life of the menu.
+
+- **`manage menu` ran off a terminal** (#1357). Piped or in CI it printed its
+  numbered choices to nobody, read EOF as a selection, executed something, and
+  exited 0. It now refuses a non-TTY with a message naming the flags instead.
+
+- **Contradictory and unrecognized boolean flags silently picked a side**
+  (#1355). `edit-tenant --activate --deactivate` took the tenant *offline* and
+  returned 0 — last flag wins, no warning, on the one pair where guessing wrong
+  is an outage. Both directions given is now an error. Separately,
+  `set-host-enabled --enabled TRUE` parked the host: the allow-list was
+  lowercase-only and anything unmatched fell through to "false". The set is
+  closed and case-insensitive now, and a value outside it is rejected.
+
+- **Errors named the wrong object, and bad filters looked like empty results**
+  (#1356). A single `HostError::NotFound` covered both "no such tenant" and "no
+  such hostname", so a typo'd slug reported a missing *host*. Split into
+  `NoSuchOrg`. Filters on `list-runs` / `audit-log` took any string and returned
+  nothing for a value no row could hold — an unrecognized kind or state is now
+  refused with the valid set.
+
+- **`cargo rustango new` accepted four names that produce an unloadable
+  project** (#1358). `build`, `deps`, `examples` and `incremental` are Cargo's
+  own subdirectories of `target/`, so a crate by those names collides with the
+  build directory it compiles into. Refused up front rather than at the first
+  `cargo run`.
+
+- **The generated `.env.example` shipped a session secret the framework
+  discards** (#1359). It carried a placeholder `RUSTANGO_SESSION_SECRET` short
+  enough to fail the length check, which `from_env_or_disk` handled by silently
+  falling back to a random key — so sessions died on every restart and the
+  `.env` said otherwise. The line is commented out with the length requirement
+  beside it, and an unusable secret now warns instead of vanishing.
+
+- **Every in-page link in the `de` / `fr` / `es` docs pointed at an English
+  anchor** (#1354). The translations translated their headings and kept the
+  English `#fragment`s, so 930 links across 94 pages — every table of contents,
+  plus the cross-page links into `manage.md`, `glossary.md` and `orm.md` — put
+  the reader at the top of the page instead. `docs_links` skipped fragments by
+  design; it now derives each heading's id the way GitHub and the docs site do
+  and asserts every fragment finds one. The rule is validated by the English
+  pages resolving 100% under it.
+
 ## [0.56.1] — 2026-09-04
 
 Documentation fixes. No code changes — the crate is byte-for-byte 0.56.0

--- a/crates/rustango/tests/docs_links.rs
+++ b/crates/rustango/tests/docs_links.rs
@@ -72,6 +72,100 @@ fn link_targets(text: &str) -> Vec<String> {
     out
 }
 
+/// The id a heading gets, GitHub-style — which is what the docs site and
+/// GitHub both use.
+///
+/// Lowercase, drop punctuation but keep Unicode letters, spaces to
+/// hyphens. A dropped separator leaves its spaces behind, so `Auth &
+/// tenancy` becomes `auth--tenancy` with two hyphens.
+///
+/// Verified against the English pages, which resolve 100% under this rule
+/// (#1354). That is what makes it safe to assert on the translations.
+fn heading_slug(heading: &str) -> String {
+    heading
+        .trim()
+        .to_lowercase()
+        .replace('`', "")
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-' || *c == '_')
+        .collect::<String>()
+        .replace(' ', "-")
+}
+
+/// Every heading id a page offers.
+fn heading_ids(text: &str) -> HashSet<String> {
+    text.lines()
+        .filter_map(|l| {
+            let t = l.trim_end();
+            let rest = t.trim_start_matches('#');
+            // A heading is `#`+ then a space; `#!/bin/sh` inside a fence is not.
+            (t.starts_with('#') && rest.starts_with(' ')).then(|| heading_slug(rest))
+        })
+        .collect()
+}
+
+/// `#fragment` links must resolve too (#1354).
+///
+/// The translations translated their **headings** and kept the **English
+/// anchors**, so every table of contents in `de` / `fr` / `es` pointed at
+/// ids that exist only in the English file — 886 dead links across 91
+/// pages, invisible to the check below because it skips fragments.
+#[test]
+fn every_anchor_resolves_in_every_locale() {
+    let root = repo_root();
+    let published = published_pages(&root);
+    let mut problems = Vec::new();
+
+    for locale_dir in ["docs", "docs/de", "docs/es", "docs/fr"] {
+        for page in &published {
+            let path = root.join(locale_dir).join(page);
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let own = heading_ids(&text);
+            for target in link_targets(&text) {
+                if target.starts_with("http") || target.starts_with("mailto") {
+                    continue;
+                }
+                let (file, anchor) = match target.split_once('#') {
+                    Some((f, a)) if !a.is_empty() => (f, a),
+                    _ => continue,
+                };
+                // Same page, or a heading in a sibling page.
+                let ids = if file.is_empty() {
+                    own.clone()
+                } else {
+                    let sibling = path.parent().expect("parent").join(file);
+                    match std::fs::read_to_string(&sibling) {
+                        Ok(t) => heading_ids(&t),
+                        // A missing file is the other test's business.
+                        Err(_) => continue,
+                    }
+                };
+                if !ids.contains(anchor) {
+                    problems.push(format!(
+                        "{locale_dir}/{page}: `#{anchor}`{} matches no heading",
+                        if file.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" in {file}")
+                        }
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "{} dead anchor(s):\n  {}\n\nThe id is the heading text: lowercased, \
+         punctuation dropped, spaces to hyphens. Translating a heading changes \
+         its id, so the links pointing at it have to move too.",
+        problems.len(),
+        problems.join("\n  "),
+    );
+}
+
 #[test]
 fn every_published_doc_link_resolves_in_every_locale() {
     let root = repo_root();

--- a/docs/de/admin.md
+++ b/docs/de/admin.md
@@ -28,16 +28,16 @@ auf Modulebene.
 ---
 
 ## Inhaltsverzeichnis
-- [Einbinden](#mount-it) · [Die Startseite](#the-home-page)
-- [Ein Modell konfigurieren: der `admin(...)`-Block](#configure-a-model-the-admin-block)
-- [Die Listenansicht](#the-list-view) — Spalten, Suche, Filter, Datumshierarchie, Sortierung, Paginierung
-- [Das Änderungsformular](#the-change-form) — Feldgruppen, Widgets, FK-Bearbeitung, vorbefüllte & schreibgeschützte Felder
-- [Inlines](#inlines) · [Massenaktionen](#bulk-actions) · [Prüfpfad](#audit-trail)
-- [Berechnete Spalten & benutzerdefinierte Filter](#computed-columns-and-custom-filters)
-- [Benutzerdefinierte Views, Querysets & Berechtigungen](#custom-views-querysets-and-permissions)
-- [Authentifizierung](#authentication) · [Theming & Branding](#theming-and-branding)
-- [`Builder`-Referenz](#builder-reference) · [Routen-Referenz](#routes-reference)
-- [Die Modellreferenz (`__docs`)](#the-model-reference) · [Das Beispiel ausprobieren](#try-the-example)
+- [Einbinden](#einbinden) · [Die Startseite](#die-startseite)
+- [Ein Modell konfigurieren: der `admin(...)`-Block](#ein-modell-konfigurieren-der-admin-block)
+- [Die Listenansicht](#die-listenansicht) — Spalten, Suche, Filter, Datumshierarchie, Sortierung, Paginierung
+- [Das Änderungsformular](#das-änderungsformular) — Feldgruppen, Widgets, FK-Bearbeitung, vorbefüllte & schreibgeschützte Felder
+- [Inlines](#inlines) · [Massenaktionen](#massenaktionen) · [Prüfpfad](#prüfpfad)
+- [Berechnete Spalten & benutzerdefinierte Filter](#berechnete-spalten-und-benutzerdefinierte-filter)
+- [Benutzerdefinierte Views, Querysets & Berechtigungen](#benutzerdefinierte-views-querysets-und-berechtigungen)
+- [Authentifizierung](#authentifizierung) · [Theming & Branding](#theming-und-branding)
+- [`Builder`-Referenz](#builder-referenz) · [Routen-Referenz](#routen-referenz)
+- [Die Modellreferenz (`__docs`)](#die-modellreferenz) · [Das Beispiel ausprobieren](#das-beispiel-ausprobieren)
 
 ---
 
@@ -46,7 +46,7 @@ auf Modulebene.
 > **Das Admin ist standardmäßig offen.** Es erkennt und liefert *jedes* Modell
 > automatisch — auflisten, erstellen, bearbeiten, löschen — ohne Authentifizierung,
 > bis du sie hinzufügst. Mache es nicht öffentlich zugänglich, bevor du das Login
-> verdrahtet hast: siehe [Authentifizierung](#authentication) weiter unten.
+> verdrahtet hast: siehe [Authentifizierung](#authentifizierung) weiter unten.
 
 Das Admin ist ein `axum::Router`, den du aus einem Datenbank-Pool baust und unter
 einen Pfad einhängst:
@@ -133,13 +133,13 @@ den Listen anderer Modelle, der Breadcrumb, der Titel der Detailseite.
 | `list_per_page` | `10` | Seitengröße (Standard 50). |
 | `date_hierarchy` | `"published_at"` | Aufschlüsselungsleiste Jahr → Monat → Tag über der Liste, auf einer Date-/DateTime-Spalte. |
 | `fieldsets` | `"Content: title, body \| Meta: status"` | Gliedert das Änderungsformular in benannte Abschnitte. Pipe `\|` trennt Abschnitte, Komma trennt Felder; die `Title:`-Legende ist optional. |
-| `actions` | `"publish, archive"` | Massenaktionen, die im Aktionsauswähler der Liste angeboten werden (jede benötigt einen registrierten Handler — siehe [Massenaktionen](#bulk-actions)). |
+| `actions` | `"publish, archive"` | Massenaktionen, die im Aktionsauswähler der Liste angeboten werden (jede benötigt einen registrierten Handler — siehe [Massenaktionen](#massenaktionen)). |
 | `readonly_fields` | `"created_at"` | Felder, die im Änderungsformular als Text (ohne Eingabe) gerendert werden. |
 | `raw_id_fields` | `"author_id"` | FK-Felder, die über eine reine ID-Eingabe + Nachschlage-Link bearbeitet werden (gut für große Zieltabellen). |
 | `autocomplete_fields` | `"author_id"` | FK-Felder, die über eine Ajax-Vervollständigung bearbeitet werden, gestützt auf den `__autocomplete`-Endpunkt des Ziels. |
 | `prepopulated_fields` | `"slug:title"` | Ein Feld automatisch befüllen, indem ein anderes beim Tippen sluggifiziert wird (`target:source`; kombiniere Quellen mit `+`). |
 | `list_select_related` | `"all"` / `"none"` / `"author_id"` | Steuert das automatische JOIN von FK-Spalten in der Listenabfrage. `"all"` (Standard) joint jeden FK; `"none"` deaktiviert; ein CSV beschränkt auf benannte FKs. |
-| `formfield_overrides` | `"status:textarea"` | Überschreibt das Formular-Widget eines Feldes (`field:widget`) — siehe die [Widget-Tabelle](#form-widgets). |
+| `formfield_overrides` | `"status:textarea"` | Überschreibt das Formular-Widget eines Feldes (`field:widget`) — siehe die [Widget-Tabelle](#formular-widgets). |
 | `actions_on_top` | `true` | Rendert die Massenaktionsleiste über der Liste (Standard `true`). |
 | `actions_on_bottom` | `false` | Rendert eine zweite Aktionsleiste unter der Liste (Standard `false`). |
 

--- a/docs/de/api-conventions.md
+++ b/docs/de/api-conventions.md
@@ -8,18 +8,18 @@ Diese Seite erklärt die Muster, denen die API von **Rustango** folgt, damit Sie
 
 ## Inhaltsverzeichnis
 
-- [Naming](#naming)
-- [Constructors](#constructors)
-- [Return types](#return-types)
+- [Naming](#namensgebung)
+- [Constructors](#konstruktoren)
+- [Return types](#rückgabetypen)
 - [Async vs sync](#async-vs-sync)
-- [The pool argument](#the-pool-argument)
-- [Filtering](#filtering)
-- [Errors](#errors)
-- [Module naming](#module-naming)
-- [Builders vs config structs](#builders-vs-config-structs)
+- [The pool argument](#das-pool-argument)
+- [Filtering](#filtern)
+- [Errors](#fehler)
+- [Module naming](#modul-namensgebung)
+- [Builders vs config structs](#builder-vs-config-structs)
 - [Feature flags](#feature-flags)
-- [Macros vs runtime](#macros-vs-runtime)
-- [Contributing](#contributing)
+- [Macros vs runtime](#makros-vs-laufzeit)
+- [Contributing](#mitwirken)
 
 ---
 
@@ -311,7 +311,7 @@ Wenn Sie ein neues Feature hinzufügen, befolgen Sie diese Schritte:
 5. **Platzieren Sie Unit-Tests in derselben Datei**, hinter `#[cfg(test)] mod tests` — keine Datenbank, es sei denn, Sie brauchen wirklich eine.
 6. **Platzieren Sie Integrationstests in `crates/rustango/tests/<name>.rs`** für die End-to-End-Geschichte.
 7. **Fügen Sie keinen neuen Fehlertyp hinzu, es sei denn, die bestehenden passen nicht** — erweitern Sie zuerst eine bestehende Enum.
-8. **Folgen Sie dem [Rückgabetyp-Leitfaden](#return-types)** bei der Wahl zwischen `Result`, `Option` oder `bool`.
+8. **Folgen Sie dem [Rückgabetyp-Leitfaden](#rückgabetypen)** bei der Wahl zwischen `Result`, `Option` oder `bool`.
 9. **Fügen Sie einen `manage`-Unterbefehl hinzu?** Verdrahten Sie ihn in den `match cmd`-Dispatcher und `print_help`, fügen Sie einen Test in `crates/rustango/tests/migrate_manage.rs` hinzu und dokumentieren Sie eine Zeile in `docs/manage.md`.
 10. **Aktualisieren Sie `CHANGELOG.md`** mit einem `Added`-Eintrag unter der nächsten Version.
 

--- a/docs/de/auth-api-keys.md
+++ b/docs/de/auth-api-keys.md
@@ -28,13 +28,13 @@ das Schlüssel speichert und `Authorization: Bearer`-Anfragen authentifiziert.
 
 ## Inhaltsverzeichnis
 
-- [Wie ein API-Schlüssel funktioniert](#how-an-api-key-works)
-- [Der eigenständige Helfer](#the-standalone-helper)
-- [Das speichernde Backend](#the-stored-backend)
-- [Einen Schlüssel ausstellen (CLI + Code)](#issuing-a-key)
-- [Anfragen authentifizieren](#authenticating-requests)
-- [Sicherheitshinweise](#security-notes)
-- [Siehe auch](#see-also)
+- [Wie ein API-Schlüssel funktioniert](#wie-ein-api-schlüssel-funktioniert)
+- [Der eigenständige Helfer](#der-eigenständige-helfer)
+- [Das speichernde Backend](#das-speichernde-backend)
+- [Einen Schlüssel ausstellen (CLI + Code)](#einen-schlüssel-ausstellen)
+- [Anfragen authentifizieren](#anfragen-authentifizieren)
+- [Sicherheitshinweise](#sicherheitshinweise)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/auth-backends.md
+++ b/docs/de/auth-backends.md
@@ -25,12 +25,12 @@ abzusichern, und dem `CurrentUser`-Extraktor, um das Ergebnis zu lesen.
 
 ## Inhaltsverzeichnis
 
-- [Die Kette](#the-chain) · [Die eingebauten Backends](#the-built-in-backends)
-- [Routen absichern: require_auth](#gating-routes-require_auth)
-- [Den Benutzer lesen: CurrentUser](#reading-the-user-currentuser)
-- [Berechtigungen: require_perm](#permissions-require_perm)
-- [Die portable Registry](#the-portable-registry)
-- [Siehe auch](#see-also)
+- [Die Kette](#die-kette) · [Die eingebauten Backends](#die-eingebauten-backends)
+- [Routen absichern: require_auth](#routen-absichern-require_auth)
+- [Den Benutzer lesen: CurrentUser](#den-benutzer-lesen-currentuser)
+- [Berechtigungen: require_perm](#berechtigungen-require_perm)
+- [Die portable Registry](#die-portable-registry)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/auth-decorators.md
+++ b/docs/de/auth-decorators.md
@@ -26,10 +26,10 @@ beantwortet (API-Ablauf) —, bevor sie je den Handler erreichen.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) · [Browser- vs. API-Gatter](#browser-vs-api-gates)
-- [Die Gatter-Familie](#the-gate-family) · [Prädikat- und Rollen-Gatter](#predicate-and-role-gates)
-- [Berechtigungs-Gatter](#permission-gates) · [Der `?next=`-Umlauf](#the-next-round-trip)
-- [Hinweise und Grenzen](#notes-and-limits)
+- [Schnellstart](#schnellstart) · [Browser- vs. API-Gatter](#browser--vs-api-gatter)
+- [Die Gatter-Familie](#die-gatter-familie) · [Prädikat- und Rollen-Gatter](#prädikat--und-rollen-gatter)
+- [Berechtigungs-Gatter](#berechtigungs-gatter) · [Der `?next=`-Umlauf](#der-next-umlauf)
+- [Hinweise und Grenzen](#hinweise-und-grenzen)
 
 ---
 

--- a/docs/de/auth-flows.md
+++ b/docs/de/auth-flows.md
@@ -22,13 +22,13 @@ der Server ihren Parametern vertrauen kann, ohne irgendetwas zu speichern.
 
 ## Inhaltsverzeichnis
 
-- [Signierte URLs: das Fundament](#signed-urls-the-substrate)
-- [Passwort-Zurücksetzung](#password-reset)
-- [E-Mail-Verifizierung](#email-verification)
-- [Magic-Link-Anmeldung](#magic-link-login)
-- [Einmal-Tokens](#single-use-tokens)
-- [Was Sie bereitstellen](#what-you-provide)
-- [Siehe auch](#see-also)
+- [Signierte URLs: das Fundament](#signierte-urls-das-fundament)
+- [Passwort-Zurücksetzung](#passwort-zurücksetzung)
+- [E-Mail-Verifizierung](#e-mail-verifizierung)
+- [Magic-Link-Anmeldung](#magic-link-anmeldung)
+- [Einmal-Tokens](#einmal-tokens)
+- [Was Sie bereitstellen](#was-sie-bereitstellen)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/auth-hmac.md
+++ b/docs/de/auth-hmac.md
@@ -25,13 +25,13 @@ Tower-Layer.
 
 ## Inhaltsverzeichnis
 
-- [Wann einsetzen](#when-to-use-it)
-- [Was signiert wird](#what-gets-signed)
-- [Server: mit dem Layer verifizieren](#server-verify-with-the-layer)
-- [Client: eine Anfrage signieren](#client-sign-a-request)
-- [Uhren-Skew und Replay](#clock-skew-and-replay)
-- [Grenzen](#limits)
-- [Siehe auch](#see-also)
+- [Wann einsetzen](#wann-einsetzen)
+- [Was signiert wird](#was-signiert-wird)
+- [Server: mit dem Layer verifizieren](#server-mit-dem-layer-verifizieren)
+- [Client: eine Anfrage signieren](#client-eine-anfrage-signieren)
+- [Uhren-Skew und Replay](#uhren-skew-und-replay)
+- [Grenzen](#grenzen)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/auth-jwt-api.md
+++ b/docs/de/auth-jwt-api.md
@@ -30,10 +30,10 @@ Refresh und **Widerruf** für das Abmelden. **Rustango** liefert das als
 ---
 
 ## Inhaltsverzeichnis
-- [Der eingebaute Router](#the-built-in-router) · [Die Verdrahtung](#wiring-it-up)
-- [Die Token-Engine](#the-token-engine-jwtlifecycle) · [Refresh & Rotation](#refresh-and-rotation)
-- [Widerruf & der JTI-Speicher](#revocation-and-the-jti-store) · [Benutzerdefinierte Claims](#custom-claims)
-- [Hinweise und Grenzen](#notes-and-limits)
+- [Der eingebaute Router](#der-eingebaute-router) · [Die Verdrahtung](#die-verdrahtung)
+- [Die Token-Engine](#die-token-engine-jwtlifecycle) · [Refresh & Rotation](#refresh-und-rotation)
+- [Widerruf & der JTI-Speicher](#widerruf-und-der-jti-speicher) · [Benutzerdefinierte Claims](#benutzerdefinierte-claims)
+- [Hinweise und Grenzen](#hinweise-und-grenzen)
 
 ---
 
@@ -248,7 +248,7 @@ Benutzerdefinierte Claims überleben `refresh` (werden auf das neue Paar
   [Auth-Backend-Kette](auth-backends.md), um beliebige Routen aus dem
   `Authorization: Bearer`-Header zu authentifizieren.
 - **HS256-Signierung**, 32-Byte-Schlüssel-Untergrenze — derselbe Algorithmus und
-  dieselben Einschränkungen wie beim [eigenständigen JWT](auth-jwt.md#security-model).
+  dieselben Einschränkungen wie beim [eigenständigen JWT](auth-jwt.md#sicherheitsmodell).
 
 
 ---

--- a/docs/de/auth-jwt.md
+++ b/docs/de/auth-jwt.md
@@ -27,10 +27,10 @@ und Zurücklesen, HS256 unter der Haube.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) · [Wann einsetzen](#when-to-use-standalone-jwt)
-- [Claims erstellen](#building-claims) · [Verifizieren](#verifying-a-token)
-- [Sicherheitsmodell](#security-model) — unbedingt lesen · [Inspizieren ohne Vertrauen](#inspecting-without-verifying)
-- [Hinweise und Grenzen](#notes-and-limits)
+- [Schnellstart](#schnellstart) · [Wann einsetzen](#wann-ein-eigenständiges-jwt-einsetzen)
+- [Claims erstellen](#claims-erstellen) · [Verifizieren](#einen-token-verifizieren)
+- [Sicherheitsmodell](#sicherheitsmodell) — unbedingt lesen · [Inspizieren ohne Vertrauen](#inspizieren-ohne-verifizieren)
+- [Hinweise und Grenzen](#hinweise-und-grenzen)
 
 ---
 

--- a/docs/de/auth-passwords.md
+++ b/docs/de/auth-passwords.md
@@ -27,10 +27,10 @@ oder vergleichen den Klartext niemals.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) · [Warum argon2id](#why-argon2id)
-- [Hashen bei der Registrierung](#hashing-on-signup) · [Prüfen bei der Anmeldung](#verifying-on-login)
-- [Timing-sichere Anmeldungen](#timing-safe-logins-account-enumeration) · [Stärkeprüfungen](#strength-checks)
-- [Wo der Hash lebt](#where-the-hash-lives) · [Hinweise und Grenzen](#notes-and-limits)
+- [Schnellstart](#schnellstart) · [Warum argon2id](#warum-argon2id)
+- [Hashen bei der Registrierung](#hashen-bei-der-registrierung) · [Prüfen bei der Anmeldung](#prüfen-bei-der-anmeldung)
+- [Timing-sichere Anmeldungen](#timing-sichere-anmeldungen-kontoaufzählung) · [Stärkeprüfungen](#stärkeprüfungen)
+- [Wo der Hash lebt](#wo-der-hash-lebt) · [Hinweise und Grenzen](#hinweise-und-grenzen)
 
 ---
 

--- a/docs/de/auth-sessions.md
+++ b/docs/de/auth-sessions.md
@@ -30,10 +30,10 @@ Eintrag, und jede Replik sieht das Abmelden bei der nächsten Anfrage.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) · [Sessions vs. JWT](#sessions-vs-jwt)
-- [Die Session-Tasche](#the-session-bag) · [Das Cookie](#the-cookie)
-- [Ein Backend wählen](#picking-a-backend) · [Ablauf und gleitende Erneuerung](#expiry-and-sliding-renewal)
-- [An Ort und Stelle aktualisieren](#updating-a-session-in-place) · [Hinweise und Grenzen](#notes-and-limits)
+- [Schnellstart](#schnellstart) · [Sessions vs. JWT](#sessions-vs-jwt)
+- [Die Session-Tasche](#die-session-tasche) · [Das Cookie](#das-cookie)
+- [Ein Backend wählen](#ein-backend-wählen) · [Ablauf und gleitende Erneuerung](#ablauf-und-gleitende-erneuerung)
+- [An Ort und Stelle aktualisieren](#eine-session-an-ort-und-stelle-aktualisieren) · [Hinweise und Grenzen](#hinweise-und-grenzen)
 
 ---
 
@@ -113,7 +113,7 @@ ein Session-Cookie benötigt:
 - **`HttpOnly`** — JavaScript kann es nicht lesen (stumpft Token-Diebstahl per
   XSS ab).
 - **`SameSite=Lax`** — wird bei seitenübergreifenden Unteranfragen nicht gesendet
-  (CSRF-Abwehr; kombinieren Sie es mit [CSRF-Tokens](security.md#protecting-against-csrf)
+  (CSRF-Abwehr; kombinieren Sie es mit [CSRF-Tokens](security.md#schutz-vor-csrf)
   für Formular-Posts).
 - **`Secure`** — nur HTTPS (nur für lokale HTTP-Entwicklung weglassen).
 - **`Path=/`** — für die gesamte Anwendung sichtbar.

--- a/docs/de/benchmarks.md
+++ b/docs/de/benchmarks.md
@@ -12,7 +12,7 @@ robusteren Laufzeit: **Django** auf **gunicorn** (WSGI) und auf **Hypercorn**
 und Go sind jeweils ein einziges residentes Binary, also gibt es von jedem eines.
 
 Jede Zahl unten ist **gemessen und reproduzierbar**, aus einem konsistenten Durchlauf eines
-Ein-Kommando-Harness (siehe [Reproduce](#reproduce)). Nichts hier ist mit Handbewegungen weggeredet.
+Ein-Kommando-Harness (siehe [Reproduce](#reproduzieren)). Nichts hier ist mit Handbewegungen weggeredet.
 
 > **Kurzfassung.** Auf identischer Hardware, die identisch gerenderte HTML-Seiten ausliefert, lassen die beiden
 > **kompilierten, nativen** Laufzeiten — **Rustango** und **Go** — die interpretierten

--- a/docs/de/caching.md
+++ b/docs/de/caching.md
@@ -27,15 +27,15 @@ oder Laravels `Cache`-Fassade.
 
 ## Inhaltsverzeichnis
 
-- [Schritt 1 — Ein Backend wählen](#step-1--pick-a-backend)
-- [Schritt 2 — get / set / delete](#step-2--get--set--delete)
-- [Schritt 3 — get_or_set (Cache-Aside)](#step-3--get_or_set-cache-aside)
-- [Typisierte JSON-Werte](#typed-json-values)
-- [TTL und Ablauf](#ttl-and-expiry)
-- [Backends tauschen](#swapping-backends)
-- [Caching unter Multi-Tenancy](#caching-under-multi-tenancy)
-- [Referenz](#reference)
-- [Siehe auch](#see-also)
+- [Schritt 1 — Ein Backend wählen](#schritt-1--ein-backend-wählen)
+- [Schritt 2 — get / set / delete](#schritt-2--get--set--delete)
+- [Schritt 3 — get_or_set (Cache-Aside)](#schritt-3--get_or_set-cache-aside)
+- [Typisierte JSON-Werte](#typisierte-json-werte)
+- [TTL und Ablauf](#ttl-und-ablauf)
+- [Backends tauschen](#backends-tauschen)
+- [Caching unter Multi-Tenancy](#caching-unter-multi-tenancy)
+- [Referenz](#referenz)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/email.md
+++ b/docs/de/email.md
@@ -24,15 +24,15 @@ in dein Terminal zu echtem SMTP mit einer einzeiligen Änderung — wie Djangos 
 
 ## Inhaltsverzeichnis
 
-- [Schritt 1 — Eine E-Mail bauen](#step-1--build-an-email)
-- [Schritt 2 — Einen Mailer wählen](#step-2--pick-a-mailer)
-- [Schritt 3 — Sie versenden](#step-3--send-it)
-- [Validierung und Schutz vor Header-Injection](#validation-and-header-injection-safety)
-- [E-Mails testen](#testing-email)
+- [Schritt 1 — Eine E-Mail bauen](#schritt-1--eine-e-mail-bauen)
+- [Schritt 2 — Einen Mailer wählen](#schritt-2--einen-mailer-wählen)
+- [Schritt 3 — Sie versenden](#schritt-3--sie-versenden)
+- [Validierung und Schutz vor Header-Injection](#validierung-und-schutz-vor-header-injection)
+- [E-Mails testen](#e-mails-testen)
 - [Templates](#templates)
-- [Sie außerhalb des Requests versenden](#send-it-off-the-request)
-- [Referenz](#reference)
-- [Siehe auch](#see-also)
+- [Sie außerhalb des Requests versenden](#sie-außerhalb-des-requests-versenden)
+- [Referenz](#referenz)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/files.md
+++ b/docs/de/files.md
@@ -27,14 +27,14 @@ einmal gegen das Trait; wechsle von lokaler Festplatte zu S3 mit einer einzeilig
 
 ## Inhaltsverzeichnis
 
-- [Schritt 1 — Ein Storage-Backend wählen](#step-1--pick-a-storage-backend)
-- [Schritt 2 — Dateien speichern, laden und ausliefern](#step-2--save-load-and-serve-files)
-- [Schritt 3 — Einen Upload annehmen](#step-3--accept-an-upload)
-- [Sichere Dateinamen](#safe-filenames)
-- [Produktion: S3-kompatibler Speicher](#production-s3-compatible-storage)
-- [Die Mediathek](#the-media-library)
-- [Referenz](#reference)
-- [Siehe auch](#see-also)
+- [Schritt 1 — Ein Storage-Backend wählen](#schritt-1--ein-storage-backend-wählen)
+- [Schritt 2 — Dateien speichern, laden und ausliefern](#schritt-2--dateien-speichern-laden-und-ausliefern)
+- [Schritt 3 — Einen Upload annehmen](#schritt-3--einen-upload-annehmen)
+- [Sichere Dateinamen](#sichere-dateinamen)
+- [Produktion: S3-kompatibler Speicher](#produktion-s3-kompatibler-speicher)
+- [Die Mediathek](#die-mediathek)
+- [Referenz](#referenz)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -4,17 +4,17 @@ Eine Referenz in einfacher Sprache für die in dieser Dokumentation verwendeten 
 Begriff in einem Leitfaden unbekannt ist, schlage ihn zuerst hier nach. Die Definitionen sind
 bewusst informell — die vertiefenden Leitfäden liefern die genauen Details.
 
-Wenn du noch nie zuvor eine Web-API gebaut hast, lies [Grundlagen der Web-APIs](#web-api-basics)
+Wenn du noch nie zuvor eine Web-API gebaut hast, lies [Grundlagen der Web-APIs](#grundlagen-der-web-apis)
 von oben bis unten; es ist eine fünfminütige Einführung. Alles andere ist zum Nachschlagen
 gedacht, während du vorankommst.
 
 ## Inhaltsverzeichnis
 
-- [Grundlagen der Web-APIs](#web-api-basics) — was eine API ist, in alltäglichen Worten
-- [Rustango-Bausteine](#rustango-building-blocks) — die Teile, die du zusammensetzt
-- [Daten und die Datenbank](#data-and-the-database)
-- [Ein paar Rust-Wörter](#a-few-rust-words) — damit die Codeblöcke nicht angsteinflößend sind
-- [Frameworks, mit denen wir vergleichen](#frameworks-we-compare-to)
+- [Grundlagen der Web-APIs](#grundlagen-der-web-apis) — was eine API ist, in alltäglichen Worten
+- [Rustango-Bausteine](#rustango-bausteine) — die Teile, die du zusammensetzt
+- [Daten und die Datenbank](#daten-und-die-datenbank)
+- [Ein paar Rust-Wörter](#ein-paar-rust-wörter) — damit die Codeblöcke nicht angsteinflößend sind
+- [Frameworks, mit denen wir vergleichen](#frameworks-mit-denen-wir-vergleichen)
 
 ---
 
@@ -76,7 +76,7 @@ verwendet, um Ergebnisse zu filtern, zu durchsuchen, zu sortieren oder zu pagini
 **Pagination (Seitennummerierung)** — das Aufteilen einer langen Ergebnisliste in Seiten, damit eine Response nicht
 riesig ist. Der **Envelope** ist die Hülle um die Seite, die dir auch die
 Gesamtwerte nennt — z. B. `{"count": 137, "page": 2, "results": [ … ]}`. Siehe
-[Pagination](viewsets.md#pagination).
+[Pagination](viewsets.md#paginierung).
 
 **`curl`** — ein Kommandozeilen-Werkzeug zum manuellen Senden von API-Requests. Die
 `curl ...`-Beispiele in dieser Dokumentation lassen dich einen Endpoint aus einem Terminal ausprobieren,

--- a/docs/de/html-views.md
+++ b/docs/de/html-views.md
@@ -29,15 +29,15 @@ Resource-Controllern, die Blade-Views zurückgeben. Sie rendern über [Tera](htt
 
 ## Inhaltsverzeichnis
 
-- [API-Views vs HTML-Views — welche willst du?](#api-views-vs-html-views--which-do-you-want)
-- [Die fünf Modell-Views](#the-five-model-views)
+- [API-Views vs HTML-Views — welche willst du?](#api-views-vs-html-views--welche-willst-du)
+- [Die fünf Modell-Views](#die-fünf-modell-views)
 - [ListView](#listview) · [DetailView](#detailview)
 - [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
-- [Der Tera-Kontext](#the-tera-context)
-- [TemplateView und RedirectView](#templateview-and-redirectview)
+- [Der Tera-Kontext](#der-tera-kontext)
+- [TemplateView und RedirectView](#templateview-und-redirectview)
 - [Single-Tenant vs Multi-Tenant](#single-tenant-vs-multi-tenant)
-- [Ein Modell auf beide Arten ausliefern](#serving-one-model-both-ways)
-- [Siehe auch](#see-also)
+- [Ein Modell auf beide Arten ausliefern](#ein-modell-auf-beide-arten-ausliefern)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -58,7 +58,7 @@ darin, *was herauskommt* und *wer aufruft*.
 | Django-Analogon | DRF `ModelViewSet` | generische klassenbasierte Views |
 
 Du musst nicht global wählen — wähle pro Ressource, und du kannst **beide auf demselben Modell**
-einhängen (siehe [unten](#serving-one-model-both-ways)). Faustregeln:
+einhängen (siehe [unten](#ein-modell-auf-beide-arten-ausliefern)). Faustregeln:
 
 - Du baust ein **JSON-Backend** für ein Frontend-Framework oder eine Mobile-App → ViewSet.
 - Du baust eine **serverseitig gerenderte Site** (der Server gibt HTML-Seiten zurück) → HTML-Views.

--- a/docs/de/i18n.md
+++ b/docs/de/i18n.md
@@ -28,17 +28,17 @@ Locale, ersetzt `{placeholders}`, behandelt Pluralformen und fällt elegant zur�
 
 ## Inhaltsverzeichnis
 
-- [Die zwei Hälften von i18n](#the-two-halves-of-i18n)
-- [Schritt 1 — Einen Translator bauen](#step-1--build-a-translator)
-- [Schritt 2 — Strings übersetzen (gettext)](#step-2--translate-strings-gettext)
-- [Platzhalter](#placeholders)
-- [Pluralisierung](#pluralization)
-- [Fallback-Reihenfolge](#fallback-order)
-- [Die Sprache aushandeln](#negotiating-the-language)
-- [Rechts-nach-links-Sprachen](#right-to-left-languages)
-- [In Templates übersetzen (Tera)](#translating-in-templates-tera)
-- [Kataloge laden + Laufzeit-Overrides](#loading-catalogs--runtime-overrides)
-- [Siehe auch](#see-also)
+- [Die zwei Hälften von i18n](#die-zwei-hälften-von-i18n)
+- [Schritt 1 — Einen Translator bauen](#schritt-1--einen-translator-bauen)
+- [Schritt 2 — Strings übersetzen (gettext)](#schritt-2--strings-übersetzen-gettext)
+- [Platzhalter](#platzhalter)
+- [Pluralisierung](#pluralisierung)
+- [Fallback-Reihenfolge](#fallback-reihenfolge)
+- [Die Sprache aushandeln](#die-sprache-aushandeln)
+- [Rechts-nach-links-Sprachen](#rechts-nach-links-sprachen)
+- [In Templates übersetzen (Tera)](#in-templates-übersetzen-tera)
+- [Kataloge laden + Laufzeit-Overrides](#kataloge-laden--laufzeit-overrides)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -46,9 +46,9 @@ Locale, ersetzt `{placeholders}`, behandelt Pluralformen und fällt elegant zur�
 
 | Anliegen | Wo | Was es tut |
 |---|---|---|
-| Die Locale **auflösen** | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | wählt eine Locale pro Anfrage (Cookie → Accept-Language → Standard) und stellt den `ActiveLocale`-Extractor bereit |
+| Die Locale **auflösen** | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-bewusste-middleware) | wählt eine Locale pro Anfrage (Cookie → Accept-Language → Standard) und stellt den `ActiveLocale`-Extractor bereit |
 | Strings **übersetzen** | `i18n::Translator` (dieser Leitfaden) | schlägt einen Nachrichtenschlüssel im Katalog der aktiven Locale nach |
-| Daten in der TZ des Nutzers rendern | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | der `{{ ts \| localtime }}`-Filter |
+| Daten in der TZ des Nutzers rendern | [`i18n::timezone`](middleware.md#zeitzonen-bewusste-middleware) | der `{{ ts \| localtime }}`-Filter |
 
 Sie verdrahten die Middleware einmal und übersetzen dann mit der von ihr
 aufgelösten Locale.
@@ -78,7 +78,7 @@ let translator = Translator::new(Locale::new("en"))   // default locale
 
 Halten Sie den `Translator` in Ihrem App-State (er ist günstig zum Clone-Teilen)
 und schlagen Sie Strings mit der von der Middleware aufgelösten
-[`ActiveLocale`](middleware.md#locale-aware-middleware) nach.
+[`ActiveLocale`](middleware.md#locale-bewusste-middleware) nach.
 
 ---
 
@@ -205,7 +205,7 @@ is_rtl_language("en");   // false
 ```
 
 In einem Template: `<html dir="{{ direction }}">`, gespeist aus der
-`ActiveLocale`. Siehe die [RTL-Notiz in Middleware](middleware.md#locale-aware-middleware).
+`ActiveLocale`. Siehe die [RTL-Notiz in Middleware](middleware.md#locale-bewusste-middleware).
 
 ---
 

--- a/docs/de/jobs.md
+++ b/docs/de/jobs.md
@@ -28,18 +28,18 @@ Celery / Laravel-Queues, in Rust.
 
 ## Inhaltsverzeichnis
 
-- [Schritt 1 — Einen Job definieren](#step-1--define-a-job)
-- [Schritt 2 — Eine Queue starten](#step-2--start-a-queue)
-- [Schritt 3 — Aus einem Handler dispatchen](#step-3--dispatch-from-a-handler)
-- [Schritt 4 — In deine App verdrahten](#step-4--wire-it-into-your-app) — das vollständige Beispiel
-- [Die Worker laufen lassen (CLI + Produktion)](#running-the-workers-cli--production)
-- [Retries und Backoff](#retries-and-backoff)
-- [Der Dead-Letter-Handler](#the-dead-letter-handler)
-- [Die persistente Queue (Produktion)](#the-persistent-queue-production)
-- [Jobs unter Multi-Tenancy](#jobs-under-multi-tenancy)
-- [Geplante Sweeps unter Multi-Tenancy](#scheduled-sweeps-under-multi-tenancy)
-- [Referenz](#reference)
-- [Siehe auch](#see-also)
+- [Schritt 1 — Einen Job definieren](#schritt-1--einen-job-definieren)
+- [Schritt 2 — Eine Queue starten](#schritt-2--eine-queue-starten)
+- [Schritt 3 — Aus einem Handler dispatchen](#schritt-3--aus-einem-handler-dispatchen)
+- [Schritt 4 — In deine App verdrahten](#schritt-4--in-deine-app-verdrahten) — das vollständige Beispiel
+- [Die Worker laufen lassen (CLI + Produktion)](#die-worker-laufen-lassen-cli--produktion)
+- [Retries und Backoff](#retries-und-backoff)
+- [Der Dead-Letter-Handler](#der-dead-letter-handler)
+- [Die persistente Queue (Produktion)](#die-persistente-queue-produktion)
+- [Jobs unter Multi-Tenancy](#jobs-unter-multi-tenancy)
+- [Geplante Sweeps unter Multi-Tenancy](#geplante-sweeps-unter-multi-tenancy)
+- [Referenz](#referenz)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -111,7 +111,7 @@ erreichen können.
 > **In-Memory bedeutet In-Memory.** In der Queue stehende oder in Bearbeitung
 > befindliche Jobs gehen **beim Neustart verloren**. Für alles, dessen Verlust
 > du dir nicht leisten kannst, verwende die [persistente
-> Queue](#the-persistent-queue-production).
+> Queue](#die-persistente-queue-produktion).
 
 ---
 
@@ -215,7 +215,7 @@ cargo run -- make:job WelcomeEmail   # scaffold a new job type
 
 Im großen Maßstab willst du die Worker oft **getrennt** von der Web-Ebene — damit
 ein Traffic-Spike keine Jobs aushungern kann und du beide unabhängig skalierst.
-Mit der [persistenten Queue](#the-persistent-queue-production) zieht jeder Prozess
+Mit der [persistenten Queue](#die-persistente-queue-produktion) zieht jeder Prozess
 aus derselben `rustango_jobs`-Tabelle, führe also einfach ein zweites,
 serverloses Binary aus, das die Queue baut, startet und bis zu einem Signal
 blockiert:
@@ -243,7 +243,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Deploye es als eigenen Container/Service und skaliere auf **N Replicas** — sie
 ziehen alle sicher aus der geteilten Tabelle. Der Web-Prozess muss dann nur noch
 `dispatch` (er muss keine Worker `start()`). Kopple den Worker mit einem
-periodischen [`reclaim_stuck_jobs_pool`](#the-persistent-queue-production)-Sweep,
+periodischen [`reclaim_stuck_jobs_pool`](#die-persistente-queue-produktion)-Sweep,
 um Jobs eines abgestürzten Workers zurückzuholen.
 
 ---
@@ -514,5 +514,5 @@ nichts geloggt. Verfolgt in
 - [E-Mail](email.md) — die kanonische „mach es in einem Job"-Workload.
 - [Caching](caching.md) — der andere Weg, Request-Handler schnell zu halten.
 - [Signals](orm.md) — Fire-and-Forget-Hooks, die oft einen Job *dispatchen*.
-- [Tenancy-Befehle](manage.md#tenancy-commands) — das Provisionieren der
+- [Tenancy-Befehle](manage.md#tenancy-befehle) — das Provisionieren der
   Tenants, über die eine Queue pro Tenant fan-out macht.

--- a/docs/de/mcp.md
+++ b/docs/de/mcp.md
@@ -29,16 +29,16 @@ eingebautem OAuth 2.1.
 
 ## Inhaltsverzeichnis
 
-- [Was MCP Ihnen bietet](#what-mcp-gives-you)
-- [Schritt 1 — Das Feature aktivieren](#step-1--enable-the-feature)
-- [Schritt 2 — Ein Tool definieren](#step-2--define-a-tool)
-- [Schritt 3 — Den Server mounten](#step-3--mount-the-server)
-- [Schritt 4 — Agenten autorisieren](#step-4--authorize-agents)
-- [Das Protokoll](#the-protocol)
-- [Einstellungen](#settings)
-- [Wie man testet](#how-to-test) — [die Suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [der visuelle MCP Inspector](#c-test-it-visually-with-the-mcp-inspector) · [ein echter Client](#d-connect-a-real-mcp-client)
-- [Optionaler vs. Standard-Build](#optional-vs-default-build)
-- [Siehe auch](#see-also)
+- [Was MCP Ihnen bietet](#was-mcp-ihnen-bietet)
+- [Schritt 1 — Das Feature aktivieren](#schritt-1--das-feature-aktivieren)
+- [Schritt 2 — Ein Tool definieren](#schritt-2--ein-tool-definieren)
+- [Schritt 3 — Den Server mounten](#schritt-3--den-server-mounten)
+- [Schritt 4 — Agenten autorisieren](#schritt-4--agenten-autorisieren)
+- [Das Protokoll](#das-protokoll)
+- [Einstellungen](#einstellungen)
+- [Wie man testet](#wie-man-testet) — [die Suite](#a-die-test-suite) · [curl](#b-curl-das-json-rpc) · [der visuelle MCP Inspector](#c-testen-sie-es-visuell-mit-dem-mcp-inspector) · [ein echter Client](#d-einen-echten-mcp-client-verbinden)
+- [Optionaler vs. Standard-Build](#optionaler-vs-standard-build)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -73,7 +73,7 @@ rustango = { version = "0.44", features = ["mcp"] }
 Es zieht `tenancy` (Agenten/Skills), `sse` (den Benachrichtigungsstrom),
 `serializer` + `openapi` (die Tool-Eingabeschemata) und `jwt` (Agenten-Tokens)
 mit. Ein Build **ohne** das Feature kompiliert nichts vom MCP-Modul — siehe
-[Optionaler vs. Standard-Build](#optional-vs-default-build).
+[Optionaler vs. Standard-Build](#optionaler-vs-standard-build).
 
 ---
 

--- a/docs/de/middleware.md
+++ b/docs/de/middleware.md
@@ -29,15 +29,15 @@ Router angehängt.
 
 ## Inhaltsverzeichnis
 
-- [Wie Middleware in Rustango funktioniert](#how-middleware-works-in-rustango)
-- [Die Reihenfolge zählt](#ordering-matters)
-- [Der eingebaute Katalog](#the-built-in-catalog)
-- [Locale-bewusste Middleware](#locale-aware-middleware)
-- [Zeitzonen-bewusste Middleware](#timezone-aware-middleware)
-- [Security-Header](#security-headers)
-- [CSRF-Schutz](#csrf-protection)
-- [Eigene Middleware schreiben](#writing-your-own-middleware)
-- [Siehe auch](#see-also)
+- [Wie Middleware in Rustango funktioniert](#wie-middleware-in-rustango-funktioniert)
+- [Die Reihenfolge zählt](#die-reihenfolge-zählt)
+- [Der eingebaute Katalog](#der-eingebaute-katalog)
+- [Locale-bewusste Middleware](#locale-bewusste-middleware)
+- [Zeitzonen-bewusste Middleware](#zeitzonen-bewusste-middleware)
+- [Security-Header](#security-header)
+- [CSRF-Schutz](#csrf-schutz)
+- [Eigene Middleware schreiben](#eigene-middleware-schreiben)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -77,7 +77,7 @@ Es gibt zwei Formen, und du wirst beide verwenden:
 2. **Eine Funktion über `axum::middleware::from_fn`** — der schnellste Weg, eine
    einmalige zu schreiben. Du erhältst den `Request` und ein `Next`; du rufst
    `next.run(req)` auf, um fortzufahren, und du kannst auf beiden Seiten dieses
-   Aufrufs arbeiten. Das [Zeitzonen-Beispiel](#timezone-aware-middleware) unten
+   Aufrufs arbeiten. Das [Zeitzonen-Beispiel](#zeitzonen-bewusste-middleware) unten
    ist genau das.
 
 Beide lassen sich frei komponieren — eine `from_fn`-Middleware *ist* ein Layer,
@@ -158,7 +158,7 @@ Jeder Eintrag ist ein `tower::Layer` mit einem passenden
 | Page-Caching | `CachePageLayer` | `.layer(..)` |
 | **Lokalisierung** | | |
 | Locale-Aushandlung | `LocaleMiddleware` | `.layer(..)` (+ `ActiveLocale`-Extractor) |
-| Aktive Zeitzone | *(mit `from_fn` komponieren)* | siehe [unten](#timezone-aware-middleware) |
+| Aktive Zeitzone | *(mit `from_fn` komponieren)* | siehe [unten](#zeitzonen-bewusste-middleware) |
 | **Entwicklung** | | |
 | Live-Reload | `LiveReloadLayer` | `.livereload(..)` |
 | Debug-Panel | `DebugPanelLayer` | `.debug_panel(..)` |
@@ -386,7 +386,7 @@ Pfad-Präfix. Der Auto-Admin aktiviert CSRF bei jeder Mutation ohne Opt-out.
 ## Eigene Middleware schreiben
 
 Die schnelle Form hast du schon gesehen — die [Zeitzonen-
-Middleware](#timezone-aware-middleware) ist ein vollständiges
+Middleware](#zeitzonen-bewusste-middleware) ist ein vollständiges
 `from_fn`-Beispiel. Greife zu `from_fn`, wann immer die Logik anwendungs-
 spezifisch ist und du sie nicht konfigurieren musst:
 

--- a/docs/de/migrations.md
+++ b/docs/de/migrations.md
@@ -12,7 +12,7 @@ Engine ohne Kollisionen zu übernehmen.
 > **Neu bei Migrationen?** Die alltäglichen CLI-Verben — `makemigrations`,
 > `migrate`, `migrate --squash`, `migrate --fake`, `downgrade`,
 > `showmigrations` — werden Befehl für Befehl im
-> [manage-Leitfaden](manage.md#migrations) behandelt. Diese Seite ist das konzeptionelle
+> [manage-Leitfaden](manage.md#migrationen) behandelt. Diese Seite ist das konzeptionelle
 > Modell dahinter.
 
 > **Quelle:** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
@@ -182,7 +182,7 @@ lösen Sie es mit `migrate --fake` auf, statt zu erzwingen.
 
 ## Siehe auch
 
-- [`manage`-Leitfaden](manage.md#migrations) — jedes Migrations-CLI-Verb, mit
+- [`manage`-Leitfaden](manage.md#migrationen) — jedes Migrations-CLI-Verb, mit
   Beispielen.
 - [Scaffolding](scaffolding.md) — woher `migrations/` und
   `system/migrations/` kommen.

--- a/docs/de/models.md
+++ b/docs/de/models.md
@@ -25,16 +25,16 @@ siehe das [ORM-Kochbuch](orm.md).
 
 ## Inhaltsverzeichnis
 
-- [Anatomie eines Modells](#anatomy-of-a-model)
-- [Feldtypen](#field-types) · [Nur-PostgreSQL-Typen](#postgresql-only-types)
-- [Primärschlüssel](#primary-keys) — [benutzerdefinierte PKs](#custom-primary-keys) · [zusammengesetzte](#composite-primary-keys)
-- [Beziehungen](#relationships)
-- [Übliche Feldattribute](#common-field-attributes)
-- [Indizes & Constraints](#indexes-and-constraints)
-- [Übliche Modellattribute](#common-model-attributes)
-- [Die generierte API](#the-generated-api) — [save vs insert](#save-vs-insert)
-- [Vollständige Attributreferenz](#full-attribute-reference)
-- [Siehe auch](#see-also)
+- [Anatomie eines Modells](#anatomie-eines-modells)
+- [Feldtypen](#feldtypen) · [Nur-PostgreSQL-Typen](#nur-postgresql-typen)
+- [Primärschlüssel](#primärschlüssel) — [benutzerdefinierte PKs](#benutzerdefinierte-primärschlüssel) · [zusammengesetzte](#zusammengesetzte-primärschlüssel)
+- [Beziehungen](#beziehungen)
+- [Übliche Feldattribute](#übliche-feldattribute)
+- [Indizes & Constraints](#indizes-und-constraints)
+- [Übliche Modellattribute](#übliche-modellattribute)
+- [Die generierte API](#die-generierte-api) — [save vs insert](#save-vs-insert)
+- [Vollständige Attributreferenz](#vollständige-attributreferenz)
+- [Siehe auch](#siehe-auch)
 
 ---
 
@@ -72,7 +72,7 @@ Aus dieser einen Deklaration generiert das Derive:
 - **typisierte Feldkonstanten** (`Post::title`, `Post::author_id`) für
   compilergeprüfte Filter — `Post::objects().where_(Post::author_id.eq(42))`;
 - Zeilenmethoden — **`save`**, **`find`**, **`delete`** und mehr (siehe
-  [die generierte API](#the-generated-api)).
+  [die generierte API](#die-generierte-api)).
 
 Der Tabellenname ist standardmäßig der Modellname, wenn du `table` weglässt;
 Spaltennamen sind standardmäßig der snake_case-Feldname, sofern du nicht `column`

--- a/docs/de/openapi.md
+++ b/docs/de/openapi.md
@@ -27,11 +27,11 @@ dieselben Typen jede beliebige Spec von Hand bauen.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) — generieren + ausliefern auf einem Bildschirm
-- [Schemata aus Serializern](#schemas-from-serializers) · [Pfade aus ViewSets](#paths-from-viewsets)
-- [Ausliefern](#serving-the-spec-swagger-ui--redoc) · [Eine Spec von Hand bauen](#hand-building-a-spec)
-- [Security-Schemata](#security-schemes) · [Der `Schema`-Builder](#the-schema-builder)
-- [Anmerkungen & Grenzen](#notes-and-limits)
+- [Schnellstart](#schnellstart) — generieren + ausliefern auf einem Bildschirm
+- [Schemata aus Serializern](#schemata-aus-serializern) · [Pfade aus ViewSets](#pfade-aus-viewsets)
+- [Ausliefern](#die-spec-ausliefern-swagger-ui--redoc) · [Eine Spec von Hand bauen](#eine-spec-von-hand-bauen)
+- [Security-Schemata](#security-schemata) · [Der `Schema`-Builder](#der-schema-builder)
+- [Anmerkungen & Grenzen](#anmerkungen-und-grenzen)
 
 ---
 
@@ -113,7 +113,7 @@ impl rustango::openapi::OpenApiSchema for Money {
 }
 ```
 
-> Siehe den [Serializer-Leitfaden](serializers.md#openapi-schemas) für die
+> Siehe den [Serializer-Leitfaden](serializers.md#openapi-schemata) für die
 > Feldattribute, die die Ausgabe formen.
 
 ---
@@ -227,7 +227,7 @@ Helfer: `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
 An einer `Operation` markiert `.no_security()` einen öffentlichen Endpunkt und
 `.require_security(scheme, scopes)` überschreibt den globalen Default. Diese
 passen zu **Rustango**s eigener Auth (siehe den
-[Security-Leitfaden](security.md#authenticating-users)): JWT → `bearer`,
+[Security-Leitfaden](security.md#benutzer-authentifizieren)): JWT → `bearer`,
 API-Keys → `apiKey`, OAuth2 → `oauth2`.
 
 ---

--- a/docs/de/orm.md
+++ b/docs/de/orm.md
@@ -35,23 +35,23 @@ Das CHANGELOG führt den vollständigen Ticket-Index für jedes Release.
 
 ## Inhaltsverzeichnis
 
-- [Abfragen](#querying)
-- [Berechnete Werte & Datenbankfunktionen](#computed-values--database-functions)
-- [Aggregationen](#aggregations)
-- [Joins & Vorladen verwandter Zeilen](#joins--preloading-related-rows)
-- [Massenoperationen](#bulk-operations)
-- [Einfügen oder aktualisieren (Upsert)](#insert-or-update-upsert)
-- [Transaktionen](#transactions)
+- [Abfragen](#abfragen)
+- [Berechnete Werte & Datenbankfunktionen](#berechnete-werte--datenbankfunktionen)
+- [Aggregationen](#aggregationen)
+- [Joins & Vorladen verwandter Zeilen](#joins--vorladen-verwandter-zeilen)
+- [Massenoperationen](#massenoperationen)
+- [Einfügen oder aktualisieren (Upsert)](#einfügen-oder-aktualisieren-upsert)
+- [Transaktionen](#transaktionen)
 - [Many-to-many](#many-to-many)
 - [JSON / JSONB](#json--jsonb)
 - [Soft Delete](#soft-delete)
 - [Audit-Trail](#audit-trail)
-- [Raw-SQL-Notausstieg](#raw-sql-escape-hatch)
-- [Lazy-FK-Laden](#lazy-fk-loading)
-- [Vier Wege zu filtern](#four-ways-to-filter)
-- [Mandantengebundene Abfragen](#tenant-scoped-queries)
-- [Signale](#signals)
-- [Performance-Tipps](#performance-tips)
+- [Raw-SQL-Notausstieg](#raw-sql-notausstieg)
+- [Lazy-FK-Laden](#lazy-fk-laden)
+- [Vier Wege zu filtern](#vier-wege-zu-filtern)
+- [Mandantengebundene Abfragen](#mandantengebundene-abfragen)
+- [Signale](#signale)
+- [Performance-Tipps](#performance-tipps)
 
 ---
 
@@ -866,7 +866,7 @@ let featured = Author::objects()
 
 ### Wann man stattdessen auf rohes SQL zurückfällt
 
-Die obigen Builder decken die häufigen Fälle ab. Für Dinge, die sie noch nicht ausdrücken — `Cast`, Volltextsuche, JSON-Pfad-Operatoren, Hash-Funktionen, Trigonometrie, Fensterfunktionen — siehe den Abschnitt [Raw-SQL-Notausstieg](#raw-sql-escape-hatch) weiter unten, oder warte auf die Nachfolge-Issues, die denselben Ausdrucksbaum erweitern.
+Die obigen Builder decken die häufigen Fälle ab. Für Dinge, die sie noch nicht ausdrücken — `Cast`, Volltextsuche, JSON-Pfad-Operatoren, Hash-Funktionen, Trigonometrie, Fensterfunktionen — siehe den Abschnitt [Raw-SQL-Notausstieg](#raw-sql-notausstieg) weiter unten, oder warte auf die Nachfolge-Issues, die denselben Ausdrucksbaum erweitern.
 
 ---
 

--- a/docs/de/security.md
+++ b/docs/de/security.md
@@ -6,25 +6,25 @@ Dieser Leitfaden behandelt jede Sicherheitsfunktion, die **Rustango** mitbringt,
 
 ## Inhaltsverzeichnis
 
-- [Die Defense-in-Depth-Checkliste](#the-defense-in-depth-checklist)
-- [Security-Header setzen](#setting-security-headers)
-- [Cross-Origin-Anfragen erlauben (CORS)](#allowing-cross-origin-requests-cors)
-- [Anfragen per Rate Limiting drosseln](#rate-limiting-requests)
-- [IPs erlauben oder blockieren](#allowing-or-blocking-ips)
-- [Schutz vor CSRF](#protecting-against-csrf)
-- [XSS verhindern](#preventing-xss)
-- [SQL-Injection verhindern](#preventing-sql-injection)
-- [Benutzer authentifizieren](#authenticating-users)
-- [Passwörter hashen und prüfen](#hashing-and-checking-passwords)
-- [JWTs ausstellen und erneuern](#issuing-and-refreshing-jwts)
-- [Mit API-Keys authentifizieren](#authenticating-with-api-keys)
-- [Zwei-Faktor-Authentifizierung hinzufügen (TOTP)](#adding-two-factor-auth-totp)
-- [Signierte URLs versenden (Magic Links)](#sending-signed-urls-magic-links)
-- [Eingehende Webhooks verifizieren](#verifying-incoming-webhooks)
-- [Secrets aus deinen Logs heraushalten](#keeping-secrets-out-of-your-logs)
-- [Anfragen über Services hinweg nachverfolgen](#tracing-requests-across-services)
-- [Secrets verwalten](#managing-secrets)
-- [Vor dem Deploy auditieren](#auditing-before-you-deploy)
+- [Die Defense-in-Depth-Checkliste](#die-defense-in-depth-checkliste)
+- [Security-Header setzen](#security-header-setzen)
+- [Cross-Origin-Anfragen erlauben (CORS)](#cross-origin-anfragen-erlauben-cors)
+- [Anfragen per Rate Limiting drosseln](#anfragen-per-rate-limiting-drosseln)
+- [IPs erlauben oder blockieren](#ips-erlauben-oder-blockieren)
+- [Schutz vor CSRF](#schutz-vor-csrf)
+- [XSS verhindern](#xss-verhindern)
+- [SQL-Injection verhindern](#sql-injection-verhindern)
+- [Benutzer authentifizieren](#benutzer-authentifizieren)
+- [Passwörter hashen und prüfen](#passwörter-hashen-und-prüfen)
+- [JWTs ausstellen und erneuern](#jwts-ausstellen-und-erneuern)
+- [Mit API-Keys authentifizieren](#mit-api-keys-authentifizieren)
+- [Zwei-Faktor-Authentifizierung hinzufügen (TOTP)](#zwei-faktor-authentifizierung-hinzufügen-totp)
+- [Signierte URLs versenden (Magic Links)](#signierte-urls-versenden-magic-links)
+- [Eingehende Webhooks verifizieren](#eingehende-webhooks-verifizieren)
+- [Secrets aus deinen Logs heraushalten](#secrets-aus-deinen-logs-heraushalten)
+- [Anfragen über Services hinweg nachverfolgen](#anfragen-über-services-hinweg-nachverfolgen)
+- [Secrets verwalten](#secrets-verwalten)
+- [Vor dem Deploy auditieren](#vor-dem-deploy-auditieren)
 
 ---
 
@@ -247,7 +247,7 @@ let safe = html_escape(user_input);
 
 Ersetzt `&`, `<`, `>`, `"`, `'`. Geeignet für HTML-Elementinhalte + doppelt-quotierte Attribute.
 
-Für CSP-basierte XSS-Verteidigung siehe [Security-Header setzen](#setting-security-headers).
+Für CSP-basierte XSS-Verteidigung siehe [Security-Header setzen](#security-header-setzen).
 
 ---
 
@@ -654,14 +654,14 @@ Für Prüfungen jenseits des Mitgelieferten erweitere mit benutzerdefiniertem Co
 Ein paar End-to-End-Flows müssen noch aus den untenstehenden Primitiven zusammengeklebt werden:
 
 - **Passwort-Reset + E-Mail-Verifizierung** — die Token-Issue-/Verify-Helper existieren (`auth_flows::confirm_password_reset_pool`, plus E-Mail-Verifizierungs-Round-Trips) und die E-Mail-Pipeline wird separat mitgeliefert, aber es gibt keinen einzelnen vorgefertigten View- + E-Mail- + Validate-Zyklus, der für dich verdrahtet ist.
-- **PII-Redaktion von Request-Body / Headern** in `access_log` — feldbasierte Log-Redaktion existiert (siehe [Secrets aus deinen Logs heraushalten](#keeping-secrets-out-of-your-logs)), aber keine automatische Bereinigung des Request-Bodys oder der Header.
+- **PII-Redaktion von Request-Body / Headern** in `access_log` — feldbasierte Log-Redaktion existiert (siehe [Secrets aus deinen Logs heraushalten](#secrets-aus-deinen-logs-heraushalten)), aber keine automatische Bereinigung des Request-Bodys oder der Header.
 
 Bereits mitgeliefert (greife nicht zu einem Workaround):
 
 - **OAuth2 / OIDC Social Login** — `oauth2::providers` bringt Google-, GitHub-, Microsoft-, GitLab- und Discord-Helper mit (plus `OAuth2Provider::from_discovery` für jeden OIDC-Provider), und `oauth2::router::oauth2_router` mountet die Login- + Callback-Routen, erstellt den Benutzerdatensatz und setzt das Session-Cookie.
 - **Sperre pro Account** — `rustango::account_lockout::Lockout` (cache-gestützt; `is_locked` / `record_failure` / `clear`, konfigurierbare `max_attempts` + `lockout_duration`).
 - **CSP-Report-Endpunkt** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
-- **Verteiltes Rate Limiting** — `rate_limit_cache::CacheRateLimitLayer` (siehe [Anfragen per Rate Limiting drosseln](#rate-limiting-requests)).
+- **Verteiltes Rate Limiting** — `rate_limit_cache::CacheRateLimitLayer` (siehe [Anfragen per Rate Limiting drosseln](#anfragen-per-rate-limiting-drosseln)).
 
 Bis die nicht mitgelieferten Flows landen, klebe sie aus den obigen Primitiven zusammen (`signed_url::sign` für Passwort-Reset-Tokens, die E-Mail-Pipeline für die Zustellung usw.).
 

--- a/docs/de/serializers.md
+++ b/docs/de/serializers.md
@@ -34,13 +34,13 @@ zu leiten.
 ---
 
 ## Inhaltsverzeichnis
-- [Schnellstart](#quick-start) · [Der `ModelSerializer`-Trait](#the-modelserializer-trait)
-- [Feldattribute](#field-attributes) — die vollständige Referenz
-- [Berechnete Felder](#computed-fields) · [Verschachtelte Serializer](#nested-serializers) · [Sammlungen](#collections-many) · [Slug-Felder](#slug-related-fields)
-- [Validierung](#validation) · [Unique-together-Validierung](#unique-together-validation)
-- [Hyperlink-Ausgabe](#hyperlinked-output) · [Listen serialisieren](#serializing-lists)
-- [Einen Serializer mit einem ViewSet verwenden](#using-a-serializer-with-a-viewset) · [Validierung in einem eigenen Handler](#validating-in-a-custom-handler)
-- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Feinheiten & Grenzen](#tweaks-and-current-limits)
+- [Schnellstart](#schnellstart) · [Der `ModelSerializer`-Trait](#der-modelserializer-trait)
+- [Feldattribute](#feldattribute) — die vollständige Referenz
+- [Berechnete Felder](#berechnete-felder) · [Verschachtelte Serializer](#verschachtelte-serializer) · [Sammlungen](#sammlungen-many) · [Slug-Felder](#slug-related-felder)
+- [Validierung](#validierung) · [Unique-together-Validierung](#unique-together-validierung)
+- [Hyperlink-Ausgabe](#hyperlink-ausgabe) · [Listen serialisieren](#listen-serialisieren)
+- [Einen Serializer mit einem ViewSet verwenden](#einen-serializer-mit-einem-viewset-verwenden) · [Validierung in einem eigenen Handler](#validierung-in-einem-eigenen-handler)
+- [OpenAPI](#openapi-schemata) · [Scaffolding](#scaffolding) · [Feinheiten & Grenzen](#feinheiten-und-aktuelle-grenzen)
 
 ---
 
@@ -136,7 +136,7 @@ Satz:
 **Deklarative Validatoren.** `max_length = N`, `min_length = N`, `min = N` und
 `max = N` fügen einem Feld Schreibzeit-Validierung hinzu, ohne dessen
 Ausgabeform zu ändern (und ein Feld ohne diese erbt die Grenzen des Modells).
-Siehe [Validierung](#validation).
+Siehe [Validierung](#validierung).
 
 `write_only` ist für rein eingehende Daten (ein Passwort, ein Einmal-Token):
 vorhanden in `writable_fields()`, fehlt in der Ausgabe. `skip` ist das
@@ -208,7 +208,7 @@ pub author: AuthorBrief,
 
 Verschachtelte Felder sind in der Ausgabeform **schreibgeschützt** —
 schreibbare verschachtelte Objekte werden noch nicht unterstützt (siehe
-[Grenzen](#tweaks-and-current-limits)).
+[Grenzen](#feinheiten-und-aktuelle-grenzen)).
 
 ---
 
@@ -411,7 +411,7 @@ ViewSets verpacken eine Seite davon in den Standard-Umschlag:
 ```
 
 (Das ist der Standard-Umschlag mit Seitennummern; siehe
-[Pagination](viewsets.md#pagination) für die Cursor- und
+[Pagination](viewsets.md#paginierung) für die Cursor- und
 Limit/Offset-Formen.)
 
 ---
@@ -439,7 +439,7 @@ pub struct PostViewSet;
 
 Das ViewSet steuert dies über drei `ModelSerializer`-Methoden, die das Derive
 generiert: `validate()`, `writable_source_fields()` und `from_writable_json()`.
-Siehe den [ViewSets-Leitfaden](viewsets.md#the-serializer-marriage-input--output)
+Siehe den [ViewSets-Leitfaden](viewsets.md#die-serializer-ehe-eingabe--ausgabe)
 für das vollständige Verhalten und ein durchgearbeitetes Beispiel.
 
 Du kannst einen Serializer auch **eigenständig** verwenden — bilde eine Zeile ab
@@ -524,7 +524,7 @@ Ein paar scharfe Kanten und Schlupflöcher, die man kennen sollte:
 - **Eingebaute Validatoren sind nur Länge/Bereich/Auswahl** — `max_length` /
   `min_length` / `min` / `max` (und geerbte `choices`) sind deklarativ; andere
   Regeln (`email`, Regex, …) sind Funktionen, die du schreibst (siehe
-  [Validierung](#validation)).
+  [Validierung](#validierung)).
 - **Ein Validator pro Feld je Feld.** Für mehrere Regeln an einem Feld
   kombiniere sie in der Funktion dieses Feldes, oder füge ein feldübergreifendes
   `validate(&self)` hinzu.

--- a/docs/de/sso.md
+++ b/docs/de/sso.md
@@ -72,7 +72,7 @@ diese Spalte aus.
    Anmeldeseite zurückgeschickt (Details gehen ins Server-Log, nie in den Browser).
 
 Das Client-**Secret ist im Ruhezustand verschlüsselt** — die `client_secret`-Spalte
-ist ein [`EncryptedString`](#secret-storage)-Cast, erst zur Anmeldezeit im Speicher
+ist ein [`EncryptedString`](#secret-speicherung)-Cast, erst zur Anmeldezeit im Speicher
 entschlüsselt.
 
 ## Anbieter sind Zeilen, verwaltet im Admin

--- a/docs/de/testing.md
+++ b/docs/de/testing.md
@@ -25,13 +25,13 @@ Rust.
 
 ## Inhaltsverzeichnis
 
-- [Schritt 1 — Steuere deine App mit TestClient an](#step-1--drive-your-app-with-testclient)
-- [Schritt 2 — Assertiere auf die Response](#step-2--assert-on-the-response)
-- [JSON, Header und Bodies senden](#sending-json-headers-and-bodies)
-- [Eine echte API testen](#testing-a-real-api)
-- [Datenbanktests mit Rollback](#database-tests-with-rollback)
-- [Response-Assertion-Helper](#response-assertion-helpers)
-- [Siehe auch](#see-also)
+- [Schritt 1 — Steuere deine App mit TestClient an](#schritt-1--steuere-deine-app-mit-testclient-an)
+- [Schritt 2 — Assertiere auf die Response](#schritt-2--assertiere-auf-die-response)
+- [JSON, Header und Bodies senden](#json-header-und-bodies-senden)
+- [Eine echte API testen](#eine-echte-api-testen)
+- [Datenbanktests mit Rollback](#datenbanktests-mit-rollback)
+- [Response-Assertion-Helper](#response-assertion-helper)
+- [Siehe auch](#siehe-auch)
 
 ---
 

--- a/docs/de/urls.md
+++ b/docs/de/urls.md
@@ -19,11 +19,11 @@ spiegelt Djangos `reverse()` / `{% url %}` / `resolve_url()` / `redirect()`.
 ---
 
 ## Inhaltsverzeichnis
-- [Eine benannte URL registrieren](#register-a-named-url)
+- [Eine benannte URL registrieren](#eine-benannte-url-registrieren)
 - [Reverse in Rust](#reverse-in-rust) · [Reverse in Templates](#reverse-in-templates)
-- [Redirect per Name](#redirect-by-name) · [Namespacing](#namespacing)
-- [Die URL-Map inspizieren](#inspect-the-url-map) · [Fehler](#errors)
-- [Regex & typisierte Pfadmuster](#regex--typed-path-patterns) · [Hinweise & Grenzen](#notes-and-limits)
+- [Redirect per Name](#redirect-per-name) · [Namespacing](#namespacing)
+- [Die URL-Map inspizieren](#die-url-map-inspizieren) · [Fehler](#fehler)
+- [Regex & typisierte Pfadmuster](#regex--typisierte-pfadmuster) · [Hinweise & Grenzen](#hinweise-und-grenzen)
 
 ---
 
@@ -73,7 +73,7 @@ let url = reverse_owned("post-detail", &owned_params)?;
 
 `reverse` ist **strikt**: ein fehlender Platzhalter oder ein zusätzlicher
 `params`-Schlüssel, den das Muster nicht hat, ist ein Fehler (kein stiller
-Fehlabgleich) — siehe [Fehler](#errors).
+Fehlabgleich) — siehe [Fehler](#fehler).
 
 ---
 
@@ -283,7 +283,7 @@ kompilieren und über Anfragen hinweg wiederverwenden kann.
   `Location`-Header oder ein `href` fallengelassen werden können.
 - **Keine Regex-/typisierten Konverter** in Mustern (Djangos `<int:pk>`);
   Platzhalter sind schlichte `{name}`, und Werte werden unverändert eingesetzt
-  (nach der Kodierung). Siehe [Regex & typisierte Pfadmuster](#regex--typed-path-patterns)
+  (nach der Kodierung). Siehe [Regex & typisierte Pfadmuster](#regex--typisierte-pfadmuster)
   für das Warum und wie man eine Route stattdessen einschränkt.
 
 

--- a/docs/de/viewsets.md
+++ b/docs/de/viewsets.md
@@ -7,7 +7,7 @@ API-Resource-Controller, falls du diese schon einmal verwendet hast.)
 
 > **Neu bei REST-APIs?** Diese Anleitung setzt voraus, dass du weißt, was ein *Endpunkt*, ein *HTTP-
 > Verb* (GET / POST / …) und eine *JSON-Anfrage und -Antwort* sind. Falls dir davon etwas
-> unklar ist, ist das [Glossar](glossary.md#web-api-basics) eine Fünf-Minuten-Einführung —
+> unklar ist, ist das [Glossar](glossary.md#glossar) eine Fünf-Minuten-Einführung —
 > lies es zuerst und komm dann hierher zurück.
 
 Kombiniere ein ViewSet mit einem [Serializer](serializers.md) — dem Baustein, der dein
@@ -39,14 +39,14 @@ ist eine Referenz für jede Stellschraube.
 
 ## Inhaltsverzeichnis
 - [API-Views vs. HTML-Views](#api-views-vs-html-views) — JSON für Clients oder HTML-Seiten?
-- [Eine REST-Blog-API bauen](#build-a-rest-blog-api) — die vollständige Anleitung
-- [Die Serializer-Ehe: Eingabe + Ausgabe](#the-serializer-marriage-input--output)
-- [Die zwei Wege, ein ViewSet zu definieren](#the-two-ways-to-define-a-viewset)
-- [Die CRUD-Endpunkte](#the-crud-endpoints) · [Auswahl, welche exponiert werden](#choosing-which-operations-to-expose)
-- [`#[viewset(...)]`-Referenz](#viewset-attribute-reference) · [Builder-Referenz](#builder-reference)
-- [Filterung, Suche & Sortierung](#filtering-search-and-ordering) · [Paginierung](#pagination)
-- [Validierung](#validation) · [Berechtigungen & Drosselung](#permissions-and-throttling) · [Eigene Aktionen](#custom-actions-beyond-crud)
-- [Einbinden](#mounting) · [Backends](#backend-support)
+- [Eine REST-Blog-API bauen](#eine-rest-blog-api-bauen) — die vollständige Anleitung
+- [Die Serializer-Ehe: Eingabe + Ausgabe](#die-serializer-ehe-eingabe--ausgabe)
+- [Die zwei Wege, ein ViewSet zu definieren](#die-zwei-wege-ein-viewset-zu-definieren)
+- [Die CRUD-Endpunkte](#die-crud-endpunkte) · [Auswahl, welche exponiert werden](#auswahl-welche-operationen-exponiert-werden)
+- [`#[viewset(...)]`-Referenz](#viewset-attributreferenz) · [Builder-Referenz](#builder-referenz)
+- [Filterung, Suche & Sortierung](#filterung-suche-und-sortierung) · [Paginierung](#paginierung)
+- [Validierung](#validierung) · [Berechtigungen & Drosselung](#berechtigungen-und-drosselung) · [Eigene Aktionen](#eigene-aktionen-jenseits-von-crud)
+- [Einbinden](#einbinden) · [Backends](#backend-unterstützung)
 
 ---
 
@@ -212,7 +212,7 @@ automatisch **die Constraints des Models** — `title` wird gegen die Längenvor
 `max_length = 200` geprüft, und eine `choices`/`min`/`max`-Spalte würde ebenfalls geprüft,
 wobei alle beim Schreiben freundliche `400`er zurückgeben. Füge `max_length` / `min_length` /
 `min` / `max` als Serializer-Attribute hinzu, um die Grenze eines Feldes zu überschreiben. (Siehe die
-[Serializer-Anleitung](serializers.md#validation) für die vollständige Validierungsgeschichte.)
+[Serializer-Anleitung](serializers.md#validierung) für die vollständige Validierungsgeschichte.)
 
 ### Schritt 5 — Das ViewSet gerüsten und den Serializer verdrahten
 
@@ -498,7 +498,7 @@ Das Einbinden unter `/api/posts` verdrahtet alle sechs REST-Operationen:
 
 | Verb | Pfad | Aktion | Erfolg | Body |
 |---|---|---|---|---|
-| `GET` | `/api/posts` | **list** | 200 | paginierter Umschlag (siehe [Paginierung](#pagination)) |
+| `GET` | `/api/posts` | **list** | 200 | paginierter Umschlag (siehe [Paginierung](#paginierung)) |
 | `POST` | `/api/posts` | **create** | 201 | das erstellte Objekt — *oder ein Array bei Bulk-Create* |
 | `GET` | `/api/posts/{pk}` | **retrieve** | 200 | das Objekt |
 | `PUT` | `/api/posts/{pk}` | **update** (vollständig) | 200 | das aktualisierte Objekt |
@@ -523,7 +523,7 @@ ViewSet::for_model(Post::SCHEMA).read_only()   // builder
 
 Es gibt keinen Umschalter pro Verb außer read_only. Für „alles außer Löschen"
 binde das ViewSet ein und überschreibe die eine Route mit deinem eigenen Handler (siehe
-[Eigene Aktionen](#custom-actions-beyond-crud)).
+[Eigene Aktionen](#eigene-aktionen-jenseits-von-crud)).
 
 ---
 
@@ -532,7 +532,7 @@ binde das ViewSet ein und überschreibe die eine Route mit deinem eigenen Handle
 | Schlüssel | Beispiel | Standard | Was er tut |
 |---|---|---|---|
 | `model` | `model = Post` | **erforderlich** | Das Model, auf dem die Ressource aufbaut. |
-| `serializer` | `serializer = path::To::S` | keiner | Einen Serializer für typisierte **Ausgabe + Eingabe** verdrahten (siehe [oben](#the-serializer-marriage-input--output)). |
+| `serializer` | `serializer = path::To::S` | keiner | Einen Serializer für typisierte **Ausgabe + Eingabe** verdrahten (siehe [oben](#die-serializer-ehe-eingabe--ausgabe)). |
 | `fields` | `"id, title, body"` | alle Skalarfelder | Whitelist für die standardmäßige (serializer-freie) Projektion + schreibbare Felder. |
 | `filter_fields` | `"author_id, status"` | keiner | Über `?field=value` filterbare Felder (+ Lookups). |
 | `search_fields` | `"title, body"` | keiner | Felder, die die `?search=`-Box durchsucht (Groß-/Kleinschreibung-unabhängiges ODER). |
@@ -633,8 +633,8 @@ für sehr große Tabellen. `?cursor=<token>&page_size=20`:
 
 Mit einem **verdrahteten Serializer** führt der Create-/Update-Pfad die Validatoren des Serializers
 aus und gibt `400`er in DRF-Form zurück — der empfohlene Weg zu validieren (siehe
-[die Ehe](#the-serializer-marriage-input--output) und die
-[Serializer-Anleitung](serializers.md#validation)). Drei Schichten laufen:
+[die Ehe](#die-serializer-ehe-eingabe--ausgabe) und die
+[Serializer-Anleitung](serializers.md#validierung)). Drei Schichten laufen:
 
 - **Deklarative Constraints** — `max_length` / `min_length` / `min` / `max`, und
   standardmäßig **erbt** das Feld das `max_length` / `min` / `max` /

--- a/docs/de/websockets.md
+++ b/docs/de/websockets.md
@@ -31,13 +31,13 @@ von Django kommst, ist das Channels; von Laravel, Echo/Reverb; von Node,
 
 ## Inhaltsverzeichnis
 
-- [SSE oder WebSocket — welches?](#sse-or-websocket--which)
-- [Der Broadcast-Bus](#the-broadcast-bus)
+- [SSE oder WebSocket — welches?](#sse-oder-websocket--welches)
+- [Der Broadcast-Bus](#der-broadcast-bus)
 - [Server-Sent Events](#server-sent-events)
 - [WebSockets](#websockets)
-- [Von anderswo senden](#sending-from-elsewhere)
-- [Auth & Mandantenfähigkeit](#auth--tenancy)
-- [Skalierungshinweise](#scaling-notes)
+- [Von anderswo senden](#von-anderswo-senden)
+- [Auth & Mandantenfähigkeit](#auth--mandantenfähigkeit)
+- [Skalierungshinweise](#skalierungshinweise)
 - [Feature-Flags](#feature-flags)
 
 ---

--- a/docs/es/admin.md
+++ b/docs/es/admin.md
@@ -28,16 +28,16 @@ registro a nivel de módulo.
 ---
 
 ## Tabla de contenidos
-- [Montarlo](#mount-it) · [La página de inicio](#the-home-page)
-- [Configurar un modelo: el bloque `admin(...)`](#configure-a-model-the-admin-block)
-- [La vista de lista](#the-list-view) — columnas, búsqueda, filtros, jerarquía de fechas, ordenación, paginación
-- [El formulario de cambio](#the-change-form) — conjuntos de campos, widgets, edición de FK, campos precompletados y de solo lectura
-- [Inlines](#inlines) · [Acciones masivas](#bulk-actions) · [Registro de auditoría](#audit-trail)
-- [Columnas calculadas y filtros personalizados](#computed-columns-and-custom-filters)
-- [Vistas, querysets y permisos personalizados](#custom-views-querysets-and-permissions)
-- [Autenticación](#authentication) · [Temas y marca](#theming-and-branding)
-- [Referencia del `Builder`](#builder-reference) · [Referencia de rutas](#routes-reference)
-- [La referencia de modelos (`__docs`)](#the-model-reference) · [Prueba el ejemplo](#try-the-example)
+- [Montarlo](#montarlo) · [La página de inicio](#la-página-de-inicio)
+- [Configurar un modelo: el bloque `admin(...)`](#configurar-un-modelo-el-bloque-admin)
+- [La vista de lista](#la-vista-de-lista) — columnas, búsqueda, filtros, jerarquía de fechas, ordenación, paginación
+- [El formulario de cambio](#el-formulario-de-cambio) — conjuntos de campos, widgets, edición de FK, campos precompletados y de solo lectura
+- [Inlines](#inlines) · [Acciones masivas](#acciones-masivas) · [Registro de auditoría](#registro-de-auditoría)
+- [Columnas calculadas y filtros personalizados](#columnas-calculadas-y-filtros-personalizados)
+- [Vistas, querysets y permisos personalizados](#vistas-querysets-y-permisos-personalizados)
+- [Autenticación](#autenticación) · [Temas y marca](#temas-y-marca)
+- [Referencia del `Builder`](#referencia-del-builder) · [Referencia de rutas](#referencia-de-rutas)
+- [La referencia de modelos (`__docs`)](#la-referencia-de-modelos) · [Prueba el ejemplo](#prueba-el-ejemplo)
 
 ---
 
@@ -46,7 +46,7 @@ registro a nivel de módulo.
 > **El admin está abierto por defecto.** Descubre y sirve *todos* los modelos
 > automáticamente — listar, crear, editar, eliminar — sin autenticación hasta que la
 > añadas. No lo expongas públicamente antes de conectar el inicio de sesión: consulta
-> [Autenticación](#authentication) más abajo.
+> [Autenticación](#autenticación) más abajo.
 
 El admin es un `axum::Router` que construyes a partir de un pool de base de datos y
 anidas bajo una ruta:
@@ -133,13 +133,13 @@ modelos, la miga de pan, el título de la página de detalle.
 | `list_per_page` | `10` | Tamaño de página (por defecto 50). |
 | `date_hierarchy` | `"published_at"` | Franja de desglose año → mes → día sobre la lista, en una columna Date/DateTime. |
 | `fieldsets` | `"Content: title, body \| Meta: status"` | Agrupa el formulario de cambio en secciones con título. La barra vertical `\|` separa secciones, la coma separa campos; la leyenda `Title:` es opcional. |
-| `actions` | `"publish, archive"` | Acciones masivas ofrecidas en el selector de acciones de la lista (cada una necesita un manejador registrado — ver [Acciones masivas](#bulk-actions)). |
+| `actions` | `"publish, archive"` | Acciones masivas ofrecidas en el selector de acciones de la lista (cada una necesita un manejador registrado — ver [Acciones masivas](#acciones-masivas)). |
 | `readonly_fields` | `"created_at"` | Campos renderizados como texto (sin entrada) en el formulario de cambio. |
 | `raw_id_fields` | `"author_id"` | Campos FK editados mediante una entrada de id sin procesar + un enlace de búsqueda (bueno para tablas objetivo grandes). |
 | `autocomplete_fields` | `"author_id"` | Campos FK editados mediante un autocompletado Ajax respaldado por el endpoint `__autocomplete` del objetivo. |
 | `prepopulated_fields` | `"slug:title"` | Autocompleta un campo sluggificando otro mientras escribes (`target:source`; combina fuentes con `+`). |
 | `list_select_related` | `"all"` / `"none"` / `"author_id"` | Controla el JOIN automático de columnas FK en la consulta de lista. `"all"` (por defecto) une cada FK; `"none"` lo desactiva; un CSV lo restringe a los FK nombrados. |
-| `formfield_overrides` | `"status:textarea"` | Sobrescribe el widget de formulario de un campo (`field:widget`) — ver la [tabla de widgets](#form-widgets). |
+| `formfield_overrides` | `"status:textarea"` | Sobrescribe el widget de formulario de un campo (`field:widget`) — ver la [tabla de widgets](#widgets-de-formulario). |
 | `actions_on_top` | `true` | Renderiza la barra de acciones masivas sobre la lista (por defecto `true`). |
 | `actions_on_bottom` | `false` | Renderiza una segunda barra de acciones bajo la lista (por defecto `false`). |
 

--- a/docs/es/api-conventions.md
+++ b/docs/es/api-conventions.md
@@ -8,18 +8,18 @@ Esta página explica los patrones que sigue la API de **Rustango**, para que pue
 
 ## Tabla de contenidos
 
-- [Naming](#naming)
-- [Constructors](#constructors)
-- [Return types](#return-types)
+- [Naming](#nombres)
+- [Constructors](#constructores)
+- [Return types](#tipos-de-retorno)
 - [Async vs sync](#async-vs-sync)
-- [The pool argument](#the-pool-argument)
-- [Filtering](#filtering)
-- [Errors](#errors)
-- [Module naming](#module-naming)
-- [Builders vs config structs](#builders-vs-config-structs)
+- [The pool argument](#el-argumento-pool)
+- [Filtering](#filtrado)
+- [Errors](#errores)
+- [Module naming](#nombres-de-módulos)
+- [Builders vs config structs](#builders-vs-structs-de-configuración)
 - [Feature flags](#feature-flags)
 - [Macros vs runtime](#macros-vs-runtime)
-- [Contributing](#contributing)
+- [Contributing](#contribuir)
 
 ---
 
@@ -311,7 +311,7 @@ Cuando añadas una nueva funcionalidad, sigue estos pasos:
 5. **Pon los tests unitarios en el mismo archivo**, tras `#[cfg(test)] mod tests` — sin base de datos a menos que realmente necesites una.
 6. **Pon los tests de integración en `crates/rustango/tests/<name>.rs`** para la historia de extremo a extremo.
 7. **No añadas un nuevo tipo de error a menos que los existentes no encajen** — extiende primero un enum existente.
-8. **Sigue la [guía de tipos de retorno](#return-types)** al elegir entre `Result`, `Option` o `bool`.
+8. **Sigue la [guía de tipos de retorno](#tipos-de-retorno)** al elegir entre `Result`, `Option` o `bool`.
 9. **¿Añades un subcomando de `manage`?** Conéctalo en el dispatcher `match cmd` y en `print_help`, añade un test en `crates/rustango/tests/migrate_manage.rs`, y documenta una fila en `docs/manage.md`.
 10. **Actualiza `CHANGELOG.md`** con una entrada `Added` bajo la próxima versión.
 

--- a/docs/es/auth-api-keys.md
+++ b/docs/es/auth-api-keys.md
@@ -28,13 +28,13 @@ las claves y autentica las peticiones `Authorization: Bearer`.
 
 ## Tabla de contenidos
 
-- [Cómo funciona una clave de API](#how-an-api-key-works)
-- [El ayudante autónomo](#the-standalone-helper)
-- [El backend con almacenamiento](#the-stored-backend)
-- [Emitir una clave (CLI + código)](#issuing-a-key)
-- [Autenticar peticiones](#authenticating-requests)
-- [Notas de seguridad](#security-notes)
-- [Véase también](#see-also)
+- [Cómo funciona una clave de API](#cómo-funciona-una-clave-de-api)
+- [El ayudante autónomo](#el-ayudante-autónomo)
+- [El backend con almacenamiento](#el-backend-con-almacenamiento)
+- [Emitir una clave (CLI + código)](#emitir-una-clave)
+- [Autenticar peticiones](#autenticar-peticiones)
+- [Notas de seguridad](#notas-de-seguridad)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/auth-backends.md
+++ b/docs/es/auth-backends.md
@@ -25,12 +25,12 @@ rutas y el extractor `CurrentUser` para leer el resultado.
 
 ## Tabla de contenidos
 
-- [La cadena](#the-chain) · [Los backends integrados](#the-built-in-backends)
-- [Restringir rutas: require_auth](#gating-routes-require_auth)
-- [Leer el usuario: CurrentUser](#reading-the-user-currentuser)
-- [Permisos: require_perm](#permissions-require_perm)
-- [El registro portable](#the-portable-registry)
-- [Véase también](#see-also)
+- [La cadena](#la-cadena) · [Los backends integrados](#los-backends-integrados)
+- [Restringir rutas: require_auth](#restringir-rutas-require_auth)
+- [Leer el usuario: CurrentUser](#leer-el-usuario-currentuser)
+- [Permisos: require_perm](#permisos-require_perm)
+- [El registro portable](#el-registro-portable)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/auth-decorators.md
+++ b/docs/es/auth-decorators.md
@@ -28,10 +28,10 @@ tu página de inicio de sesión (flujo de navegador) o respondidas con 401/403
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) · [Barreras de navegador vs. API](#browser-vs-api-gates)
-- [La familia de barreras](#the-gate-family) · [Barreras por predicado y por rol](#predicate-and-role-gates)
-- [Barreras de permiso](#permission-gates) · [El viaje de ida y vuelta de `?next=`](#the-next-round-trip)
-- [Notas y límites](#notes-and-limits)
+- [Inicio rápido](#inicio-rápido) · [Barreras de navegador vs. API](#barreras-de-navegador-vs-api)
+- [La familia de barreras](#la-familia-de-barreras) · [Barreras por predicado y por rol](#barreras-por-predicado-y-por-rol)
+- [Barreras de permiso](#barreras-de-permiso) · [El viaje de ida y vuelta de `?next=`](#el-viaje-de-ida-y-vuelta-de-next)
+- [Notas y límites](#notas-y-límites)
 
 ---
 

--- a/docs/es/auth-flows.md
+++ b/docs/es/auth-flows.md
@@ -22,13 +22,13 @@ firma HMAC añadida, de modo que el servidor puede confiar en sus parámetros si
 
 ## Tabla de contenidos
 
-- [URL firmadas: el sustrato](#signed-urls-the-substrate)
-- [Restablecimiento de contraseña](#password-reset)
-- [Verificación de correo electrónico](#email-verification)
-- [Inicio de sesión por enlace mágico](#magic-link-login)
-- [Tokens de un solo uso](#single-use-tokens)
-- [Lo que aportas tú](#what-you-provide)
-- [Véase también](#see-also)
+- [URL firmadas: el sustrato](#url-firmadas-el-sustrato)
+- [Restablecimiento de contraseña](#restablecimiento-de-contraseña)
+- [Verificación de correo electrónico](#verificación-de-correo-electrónico)
+- [Inicio de sesión por enlace mágico](#inicio-de-sesión-por-enlace-mágico)
+- [Tokens de un solo uso](#tokens-de-un-solo-uso)
+- [Lo que aportas tú](#lo-que-aportas-tú)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/auth-hmac.md
+++ b/docs/es/auth-hmac.md
@@ -24,13 +24,13 @@ como una única capa tower.
 
 ## Tabla de contenidos
 
-- [Cuándo usarlo](#when-to-use-it)
-- [Qué se firma](#what-gets-signed)
-- [Servidor: verificar con la capa](#server-verify-with-the-layer)
-- [Cliente: firmar una solicitud](#client-sign-a-request)
-- [Desfase de reloj y replay](#clock-skew-and-replay)
-- [Límites](#limits)
-- [Véase también](#see-also)
+- [Cuándo usarlo](#cuándo-usarlo)
+- [Qué se firma](#qué-se-firma)
+- [Servidor: verificar con la capa](#servidor-verificar-con-la-capa)
+- [Cliente: firmar una solicitud](#cliente-firmar-una-solicitud)
+- [Desfase de reloj y replay](#desfase-de-reloj-y-replay)
+- [Límites](#límites)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/auth-jwt-api.md
+++ b/docs/es/auth-jwt-api.md
@@ -30,10 +30,10 @@ duración, un token de *refresco* de larga duración, rotación en el refresco, 
 ---
 
 ## Tabla de contenidos
-- [El router integrado](#the-built-in-router) · [El cableado](#wiring-it-up)
-- [El motor de tokens](#the-token-engine-jwtlifecycle) · [Refresco y rotación](#refresh-and-rotation)
-- [Revocación y el almacén de JTI](#revocation-and-the-jti-store) · [Claims personalizados](#custom-claims)
-- [Notas y límites](#notes-and-limits)
+- [El router integrado](#el-router-integrado) · [El cableado](#el-cableado)
+- [El motor de tokens](#el-motor-de-tokens-jwtlifecycle) · [Refresco y rotación](#refresco-y-rotación)
+- [Revocación y el almacén de JTI](#revocación-y-el-almacén-de-jti) · [Claims personalizados](#claims-personalizados)
+- [Notas y límites](#notas-y-límites)
 
 ---
 
@@ -246,7 +246,7 @@ menos que uses `refresh_with`.
   autenticación](auth-backends.md) para autenticar rutas arbitrarias a partir de
   la cabecera `Authorization: Bearer`.
 - **Firma HS256**, suelo de clave de 32 bytes — mismo algoritmo y mismas
-  restricciones que el [JWT independiente](auth-jwt.md#security-model).
+  restricciones que el [JWT independiente](auth-jwt.md#modelo-de-seguridad).
 
 
 ---

--- a/docs/es/auth-jwt.md
+++ b/docs/es/auth-jwt.md
@@ -26,10 +26,10 @@ claims, `decode` para verificarlos y volver a leerlos, HS256 por debajo.
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) · [Cuándo usarlo](#when-to-use-standalone-jwt)
-- [Construir claims](#building-claims) · [Verificar](#verifying-a-token)
-- [Modelo de seguridad](#security-model) — léelo · [Inspeccionar sin confiar](#inspecting-without-verifying)
-- [Notas y límites](#notes-and-limits)
+- [Inicio rápido](#inicio-rápido) · [Cuándo usarlo](#cuándo-usar-un-jwt-independiente)
+- [Construir claims](#construir-claims) · [Verificar](#verificar-un-token)
+- [Modelo de seguridad](#modelo-de-seguridad) — léelo · [Inspeccionar sin confiar](#inspeccionar-sin-verificar)
+- [Notas y límites](#notas-y-límites)
 
 ---
 

--- a/docs/es/auth-passwords.md
+++ b/docs/es/auth-passwords.md
@@ -27,10 +27,10 @@ plano.
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) · [Por qué argon2id](#why-argon2id)
-- [Hashear al registrarse](#hashing-on-signup) · [Verificar al iniciar sesión](#verifying-on-login)
-- [Inicios de sesión con tiempos seguros](#timing-safe-logins-account-enumeration) · [Comprobaciones de robustez](#strength-checks)
-- [Dónde vive el hash](#where-the-hash-lives) · [Notas y límites](#notes-and-limits)
+- [Inicio rápido](#inicio-rápido) · [Por qué argon2id](#por-qué-argon2id)
+- [Hashear al registrarse](#hashear-al-registrarse) · [Verificar al iniciar sesión](#verificar-al-iniciar-sesión)
+- [Inicios de sesión con tiempos seguros](#inicios-de-sesión-con-tiempos-seguros-enumeración-de-cuentas) · [Comprobaciones de robustez](#comprobaciones-de-robustez)
+- [Dónde vive el hash](#dónde-vive-el-hash) · [Notas y límites](#notas-y-límites)
 
 ---
 

--- a/docs/es/auth-sessions.md
+++ b/docs/es/auth-sessions.md
@@ -32,10 +32,10 @@ petición.
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) · [Sesiones vs. JWT](#sessions-vs-jwt)
-- [La bolsa de sesión](#the-session-bag) · [La cookie](#the-cookie)
-- [Elegir un backend](#picking-a-backend) · [Caducidad y renovación deslizante](#expiry-and-sliding-renewal)
-- [Actualizar in situ](#updating-a-session-in-place) · [Notas y límites](#notes-and-limits)
+- [Inicio rápido](#inicio-rápido) · [Sesiones vs. JWT](#sesiones-vs-jwt)
+- [La bolsa de sesión](#la-bolsa-de-sesión) · [La cookie](#la-cookie)
+- [Elegir un backend](#elegir-un-backend) · [Caducidad y renovación deslizante](#caducidad-y-renovación-deslizante)
+- [Actualizar in situ](#actualizar-una-sesión-in-situ) · [Notas y límites](#notas-y-límites)
 
 ---
 
@@ -113,7 +113,7 @@ cookie de sesión necesita:
 
 - **`HttpOnly`** — JavaScript no puede leerla (embota el robo de tokens por XSS).
 - **`SameSite=Lax`** — no se envía en subpeticiones entre sitios (defensa CSRF;
-  combínala con [tokens CSRF](security.md#protecting-against-csrf) para los envíos
+  combínala con [tokens CSRF](security.md#protección-contra-csrf) para los envíos
   de formularios).
 - **`Secure`** — solo HTTPS (omítelo únicamente para el desarrollo HTTP local).
 - **`Path=/`** — visible para toda la aplicación.

--- a/docs/es/benchmarks.md
+++ b/docs/es/benchmarks.md
@@ -14,7 +14,7 @@ un runtime más robusto: **Django** sobre **gunicorn** (WSGI) y sobre
 de cada.
 
 Cada número de abajo es **medido y reproducible**, de una ejecución consistente
-de un arnés de un solo comando (ver [Reproducir](#reproduce)). Nada aquí es
+de un arnés de un solo comando (ver [Reproducir](#reproducir)). Nada aquí es
 palabrería.
 
 > **TL;DR.** Sobre hardware idéntico sirviendo páginas HTML renderizadas

--- a/docs/es/caching.md
+++ b/docs/es/caching.md
@@ -26,15 +26,15 @@ de Django o la fachada `Cache` de Laravel.
 
 ## Tabla de contenidos
 
-- [Paso 1 — Elegir un backend](#step-1--pick-a-backend)
-- [Paso 2 — get / set / delete](#step-2--get--set--delete)
-- [Paso 3 — get_or_set (cache-aside)](#step-3--get_or_set-cache-aside)
-- [Valores JSON tipados](#typed-json-values)
-- [TTL y expiración](#ttl-and-expiry)
-- [Cambiar de backend](#swapping-backends)
-- [Caché con multi-tenancy](#caching-under-multi-tenancy)
-- [Referencia](#reference)
-- [Véase también](#see-also)
+- [Paso 1 — Elegir un backend](#paso-1--elegir-un-backend)
+- [Paso 2 — get / set / delete](#paso-2--get--set--delete)
+- [Paso 3 — get_or_set (cache-aside)](#paso-3--get_or_set-cache-aside)
+- [Valores JSON tipados](#valores-json-tipados)
+- [TTL y expiración](#ttl-y-expiración)
+- [Cambiar de backend](#cambiar-de-backend)
+- [Caché con multi-tenancy](#caché-con-multi-tenancy)
+- [Referencia](#referencia)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/email.md
+++ b/docs/es/email.md
@@ -24,15 +24,15 @@ en tu terminal a SMTP real con un cambio de una línea — como el framework de 
 
 ## Tabla de contenidos
 
-- [Paso 1 — Construye un correo](#step-1--build-an-email)
-- [Paso 2 — Elige un mailer](#step-2--pick-a-mailer)
-- [Paso 3 — Envíalo](#step-3--send-it)
-- [Validación y protección contra inyección de cabeceras](#validation-and-header-injection-safety)
-- [Probar el correo](#testing-email)
-- [Plantillas](#templates)
-- [Envíalo fuera de la petición](#send-it-off-the-request)
-- [Referencia](#reference)
-- [Véase también](#see-also)
+- [Paso 1 — Construye un correo](#paso-1--construye-un-correo)
+- [Paso 2 — Elige un mailer](#paso-2--elige-un-mailer)
+- [Paso 3 — Envíalo](#paso-3--envíalo)
+- [Validación y protección contra inyección de cabeceras](#validación-y-protección-contra-inyección-de-cabeceras)
+- [Probar el correo](#probar-el-correo)
+- [Plantillas](#plantillas)
+- [Envíalo fuera de la petición](#envíalo-fuera-de-la-petición)
+- [Referencia](#referencia)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/files.md
+++ b/docs/es/files.md
@@ -28,14 +28,14 @@ cambio de una línea.
 
 ## Tabla de contenidos
 
-- [Paso 1 — Elige un backend de almacenamiento](#step-1--pick-a-storage-backend)
-- [Paso 2 — Guarda, carga y sirve archivos](#step-2--save-load-and-serve-files)
-- [Paso 3 — Acepta una subida](#step-3--accept-an-upload)
-- [Nombres de archivo seguros](#safe-filenames)
-- [Producción: almacenamiento compatible con S3](#production-s3-compatible-storage)
-- [La biblioteca de medios](#the-media-library)
-- [Referencia](#reference)
-- [Véase también](#see-also)
+- [Paso 1 — Elige un backend de almacenamiento](#paso-1--elige-un-backend-de-almacenamiento)
+- [Paso 2 — Guarda, carga y sirve archivos](#paso-2--guarda-carga-y-sirve-archivos)
+- [Paso 3 — Acepta una subida](#paso-3--acepta-una-subida)
+- [Nombres de archivo seguros](#nombres-de-archivo-seguros)
+- [Producción: almacenamiento compatible con S3](#producción-almacenamiento-compatible-con-s3)
+- [La biblioteca de medios](#la-biblioteca-de-medios)
+- [Referencia](#referencia)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/glossary.md
+++ b/docs/es/glossary.md
@@ -4,17 +4,17 @@ Una referencia en lenguaje sencillo de las palabras usadas en esta documentació
 término de una guía te resulta desconocido, búscalo aquí primero. Las definiciones son
 deliberadamente informales — las guías en profundidad tienen los detalles precisos.
 
-Si nunca has construido una API web antes, lee [Fundamentos de las API web](#web-api-basics)
+Si nunca has construido una API web antes, lee [Fundamentos de las API web](#fundamentos-de-las-api-web)
 de principio a fin; es una introducción de cinco minutos. Todo lo demás está pensado para
 consultarse sobre la marcha.
 
 ## Tabla de contenidos
 
-- [Fundamentos de las API web](#web-api-basics) — qué es una API, en términos cotidianos
-- [Bloques de construcción de Rustango](#rustango-building-blocks) — las piezas que ensamblas
-- [Los datos y la base de datos](#data-and-the-database)
-- [Unas pocas palabras de Rust](#a-few-rust-words) — para que los bloques de código no den miedo
-- [Frameworks con los que comparamos](#frameworks-we-compare-to)
+- [Fundamentos de las API web](#fundamentos-de-las-api-web) — qué es una API, en términos cotidianos
+- [Bloques de construcción de Rustango](#bloques-de-construcción-de-rustango) — las piezas que ensamblas
+- [Los datos y la base de datos](#los-datos-y-la-base-de-datos)
+- [Unas pocas palabras de Rust](#unas-pocas-palabras-de-rust) — para que los bloques de código no den miedo
+- [Frameworks con los que comparamos](#frameworks-con-los-que-comparamos)
 
 ---
 

--- a/docs/es/html-views.md
+++ b/docs/es/html-views.md
@@ -31,15 +31,15 @@ recursos de Laravel que devuelven vistas Blade. Renderizan mediante plantillas
 
 ## Tabla de contenidos
 
-- [Vistas de API vs vistas HTML — ¿cuál quieres?](#api-views-vs-html-views--which-do-you-want)
-- [Las cinco vistas de modelo](#the-five-model-views)
+- [Vistas de API vs vistas HTML — ¿cuál quieres?](#vistas-de-api-vs-vistas-html--cuál-quieres)
+- [Las cinco vistas de modelo](#las-cinco-vistas-de-modelo)
 - [ListView](#listview) · [DetailView](#detailview)
 - [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
-- [El contexto de Tera](#the-tera-context)
-- [TemplateView y RedirectView](#templateview-and-redirectview)
-- [Mono-inquilino vs multi-inquilino](#single-tenant-vs-multi-tenant)
-- [Servir un modelo de ambas formas](#serving-one-model-both-ways)
-- [Véase también](#see-also)
+- [El contexto de Tera](#el-contexto-de-tera)
+- [TemplateView y RedirectView](#templateview-y-redirectview)
+- [Mono-inquilino vs multi-inquilino](#mono-inquilino-vs-multi-inquilino)
+- [Servir un modelo de ambas formas](#servir-un-modelo-de-ambas-formas)
+- [Véase también](#véase-también)
 
 ---
 
@@ -60,7 +60,7 @@ Esta es la primera decisión. Ambas convierten un modelo en endpoints; difieren 
 | Análogo en Django | DRF `ModelViewSet` | vistas genéricas basadas en clases |
 
 No tienes que elegir globalmente — elige por recurso, y puedes montar **ambas
-sobre el mismo modelo** (ver [abajo](#serving-one-model-both-ways)). Reglas generales:
+sobre el mismo modelo** (ver [abajo](#servir-un-modelo-de-ambas-formas)). Reglas generales:
 
 - Construyes un **backend JSON** para un framework de frontend o app móvil → ViewSet.
 - Construyes un **sitio renderizado en el servidor** (el servidor devuelve páginas HTML) → vistas

--- a/docs/es/i18n.md
+++ b/docs/es/i18n.md
@@ -27,17 +27,17 @@ de esta guía. El `Translator` carga catálogos de mensajes por locale, sustituy
 
 ## Tabla de contenidos
 
-- [Las dos mitades de la i18n](#the-two-halves-of-i18n)
-- [Paso 1 — Construir un Translator](#step-1--build-a-translator)
-- [Paso 2 — Traducir cadenas (gettext)](#step-2--translate-strings-gettext)
+- [Las dos mitades de la i18n](#las-dos-mitades-de-la-i18n)
+- [Paso 1 — Construir un Translator](#paso-1--construir-un-translator)
+- [Paso 2 — Traducir cadenas (gettext)](#paso-2--traducir-cadenas-gettext)
 - [Placeholders](#placeholders)
-- [Pluralización](#pluralization)
-- [Orden de fallback](#fallback-order)
-- [Negociar el idioma](#negotiating-the-language)
-- [Idiomas de derecha a izquierda](#right-to-left-languages)
-- [Traducir en templates (Tera)](#translating-in-templates-tera)
-- [Cargar catálogos + sobrescrituras en tiempo de ejecución](#loading-catalogs--runtime-overrides)
-- [Véase también](#see-also)
+- [Pluralización](#pluralización)
+- [Orden de fallback](#orden-de-fallback)
+- [Negociar el idioma](#negociar-el-idioma)
+- [Idiomas de derecha a izquierda](#idiomas-de-derecha-a-izquierda)
+- [Traducir en templates (Tera)](#traducir-en-templates-tera)
+- [Cargar catálogos + sobrescrituras en tiempo de ejecución](#cargar-catálogos--sobrescrituras-en-tiempo-de-ejecución)
+- [Véase también](#véase-también)
 
 ---
 
@@ -45,9 +45,9 @@ de esta guía. El `Translator` carga catálogos de mensajes por locale, sustituy
 
 | Preocupación | Dónde | Qué hace |
 |---|---|---|
-| **Resolver** el locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | elige un locale por petición (cookie → Accept-Language → por defecto) y expone el extractor `ActiveLocale` |
+| **Resolver** el locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#middleware-consciente-del-locale) | elige un locale por petición (cookie → Accept-Language → por defecto) y expone el extractor `ActiveLocale` |
 | **Traducir** cadenas | `i18n::Translator` (esta guía) | busca una clave de mensaje en el catálogo del locale activo |
-| Renderizar fechas en la TZ del usuario | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | el filtro `{{ ts \| localtime }}` |
+| Renderizar fechas en la TZ del usuario | [`i18n::timezone`](middleware.md#middleware-consciente-de-la-zona-horaria) | el filtro `{{ ts \| localtime }}` |
 
 Cableas el middleware una vez, luego traduces usando el locale que resolvió.
 
@@ -75,7 +75,7 @@ let translator = Translator::new(Locale::new("en"))   // default locale
 ```
 
 Mantén el `Translator` en el estado de tu app (es barato de clonar-compartir) y
-busca cadenas con el [`ActiveLocale`](middleware.md#locale-aware-middleware) que
+busca cadenas con el [`ActiveLocale`](middleware.md#middleware-consciente-del-locale) que
 resolvió el middleware.
 
 ---
@@ -202,7 +202,7 @@ is_rtl_language("en");   // false
 ```
 
 En un template: `<html dir="{{ direction }}">`, alimentado desde el `ActiveLocale`.
-Consulta la [nota RTL en Middleware](middleware.md#locale-aware-middleware).
+Consulta la [nota RTL en Middleware](middleware.md#middleware-consciente-del-locale).
 
 ---
 

--- a/docs/es/jobs.md
+++ b/docs/es/jobs.md
@@ -28,18 +28,18 @@ es Django-Q / Celery / las colas de Laravel, en Rust.
 
 ## Tabla de contenidos
 
-- [Paso 1 — Definir un trabajo](#step-1--define-a-job)
-- [Paso 2 — Iniciar una cola](#step-2--start-a-queue)
-- [Paso 3 — Despachar desde un handler](#step-3--dispatch-from-a-handler)
-- [Paso 4 — Cablearlo en tu aplicación](#step-4--wire-it-into-your-app) — el ejemplo completo
-- [Ejecutar los workers (CLI + producción)](#running-the-workers-cli--production)
-- [Reintentos y backoff](#retries-and-backoff)
-- [El handler dead-letter](#the-dead-letter-handler)
-- [La cola persistente (producción)](#the-persistent-queue-production)
-- [Trabajos con multi-tenancy](#jobs-under-multi-tenancy)
-- [Barridos programados con multi-tenancy](#scheduled-sweeps-under-multi-tenancy)
-- [Referencia](#reference)
-- [Véase también](#see-also)
+- [Paso 1 — Definir un trabajo](#paso-1--definir-un-trabajo)
+- [Paso 2 — Iniciar una cola](#paso-2--iniciar-una-cola)
+- [Paso 3 — Despachar desde un handler](#paso-3--despachar-desde-un-handler)
+- [Paso 4 — Cablearlo en tu aplicación](#paso-4--cablearlo-en-tu-aplicación) — el ejemplo completo
+- [Ejecutar los workers (CLI + producción)](#ejecutar-los-workers-cli--producción)
+- [Reintentos y backoff](#reintentos-y-backoff)
+- [El handler dead-letter](#el-handler-dead-letter)
+- [La cola persistente (producción)](#la-cola-persistente-producción)
+- [Trabajos con multi-tenancy](#trabajos-con-multi-tenancy)
+- [Barridos programados con multi-tenancy](#barridos-programados-con-multi-tenancy)
+- [Referencia](#referencia)
+- [Véase también](#véase-también)
 
 ---
 
@@ -109,7 +109,7 @@ handlers puedan alcanzarlo.
 
 > **In-memory significa in-memory.** Los trabajos encolados o en curso se
 > **pierden al reiniciar**. Para todo lo que no puedas permitirte perder, usa la
-> [cola persistente](#the-persistent-queue-production).
+> [cola persistente](#la-cola-persistente-producción).
 
 ---
 
@@ -213,7 +213,7 @@ cargo run -- make:job WelcomeEmail   # scaffold a new job type
 A escala, a menudo quieres los workers **separados** del nivel web — para que un
 pico de tráfico no pueda dejar sin recursos a los trabajos, y para escalar cada
 uno de forma independiente. Con la [cola
-persistente](#the-persistent-queue-production) cada proceso extrae de la misma
+persistente](#la-cola-persistente-producción) cada proceso extrae de la misma
 tabla `rustango_jobs`, así que simplemente ejecuta un segundo binario, sin
 servidor, que construye la cola, la inicia y bloquea hasta una señal:
 
@@ -241,7 +241,7 @@ Despliégalo como su propio contenedor/servicio y escálalo a **N réplicas** �
 todas extraen de la tabla compartida de forma segura. El proceso web entonces
 solo necesita `dispatch` (no tiene que `start()` los workers). Empareja el worker
 con un barrido periódico
-[`reclaim_stuck_jobs_pool`](#the-persistent-queue-production) para recuperar
+[`reclaim_stuck_jobs_pool`](#la-cola-persistente-producción) para recuperar
 trabajos de un worker que se ha caído.
 
 ---
@@ -510,5 +510,5 @@ rechazado es el resultado esperado, así que no se registra nada. Seguimiento en
 - [Caché](caching.md) — la otra manera de mantener rápidos los handlers de
   peticiones.
 - [Signals](orm.md) — hooks fire-and-forget que a menudo *despachan* un trabajo.
-- [Comandos de tenancy](manage.md#tenancy-commands) — el provisionamiento de los
+- [Comandos de tenancy](manage.md#comandos-de-tenancy) — el provisionamiento de los
   tenants sobre los que una cola por tenant hace fan-out.

--- a/docs/es/mcp.md
+++ b/docs/es/mcp.md
@@ -28,16 +28,16 @@ por agente y OAuth 2.1 integrados.
 
 ## Tabla de contenidos
 
-- [Qué te aporta MCP](#what-mcp-gives-you)
-- [Paso 1 — Activar el feature](#step-1--enable-the-feature)
-- [Paso 2 — Definir una tool](#step-2--define-a-tool)
-- [Paso 3 — Montar el servidor](#step-3--mount-the-server)
-- [Paso 4 — Autorizar agentes](#step-4--authorize-agents)
-- [El protocolo](#the-protocol)
-- [Ajustes](#settings)
-- [Cómo probar](#how-to-test) — [la suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [el MCP Inspector visual](#c-test-it-visually-with-the-mcp-inspector) · [un cliente real](#d-connect-a-real-mcp-client)
-- [Build opcional vs. por defecto](#optional-vs-default-build)
-- [Véase también](#see-also)
+- [Qué te aporta MCP](#qué-te-aporta-mcp)
+- [Paso 1 — Activar el feature](#paso-1--activar-el-feature)
+- [Paso 2 — Definir una tool](#paso-2--definir-una-tool)
+- [Paso 3 — Montar el servidor](#paso-3--montar-el-servidor)
+- [Paso 4 — Autorizar agentes](#paso-4--autorizar-agentes)
+- [El protocolo](#el-protocolo)
+- [Ajustes](#ajustes)
+- [Cómo probar](#cómo-probar) — [la suite](#a-la-suite-de-tests) · [curl](#b-curl-al-json-rpc) · [el MCP Inspector visual](#c-pruébalo-visualmente-con-el-mcp-inspector) · [un cliente real](#d-conecta-un-cliente-mcp-real)
+- [Build opcional vs. por defecto](#build-opcional-vs-por-defecto)
+- [Véase también](#véase-también)
 
 ---
 
@@ -71,7 +71,7 @@ rustango = { version = "0.44", features = ["mcp"] }
 Arrastra `tenancy` (agentes/skills), `sse` (el flujo de notificaciones),
 `serializer` + `openapi` (los esquemas de entrada de las tools) y `jwt` (los
 tokens de agente). Un build **sin** el feature no compila nada del módulo MCP —
-consulta [Build opcional vs. por defecto](#optional-vs-default-build).
+consulta [Build opcional vs. por defecto](#build-opcional-vs-por-defecto).
 
 ---
 

--- a/docs/es/middleware.md
+++ b/docs/es/middleware.md
@@ -30,15 +30,15 @@ misma idea, adjunta a tu router.
 
 ## Tabla de contenidos
 
-- [Cómo funciona el middleware en Rustango](#how-middleware-works-in-rustango)
-- [El orden importa](#ordering-matters)
-- [El catálogo integrado](#the-built-in-catalog)
-- [Middleware consciente del locale](#locale-aware-middleware)
-- [Middleware consciente de la zona horaria](#timezone-aware-middleware)
-- [Cabeceras de seguridad](#security-headers)
-- [Protección CSRF](#csrf-protection)
-- [Escribir tu propio middleware](#writing-your-own-middleware)
-- [Véase también](#see-also)
+- [Cómo funciona el middleware en Rustango](#cómo-funciona-el-middleware-en-rustango)
+- [El orden importa](#el-orden-importa)
+- [El catálogo integrado](#el-catálogo-integrado)
+- [Middleware consciente del locale](#middleware-consciente-del-locale)
+- [Middleware consciente de la zona horaria](#middleware-consciente-de-la-zona-horaria)
+- [Cabeceras de seguridad](#cabeceras-de-seguridad)
+- [Protección CSRF](#protección-csrf)
+- [Escribir tu propio middleware](#escribir-tu-propio-middleware)
+- [Véase también](#véase-también)
 
 ---
 
@@ -76,7 +76,7 @@ Hay dos formas, y usarás ambas:
 2. **Una función mediante `axum::middleware::from_fn`** — la forma más rápida de
    escribir uno puntual. Recibes la `Request` y un `Next`; llamas a
    `next.run(req)` para continuar, y puedes hacer trabajo a ambos lados de esa
-   llamada. El [ejemplo de zona horaria](#timezone-aware-middleware) más abajo es
+   llamada. El [ejemplo de zona horaria](#middleware-consciente-de-la-zona-horaria) más abajo es
    exactamente esto.
 
 Ambos se componen libremente — un middleware `from_fn` *es* un layer, así que se
@@ -156,7 +156,7 @@ para obtener el método.
 | Caché de página | `CachePageLayer` | `.layer(..)` |
 | **Localización** | | |
 | Negociación de locale | `LocaleMiddleware` | `.layer(..)` (+ extractor `ActiveLocale`) |
-| Zona horaria activa | *(componer con `from_fn`)* | ver [más abajo](#timezone-aware-middleware) |
+| Zona horaria activa | *(componer con `from_fn`)* | ver [más abajo](#middleware-consciente-de-la-zona-horaria) |
 | **Desarrollo** | | |
 | Recarga en vivo | `LiveReloadLayer` | `.livereload(..)` |
 | Panel de depuración | `DebugPanelLayer` | `.debug_panel(..)` |
@@ -382,7 +382,7 @@ mutación sin opción de desactivarlo.
 ## Escribir tu propio middleware
 
 Ya viste la forma rápida — el [middleware de zona
-horaria](#timezone-aware-middleware) es un ejemplo `from_fn` completo. Recurre a
+horaria](#middleware-consciente-de-la-zona-horaria) es un ejemplo `from_fn` completo. Recurre a
 `from_fn` siempre que la lógica sea específica de la aplicación y no necesites
 configurarla:
 

--- a/docs/es/migrations.md
+++ b/docs/es/migrations.md
@@ -12,7 +12,7 @@ que una base de datos preexistente adopte el motor sin colisiones.
 > **¿Nuevo en las migraciones?** Los verbos de la CLI del día a día —
 > `makemigrations`, `migrate`, `migrate --squash`, `migrate --fake`,
 > `downgrade`, `showmigrations` — se tratan comando por comando en la
-> [guía de manage](manage.md#migrations). Esta página es el modelo conceptual
+> [guía de manage](manage.md#migraciones). Esta página es el modelo conceptual
 > que hay detrás de ellos.
 
 > **Fuente:** `rustango::migrate` (`runner`, `make`, `file`, `manage`)
@@ -189,7 +189,7 @@ en lugar de forzarlo.
 
 ## Véase también
 
-- [Guía de `manage`](manage.md#migrations) — cada verbo de la CLI de migración,
+- [Guía de `manage`](manage.md#migraciones) — cada verbo de la CLI de migración,
   con ejemplos.
 - [Scaffolding](scaffolding.md) — de dónde vienen `migrations/` y
   `system/migrations/`.

--- a/docs/es/models.md
+++ b/docs/es/models.md
@@ -26,16 +26,16 @@ consulta el [recetario del ORM](orm.md).
 
 ## Tabla de contenidos
 
-- [Anatomía de un modelo](#anatomy-of-a-model)
-- [Tipos de campo](#field-types) · [Tipos exclusivos de PostgreSQL](#postgresql-only-types)
-- [Claves primarias](#primary-keys) — [PKs personalizadas](#custom-primary-keys) · [compuestas](#composite-primary-keys)
-- [Relaciones](#relationships)
-- [Atributos de campo comunes](#common-field-attributes)
-- [Índices y restricciones](#indexes-and-constraints)
-- [Atributos de modelo comunes](#common-model-attributes)
-- [La API generada](#the-generated-api) — [save vs insert](#save-vs-insert)
-- [Referencia completa de atributos](#full-attribute-reference)
-- [Véase también](#see-also)
+- [Anatomía de un modelo](#anatomía-de-un-modelo)
+- [Tipos de campo](#tipos-de-campo) · [Tipos exclusivos de PostgreSQL](#tipos-exclusivos-de-postgresql)
+- [Claves primarias](#claves-primarias) — [PKs personalizadas](#claves-primarias-personalizadas) · [compuestas](#claves-primarias-compuestas)
+- [Relaciones](#relaciones)
+- [Atributos de campo comunes](#atributos-de-campo-comunes)
+- [Índices y restricciones](#índices-y-restricciones)
+- [Atributos de modelo comunes](#atributos-de-modelo-comunes)
+- [La API generada](#la-api-generada) — [save vs insert](#save-vs-insert)
+- [Referencia completa de atributos](#referencia-completa-de-atributos)
+- [Véase también](#véase-también)
 
 ---
 
@@ -73,7 +73,7 @@ A partir de esa única declaración el derive genera:
 - **constantes de campo tipadas** (`Post::title`, `Post::author_id`) para filtros
   verificados en compilación — `Post::objects().where_(Post::author_id.eq(42))`;
 - métodos de fila — **`save`**, **`find`**, **`delete`** y más (consulta
-  [la API generada](#the-generated-api)).
+  [la API generada](#la-api-generada)).
 
 El nombre de la tabla toma por defecto el nombre del modelo si omites `table`; los
 nombres de columna toman por defecto el nombre del campo en snake_case a menos que
@@ -269,7 +269,7 @@ pub author: ForeignKey<Author>,
 `ForeignKey<T>` toma por defecto `i64` como tipo de clave; si la PK del padre es de un
 tipo distinto, nómbralo: `ForeignKey<User, String>`. Uno-a-uno usa `#[rustango(o2o)]`;
 muchos-a-muchos es una tabla separada — consulta
-[Recetario del ORM → Muchos-a-muchos](orm.md#many-to-many). Carga de forma anticipada las
+[Recetario del ORM → Muchos-a-muchos](orm.md#muchos-a-muchos). Carga de forma anticipada las
 filas relacionadas con `select_related` (también en la guía del ORM).
 
 ---

--- a/docs/es/openapi.md
+++ b/docs/es/openapi.md
@@ -26,11 +26,11 @@ control total, los mismos tipos te permiten construir a mano cualquier especific
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) — genera + sirve en una sola pantalla
-- [Esquemas desde serializadores](#schemas-from-serializers) · [Rutas desde ViewSets](#paths-from-viewsets)
-- [Servirlo](#serving-the-spec-swagger-ui--redoc) · [Construir una especificación a mano](#hand-building-a-spec)
-- [Esquemas de seguridad](#security-schemes) · [El builder `Schema`](#the-schema-builder)
-- [Notas y límites](#notes-and-limits)
+- [Inicio rápido](#inicio-rápido) — genera + sirve en una sola pantalla
+- [Esquemas desde serializadores](#esquemas-desde-serializadores) · [Rutas desde ViewSets](#rutas-desde-viewsets)
+- [Servirlo](#servir-la-especificación-swagger-ui--redoc) · [Construir una especificación a mano](#construir-una-especificación-a-mano)
+- [Esquemas de seguridad](#esquemas-de-seguridad) · [El builder `Schema`](#el-builder-schema)
+- [Notas y límites](#notas-y-límites)
 
 ---
 
@@ -112,7 +112,7 @@ impl rustango::openapi::OpenApiSchema for Money {
 }
 ```
 
-> Consulta la [guía de Serializadores](serializers.md#openapi-schemas) para los
+> Consulta la [guía de Serializadores](serializers.md#esquemas-openapi) para los
 > atributos de campo que dan forma a la salida.
 
 ---
@@ -224,7 +224,7 @@ Helpers: `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
 `Operation`, `.no_security()` marca un endpoint público y
 `.require_security(scheme, scopes)` sobrescribe el valor global por defecto. Estos se
 alinean con la propia autenticación de **Rustango** (consulta la
-[guía de Seguridad](security.md#authenticating-users)): JWT → `bearer`, API keys →
+[guía de Seguridad](security.md#autenticar-usuarios)): JWT → `bearer`, API keys →
 `apiKey`, OAuth2 → `oauth2`.
 
 ---

--- a/docs/es/orm.md
+++ b/docs/es/orm.md
@@ -35,23 +35,23 @@ El CHANGELOG contiene el índice completo de tickets de cada versión.
 
 ## Tabla de contenidos
 
-- [Consultas](#querying)
-- [Valores calculados y funciones de base de datos](#computed-values--database-functions)
-- [Agregaciones](#aggregations)
-- [Joins y precarga de filas relacionadas](#joins--preloading-related-rows)
-- [Operaciones en lote](#bulk-operations)
-- [Insertar o actualizar (upsert)](#insert-or-update-upsert)
-- [Transacciones](#transactions)
-- [Muchos-a-muchos](#many-to-many)
+- [Consultas](#consultas)
+- [Valores calculados y funciones de base de datos](#valores-calculados-y-funciones-de-base-de-datos)
+- [Agregaciones](#agregaciones)
+- [Joins y precarga de filas relacionadas](#joins-y-precarga-de-filas-relacionadas)
+- [Operaciones en lote](#operaciones-en-lote)
+- [Insertar o actualizar (upsert)](#insertar-o-actualizar-upsert)
+- [Transacciones](#transacciones)
+- [Muchos-a-muchos](#muchos-a-muchos)
 - [JSON / JSONB](#json--jsonb)
-- [Borrado lógico (soft delete)](#soft-delete)
-- [Rastro de auditoría](#audit-trail)
-- [Válvula de escape a SQL crudo](#raw-sql-escape-hatch)
-- [Carga perezosa de FK](#lazy-fk-loading)
-- [Cuatro maneras de filtrar](#four-ways-to-filter)
-- [Consultas acotadas por tenant](#tenant-scoped-queries)
-- [Señales](#signals)
-- [Consejos de rendimiento](#performance-tips)
+- [Borrado lógico (soft delete)](#borrado-lógico-soft-delete)
+- [Rastro de auditoría](#rastro-de-auditoría)
+- [Válvula de escape a SQL crudo](#válvula-de-escape-a-sql-crudo)
+- [Carga perezosa de FK](#carga-perezosa-de-fk)
+- [Cuatro maneras de filtrar](#cuatro-maneras-de-filtrar)
+- [Consultas acotadas por tenant](#consultas-acotadas-por-tenant)
+- [Señales](#señales)
+- [Consejos de rendimiento](#consejos-de-rendimiento)
 
 ---
 
@@ -866,7 +866,7 @@ let featured = Author::objects()
 
 ### Cuándo bajar a SQL crudo en su lugar
 
-Los builders de arriba cubren los casos comunes. Para cosas que aún no expresan — `Cast`, búsqueda de texto completo, operadores de path de JSON, funciones de hash, trigonometría, funciones de ventana — ver la sección [Válvula de escape a SQL crudo](#raw-sql-escape-hatch) más abajo, o espera a los issues de seguimiento que extienden el mismo árbol de expresiones.
+Los builders de arriba cubren los casos comunes. Para cosas que aún no expresan — `Cast`, búsqueda de texto completo, operadores de path de JSON, funciones de hash, trigonometría, funciones de ventana — ver la sección [Válvula de escape a SQL crudo](#válvula-de-escape-a-sql-crudo) más abajo, o espera a los issues de seguimiento que extienden el mismo árbol de expresiones.
 
 ---
 

--- a/docs/es/security.md
+++ b/docs/es/security.md
@@ -6,25 +6,25 @@ Esta guía cubre todas las funciones de seguridad que incluye **Rustango** y có
 
 ## Tabla de contenidos
 
-- [La lista de comprobación de defensa en profundidad](#the-defense-in-depth-checklist)
-- [Establecer cabeceras de seguridad](#setting-security-headers)
-- [Permitir peticiones de origen cruzado (CORS)](#allowing-cross-origin-requests-cors)
-- [Limitar la tasa de peticiones](#rate-limiting-requests)
-- [Permitir o bloquear IPs](#allowing-or-blocking-ips)
-- [Protección contra CSRF](#protecting-against-csrf)
-- [Prevenir XSS](#preventing-xss)
-- [Prevenir la inyección SQL](#preventing-sql-injection)
-- [Autenticar usuarios](#authenticating-users)
-- [Hashear y verificar contraseñas](#hashing-and-checking-passwords)
-- [Emitir y refrescar JWTs](#issuing-and-refreshing-jwts)
-- [Autenticar con claves de API](#authenticating-with-api-keys)
-- [Añadir autenticación de dos factores (TOTP)](#adding-two-factor-auth-totp)
-- [Enviar URLs firmadas (enlaces mágicos)](#sending-signed-urls-magic-links)
-- [Verificar webhooks entrantes](#verifying-incoming-webhooks)
-- [Mantener los secretos fuera de tus registros](#keeping-secrets-out-of-your-logs)
-- [Rastrear peticiones a través de servicios](#tracing-requests-across-services)
-- [Gestionar secretos](#managing-secrets)
-- [Auditar antes de desplegar](#auditing-before-you-deploy)
+- [La lista de comprobación de defensa en profundidad](#la-lista-de-comprobación-de-defensa-en-profundidad)
+- [Establecer cabeceras de seguridad](#establecer-cabeceras-de-seguridad)
+- [Permitir peticiones de origen cruzado (CORS)](#permitir-peticiones-de-origen-cruzado-cors)
+- [Limitar la tasa de peticiones](#limitar-la-tasa-de-peticiones)
+- [Permitir o bloquear IPs](#permitir-o-bloquear-ips)
+- [Protección contra CSRF](#protección-contra-csrf)
+- [Prevenir XSS](#prevenir-xss)
+- [Prevenir la inyección SQL](#prevenir-la-inyección-sql)
+- [Autenticar usuarios](#autenticar-usuarios)
+- [Hashear y verificar contraseñas](#hashear-y-verificar-contraseñas)
+- [Emitir y refrescar JWTs](#emitir-y-refrescar-jwts)
+- [Autenticar con claves de API](#autenticar-con-claves-de-api)
+- [Añadir autenticación de dos factores (TOTP)](#añadir-autenticación-de-dos-factores-totp)
+- [Enviar URLs firmadas (enlaces mágicos)](#enviar-urls-firmadas-enlaces-mágicos)
+- [Verificar webhooks entrantes](#verificar-webhooks-entrantes)
+- [Mantener los secretos fuera de tus registros](#mantener-los-secretos-fuera-de-tus-registros)
+- [Rastrear peticiones a través de servicios](#rastrear-peticiones-a-través-de-servicios)
+- [Gestionar secretos](#gestionar-secretos)
+- [Auditar antes de desplegar](#auditar-antes-de-desplegar)
 
 ---
 
@@ -247,7 +247,7 @@ let safe = html_escape(user_input);
 
 Reemplaza `&`, `<`, `>`, `"`, `'`. Adecuado para el contenido de elementos HTML + atributos entre comillas dobles.
 
-Para la defensa XSS basada en CSP, consulta [Establecer cabeceras de seguridad](#setting-security-headers).
+Para la defensa XSS basada en CSP, consulta [Establecer cabeceras de seguridad](#establecer-cabeceras-de-seguridad).
 
 ---
 
@@ -655,14 +655,14 @@ Para comprobaciones más allá de las que se incluyen, extiende con código pers
 Un par de flujos de extremo a extremo todavía necesitan ensamblarse a partir de las primitivas de abajo:
 
 - **Restablecimiento de contraseña + verificación de email** — los ayudantes de emisión/verificación de tokens existen (`auth_flows::confirm_password_reset_pool`, además de los viajes de ida y vuelta de verificación de email) y la canalización de email se incluye por separado, pero no hay un único ciclo prefabricado de vista + email + validación conectado para ti.
-- **Redacción de PII del cuerpo / las cabeceras de la petición** en `access_log` — existe la redacción de registros a nivel de campo (consulta [Mantener los secretos fuera de tus registros](#keeping-secrets-out-of-your-logs)), pero no la depuración automática del cuerpo o las cabeceras de la petición.
+- **Redacción de PII del cuerpo / las cabeceras de la petición** en `access_log` — existe la redacción de registros a nivel de campo (consulta [Mantener los secretos fuera de tus registros](#mantener-los-secretos-fuera-de-tus-registros)), pero no la depuración automática del cuerpo o las cabeceras de la petición.
 
 Ya incluido (no recurras a un apaño):
 
 - **Inicio de sesión social OAuth2 / OIDC** — `oauth2::providers` incluye ayudantes para Google, GitHub, Microsoft, GitLab y Discord (además de `OAuth2Provider::from_discovery` para cualquier proveedor OIDC), y `oauth2::router::oauth2_router` monta las rutas de inicio de sesión + callback, crea el registro de usuario y establece la cookie de sesión.
 - **Bloqueo por cuenta** — `rustango::account_lockout::Lockout` (respaldado por caché; `is_locked` / `record_failure` / `clear`, con `max_attempts` + `lockout_duration` configurables).
 - **Endpoint de informe de CSP** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
-- **Limitación de tasa distribuida** — `rate_limit_cache::CacheRateLimitLayer` (consulta [Limitar la tasa de peticiones](#rate-limiting-requests)).
+- **Limitación de tasa distribuida** — `rate_limit_cache::CacheRateLimitLayer` (consulta [Limitar la tasa de peticiones](#limitar-la-tasa-de-peticiones)).
 
 Hasta que aterricen los flujos no incluidos, ensámblalos a partir de las primitivas de arriba (`signed_url::sign` para los tokens de restablecimiento de contraseña, la canalización de email para la entrega, etc.).
 

--- a/docs/es/serializers.md
+++ b/docs/es/serializers.md
@@ -33,13 +33,13 @@ escrituras *a través* de él.
 ---
 
 ## Tabla de contenidos
-- [Inicio rápido](#quick-start) · [El trait `ModelSerializer`](#the-modelserializer-trait)
-- [Atributos de campo](#field-attributes) — la referencia completa
-- [Campos calculados](#computed-fields) · [Serializadores anidados](#nested-serializers) · [Colecciones](#collections-many) · [Campos slug](#slug-related-fields)
-- [Validación](#validation) · [Validación unique-together](#unique-together-validation)
-- [Salida con hipervínculos](#hyperlinked-output) · [Serializar listas](#serializing-lists)
-- [Usar un serializador con un ViewSet](#using-a-serializer-with-a-viewset) · [Validar en un handler personalizado](#validating-in-a-custom-handler)
-- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Ajustes y límites](#tweaks-and-current-limits)
+- [Inicio rápido](#inicio-rápido) · [El trait `ModelSerializer`](#el-trait-modelserializer)
+- [Atributos de campo](#atributos-de-campo) — la referencia completa
+- [Campos calculados](#campos-calculados) · [Serializadores anidados](#serializadores-anidados) · [Colecciones](#colecciones-many) · [Campos slug](#campos-slug-relacionados)
+- [Validación](#validación) · [Validación unique-together](#validación-unique-together)
+- [Salida con hipervínculos](#salida-con-hipervínculos) · [Serializar listas](#serializar-listas)
+- [Usar un serializador con un ViewSet](#usar-un-serializador-con-un-viewset) · [Validar en un handler personalizado](#validar-en-un-handler-personalizado)
+- [OpenAPI](#esquemas-openapi) · [Scaffolding](#scaffolding) · [Ajustes y límites](#ajustes-y-límites-actuales)
 
 ---
 
@@ -133,7 +133,7 @@ Todo se controla con `#[serializer(...)]` en cada campo. El conjunto completo:
 **Validadores declarativos.** `max_length = N`, `min_length = N`, `min = N` y
 `max = N` añaden validación en tiempo de escritura a un campo sin cambiar su forma de
 salida (y un campo sin ninguno de ellos hereda los límites del modelo). Consulta
-[Validación](#validation).
+[Validación](#validación).
 
 `write_only` es para datos solo de entrada (una contraseña, un token de un solo uso):
 presente en `writable_fields()`, ausente de la salida. `skip` es la escotilla de
@@ -203,7 +203,7 @@ pub author: AuthorBrief,
 
 Los campos anidados son **de solo lectura** en la forma de salida — los objetos
 anidados escribibles todavía no están soportados (consulta
-[límites](#tweaks-and-current-limits)).
+[límites](#ajustes-y-límites-actuales)).
 
 ---
 
@@ -512,7 +512,7 @@ Unos cuantos filos afilados y escotillas de escape que conviene conocer:
 - **Los validadores integrados son solo de longitud/rango/opción** — `max_length` /
   `min_length` / `min` / `max` (y `choices` heredados) son declarativos; otras reglas
   (`email`, regex, …) son funciones que escribes tú (consulta
-  [Validación](#validation)).
+  [Validación](#validación)).
 - **Un validador por campo por cada campo.** Para varias reglas en un campo,
   combínalas en la función de ese campo, o añade un `validate(&self)` entre campos.
 - **El serializador no persiste.** Mapea → valida → entrega los datos al ORM; no hay

--- a/docs/es/sso.md
+++ b/docs/es/sso.md
@@ -72,7 +72,7 @@ para esa columna.
    error genérico (los detalles van al log del servidor, nunca al navegador).
 
 El **secreto** del cliente está **cifrado en reposo** — la columna `client_secret`
-es un cast [`EncryptedString`](#secret-storage), descifrado en memoria solo en el
+es un cast [`EncryptedString`](#almacenamiento-de-secretos), descifrado en memoria solo en el
 momento del inicio de sesión.
 
 ## Los proveedores son filas, gestionadas en el admin

--- a/docs/es/testing.md
+++ b/docs/es/testing.md
@@ -26,13 +26,13 @@ Rust.
 
 ## Tabla de contenidos
 
-- [Paso 1 — Controla tu aplicación con TestClient](#step-1--drive-your-app-with-testclient)
-- [Paso 2 — Haz aserciones sobre la respuesta](#step-2--assert-on-the-response)
-- [Enviar JSON, cabeceras y cuerpos](#sending-json-headers-and-bodies)
-- [Probar una API real](#testing-a-real-api)
-- [Pruebas de base de datos con reversión](#database-tests-with-rollback)
-- [Ayudantes de aserción de respuesta](#response-assertion-helpers)
-- [Véase también](#see-also)
+- [Paso 1 — Controla tu aplicación con TestClient](#paso-1--controla-tu-aplicación-con-testclient)
+- [Paso 2 — Haz aserciones sobre la respuesta](#paso-2--haz-aserciones-sobre-la-respuesta)
+- [Enviar JSON, cabeceras y cuerpos](#enviar-json-cabeceras-y-cuerpos)
+- [Probar una API real](#probar-una-api-real)
+- [Pruebas de base de datos con reversión](#pruebas-de-base-de-datos-con-reversión)
+- [Ayudantes de aserción de respuesta](#ayudantes-de-aserción-de-respuesta)
+- [Véase también](#véase-también)
 
 ---
 

--- a/docs/es/urls.md
+++ b/docs/es/urls.md
@@ -20,11 +20,11 @@ Django.
 ---
 
 ## Tabla de contenidos
-- [Registrar una URL con nombre](#register-a-named-url)
-- [Reverse en Rust](#reverse-in-rust) · [Reverse en templates](#reverse-in-templates)
-- [Redirigir por nombre](#redirect-by-name) · [Namespacing](#namespacing)
-- [Inspeccionar el mapa de URLs](#inspect-the-url-map) · [Errores](#errors)
-- [Patrones regex y de ruta tipados](#regex--typed-path-patterns) · [Notas y límites](#notes-and-limits)
+- [Registrar una URL con nombre](#registrar-una-url-con-nombre)
+- [Reverse en Rust](#reverse-en-rust) · [Reverse en templates](#reverse-en-templates)
+- [Redirigir por nombre](#redirigir-por-nombre) · [Namespacing](#namespacing)
+- [Inspeccionar el mapa de URLs](#inspeccionar-el-mapa-de-urls) · [Errores](#errores)
+- [Patrones regex y de ruta tipados](#patrones-regex-y-de-ruta-tipados) · [Notas y límites](#notas-y-límites)
 
 ---
 
@@ -75,7 +75,7 @@ let url = reverse_owned("post-detail", &owned_params)?;
 
 `reverse` es **estricto**: un placeholder faltante, o una clave `params` extra que
 el patrón no tiene, es un error (no un desajuste silencioso) — consulta
-[Errores](#errors).
+[Errores](#errores).
 
 ---
 
@@ -285,7 +285,7 @@ para los lookups `__regex`), así que un extractor validador puede compilar una
   colocar en un header `Location` o un `href`.
 - **Sin convertidores regex/tipados** en los patrones (el `<int:pk>` de Django);
   los placeholders son simples `{name}` y los valores se sustituyen tal cual
-  (después de codificar). Consulta [Patrones regex y de ruta tipados](#regex--typed-path-patterns)
+  (después de codificar). Consulta [Patrones regex y de ruta tipados](#patrones-regex-y-de-ruta-tipados)
   para el porqué, y cómo restringir una ruta en su lugar.
 
 

--- a/docs/es/viewsets.md
+++ b/docs/es/viewsets.md
@@ -8,7 +8,7 @@ alguno de esos.)
 
 > **¿Nuevo en las APIs REST?** Esta guía asume que sabes qué es un *endpoint*, un
 > *verbo HTTP* (GET / POST / …) y una *petición y respuesta JSON*. Si algo de eso
-> te resulta confuso, el [glosario](glossary.md#web-api-basics) es una
+> te resulta confuso, el [glosario](glossary.md#fundamentos-de-las-api-web) es una
 > introducción de cinco minutos — léelo primero y luego vuelve aquí.
 
 Empareja un ViewSet con un [serializador](serializers.md) — la pieza que da forma
@@ -215,7 +215,7 @@ verifica la longitud contra el `max_length = 200` del modelo, y una columna con
 `choices`/`min`/`max` también se verificaría, todo devolviendo `400`s amigables
 en la escritura. Añade los atributos de serializador `max_length` / `min_length` /
 `min` / `max` para sobrescribir el límite de un campo. (Consulta la
-[guía de serializadores](serializers.md#validation) para la historia completa de
+[guía de serializadores](serializers.md#validación) para la historia completa de
 validación.)
 
 ### Step 5 — Scaffold the ViewSet and wire the serializer
@@ -647,7 +647,7 @@ tablas muy grandes. `?cursor=<token>&page_size=20`:
 Con un **serializador conectado**, la ruta de create/update ejecuta los
 validadores del serializador y devuelve `400`s con forma de DRF — la forma
 recomendada de validar (ver [el matrimonio](#the-serializer-marriage-input--output)
-y la [guía de serializadores](serializers.md#validation)). Se ejecutan tres capas:
+y la [guía de serializadores](serializers.md#validación)). Se ejecutan tres capas:
 
 - **Restricciones declarativas** — `max_length` / `min_length` / `min` / `max`, y
   por defecto el campo **hereda del modelo** `max_length` / `min` / `max` /

--- a/docs/es/websockets.md
+++ b/docs/es/websockets.md
@@ -31,14 +31,14 @@ vienes de Django, esto es Channels; de Laravel, Echo/Reverb; de Node,
 
 ## Tabla de contenidos
 
-- [¿SSE o WebSocket — cuál?](#sse-or-websocket--which)
-- [El bus de difusión](#the-broadcast-bus)
+- [¿SSE o WebSocket — cuál?](#sse-o-websocket--cuál)
+- [El bus de difusión](#el-bus-de-difusión)
 - [Server-Sent Events](#server-sent-events)
 - [WebSockets](#websockets)
-- [Enviar desde otro sitio](#sending-from-elsewhere)
-- [Auth y multi-inquilino](#auth--tenancy)
-- [Notas de escalado](#scaling-notes)
-- [Flags de características](#feature-flags)
+- [Enviar desde otro sitio](#enviar-desde-otro-sitio)
+- [Auth y multi-inquilino](#auth-y-multi-inquilino)
+- [Notas de escalado](#notas-de-escalado)
+- [Flags de características](#flags-de-características)
 
 ---
 

--- a/docs/fr/admin.md
+++ b/docs/fr/admin.md
@@ -29,16 +29,16 @@ macros d'enregistrement au niveau du module.
 ---
 
 ## Table des matières
-- [Le monter](#mount-it) · [La page d'accueil](#the-home-page)
-- [Configurer un modèle : le bloc `admin(...)`](#configure-a-model-the-admin-block)
-- [La vue liste](#the-list-view) — colonnes, recherche, filtres, hiérarchie de dates, tri, pagination
-- [Le formulaire de modification](#the-change-form) — fieldsets, widgets, édition des FK, champs prépeuplés et en lecture seule
-- [Inlines](#inlines) · [Actions groupées](#bulk-actions) · [Piste d'audit](#audit-trail)
-- [Colonnes calculées et filtres personnalisés](#computed-columns-and-custom-filters)
-- [Vues personnalisées, querysets et permissions](#custom-views-querysets-and-permissions)
-- [Authentification](#authentication) · [Thème et image de marque](#theming-and-branding)
-- [Référence `Builder`](#builder-reference) · [Référence des routes](#routes-reference)
-- [La référence de modèle (`__docs`)](#the-model-reference) · [Essayer l'exemple](#try-the-example)
+- [Le monter](#le-monter) · [La page d'accueil](#la-page-daccueil)
+- [Configurer un modèle : le bloc `admin(...)`](#configurer-un-modèle--le-bloc-admin)
+- [La vue liste](#la-vue-liste) — colonnes, recherche, filtres, hiérarchie de dates, tri, pagination
+- [Le formulaire de modification](#le-formulaire-de-modification) — fieldsets, widgets, édition des FK, champs prépeuplés et en lecture seule
+- [Inlines](#inlines) · [Actions groupées](#actions-groupées) · [Piste d'audit](#piste-daudit)
+- [Colonnes calculées et filtres personnalisés](#colonnes-calculées-et-filtres-personnalisés)
+- [Vues personnalisées, querysets et permissions](#vues-personnalisées-querysets-et-permissions)
+- [Authentification](#authentification) · [Thème et image de marque](#thème-et-image-de-marque)
+- [Référence `Builder`](#référence-builder) · [Référence des routes](#référence-des-routes)
+- [La référence de modèle (`__docs`)](#la-référence-de-modèle) · [Essayer l'exemple](#essayer-lexemple)
 
 ---
 
@@ -48,7 +48,7 @@ macros d'enregistrement au niveau du module.
 > *chaque* modèle — liste, création, édition, suppression — sans
 > authentification jusqu'à ce que vous l'ajoutiez. Ne l'exposez pas
 > publiquement avant d'avoir câblé la connexion : voir
-> [Authentification](#authentication) ci-dessous.
+> [Authentification](#authentification) ci-dessous.
 
 L'admin est un `axum::Router` que vous construisez à partir d'un pool de base
 de données et que vous nichez (« nest ») sous un chemin :
@@ -138,13 +138,13 @@ détail.
 | `list_per_page` | `10` | Taille de page (par défaut 50). |
 | `date_hierarchy` | `"published_at"` | Bandeau de forage année → mois → jour au-dessus de la liste, sur une colonne Date/DateTime. |
 | `fieldsets` | `"Content: title, body \| Meta: status"` | Regroupe le formulaire de modification en sections titrées. La barre `\|` sépare les sections, la virgule sépare les champs ; la légende `Title:` est optionnelle. |
-| `actions` | `"publish, archive"` | Actions groupées proposées dans le sélecteur d'actions de la liste (chacune nécessite un gestionnaire enregistré — voir [Actions groupées](#bulk-actions)). |
+| `actions` | `"publish, archive"` | Actions groupées proposées dans le sélecteur d'actions de la liste (chacune nécessite un gestionnaire enregistré — voir [Actions groupées](#actions-groupées)). |
 | `readonly_fields` | `"created_at"` | Champs affichés en texte (sans saisie) sur le formulaire de modification. |
 | `raw_id_fields` | `"author_id"` | Champs FK édités via une saisie d'id brut + un lien de recherche (bien adapté aux grandes tables cibles). |
 | `autocomplete_fields` | `"author_id"` | Champs FK édités via un typeahead Ajax adossé à l'endpoint `__autocomplete` de la cible. |
 | `prepopulated_fields` | `"slug:title"` | Remplit automatiquement un champ en slugifiant un autre au fur et à mesure de la saisie (`cible:source` ; combinez les sources avec `+`). |
 | `list_select_related` | `"all"` / `"none"` / `"author_id"` | Contrôle la JOIN automatique des colonnes FK dans la requête de liste. `"all"` (par défaut) joint chaque FK ; `"none"` désactive ; une liste CSV restreint aux FK nommées. |
-| `formfield_overrides` | `"status:textarea"` | Remplace le widget de formulaire d'un champ (`champ:widget`) — voir le [tableau des widgets](#form-widgets). |
+| `formfield_overrides` | `"status:textarea"` | Remplace le widget de formulaire d'un champ (`champ:widget`) — voir le [tableau des widgets](#widgets-de-formulaire). |
 | `actions_on_top` | `true` | Affiche la barre d'actions groupées au-dessus de la liste (par défaut `true`). |
 | `actions_on_bottom` | `false` | Affiche une seconde barre d'actions sous la liste (par défaut `false`). |
 

--- a/docs/fr/api-conventions.md
+++ b/docs/fr/api-conventions.md
@@ -8,18 +8,18 @@ Cette page explique les patterns que suit l'API de **Rustango**, afin que vous p
 
 ## Table des matières
 
-- [Naming](#naming)
-- [Constructors](#constructors)
-- [Return types](#return-types)
+- [Naming](#nommage)
+- [Constructors](#constructeurs)
+- [Return types](#types-de-retour)
 - [Async vs sync](#async-vs-sync)
-- [The pool argument](#the-pool-argument)
-- [Filtering](#filtering)
-- [Errors](#errors)
-- [Module naming](#module-naming)
-- [Builders vs config structs](#builders-vs-config-structs)
+- [The pool argument](#largument-pool)
+- [Filtering](#filtrage)
+- [Errors](#erreurs)
+- [Module naming](#nommage-des-modules)
+- [Builders vs config structs](#builders-vs-structs-de-config)
 - [Feature flags](#feature-flags)
 - [Macros vs runtime](#macros-vs-runtime)
-- [Contributing](#contributing)
+- [Contributing](#contribuer)
 
 ---
 
@@ -311,7 +311,7 @@ Lorsque vous ajoutez une nouvelle fonctionnalité, suivez ces étapes :
 5. **Placez les tests unitaires dans le même fichier**, derrière `#[cfg(test)] mod tests` — pas de base de données à moins d'en avoir vraiment besoin.
 6. **Placez les tests d'intégration dans `crates/rustango/tests/<name>.rs`** pour le scénario de bout en bout.
 7. **N'ajoutez pas de nouveau type d'erreur à moins que les existants ne conviennent pas** — étendez d'abord une enum existante.
-8. **Suivez le [guide des types de retour](#return-types)** au moment de choisir entre `Result`, `Option` ou `bool`.
+8. **Suivez le [guide des types de retour](#types-de-retour)** au moment de choisir entre `Result`, `Option` ou `bool`.
 9. **Vous ajoutez une sous-commande `manage` ?** Câblez-la dans le dispatcher `match cmd` et `print_help`, ajoutez un test dans `crates/rustango/tests/migrate_manage.rs`, et documentez une ligne dans `docs/manage.md`.
 10. **Mettez à jour `CHANGELOG.md`** avec une entrée `Added` sous la prochaine version.
 

--- a/docs/fr/auth-api-keys.md
+++ b/docs/fr/auth-api-keys.md
@@ -29,13 +29,13 @@ backend clé en main qui stocke les clés et authentifie les requêtes
 
 ## Table des matières
 
-- [Comment fonctionne une clé d'API](#how-an-api-key-works)
-- [L'utilitaire autonome](#the-standalone-helper)
-- [Le backend avec stockage](#the-stored-backend)
-- [Émettre une clé (CLI + code)](#issuing-a-key)
-- [Authentifier les requêtes](#authenticating-requests)
-- [Notes de sécurité](#security-notes)
-- [Voir aussi](#see-also)
+- [Comment fonctionne une clé d'API](#comment-fonctionne-une-clé-dapi)
+- [L'utilitaire autonome](#lutilitaire-autonome)
+- [Le backend avec stockage](#le-backend-avec-stockage)
+- [Émettre une clé (CLI + code)](#émettre-une-clé)
+- [Authentifier les requêtes](#authentifier-les-requêtes)
+- [Notes de sécurité](#notes-de-sécurité)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/auth-backends.md
+++ b/docs/fr/auth-backends.md
@@ -26,12 +26,12 @@ accepter humains et machines sur les mêmes routes. C'est l'idée
 
 ## Table des matières
 
-- [La chaîne](#the-chain) · [Les backends intégrés](#the-built-in-backends)
-- [Verrouiller les routes : require_auth](#gating-routes-require_auth)
-- [Lire l'utilisateur : CurrentUser](#reading-the-user-currentuser)
-- [Permissions : require_perm](#permissions-require_perm)
-- [Le registre portable](#the-portable-registry)
-- [Voir aussi](#see-also)
+- [La chaîne](#la-chaîne) · [Les backends intégrés](#les-backends-intégrés)
+- [Verrouiller les routes : require_auth](#verrouiller-les-routes--require_auth)
+- [Lire l'utilisateur : CurrentUser](#lire-lutilisateur--currentuser)
+- [Permissions : require_perm](#permissions--require_perm)
+- [Le registre portable](#le-registre-portable)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/auth-decorators.md
+++ b/docs/fr/auth-decorators.md
@@ -27,10 +27,10 @@ répondues par 401/403 (flux API) — avant même d'atteindre le handler.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) · [Verrous navigateur vs API](#browser-vs-api-gates)
-- [La famille de verrous](#the-gate-family) · [Verrous par prédicat et par rôle](#predicate-and-role-gates)
-- [Verrous de permission](#permission-gates) · [L'aller-retour `?next=`](#the-next-round-trip)
-- [Remarques et limites](#notes-and-limits)
+- [Démarrage rapide](#démarrage-rapide) · [Verrous navigateur vs API](#verrous-navigateur-vs-api)
+- [La famille de verrous](#la-famille-de-verrous) · [Verrous par prédicat et par rôle](#verrous-par-prédicat-et-par-rôle)
+- [Verrous de permission](#verrous-de-permission) · [L'aller-retour `?next=`](#laller-retour-next)
+- [Remarques et limites](#remarques-et-limites)
 
 ---
 

--- a/docs/fr/auth-flows.md
+++ b/docs/fr/auth-flows.md
@@ -22,13 +22,13 @@ de sorte que le serveur peut faire confiance à ses paramètres sans rien stocke
 
 ## Table des matières
 
-- [Les URL signées : le socle](#signed-urls-the-substrate)
-- [Réinitialisation du mot de passe](#password-reset)
-- [Vérification de l'e-mail](#email-verification)
-- [Connexion par lien magique](#magic-link-login)
-- [Tokens à usage unique](#single-use-tokens)
-- [Ce que vous fournissez](#what-you-provide)
-- [Voir aussi](#see-also)
+- [Les URL signées : le socle](#les-url-signées--le-socle)
+- [Réinitialisation du mot de passe](#réinitialisation-du-mot-de-passe)
+- [Vérification de l'e-mail](#vérification-de-le-mail)
+- [Connexion par lien magique](#connexion-par-lien-magique)
+- [Tokens à usage unique](#tokens-à-usage-unique)
+- [Ce que vous fournissez](#ce-que-vous-fournissez)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/auth-hmac.md
+++ b/docs/fr/auth-hmac.md
@@ -24,13 +24,13 @@ sous la forme d'une seule couche tower.
 
 ## Table des matières
 
-- [Quand l'utiliser](#when-to-use-it)
-- [Ce qui est signé](#what-gets-signed)
-- [Serveur : vérifier avec la couche](#server-verify-with-the-layer)
-- [Client : signer une requête](#client-sign-a-request)
-- [Dérive d'horloge et rejeu](#clock-skew-and-replay)
-- [Limites](#limits)
-- [Voir aussi](#see-also)
+- [Quand l'utiliser](#quand-lutiliser)
+- [Ce qui est signé](#ce-qui-est-signé)
+- [Serveur : vérifier avec la couche](#serveur--vérifier-avec-la-couche)
+- [Client : signer une requête](#client--signer-une-requête)
+- [Dérive d'horloge et rejeu](#dérive-dhorloge-et-rejeu)
+- [Limites](#limites)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/auth-jwt-api.md
+++ b/docs/fr/auth-jwt-api.md
@@ -30,10 +30,10 @@ forme de `JwtLifecycle` — et un routeur clé en main qui monte pour vous
 ---
 
 ## Table des matières
-- [Le routeur intégré](#the-built-in-router) · [Le câblage](#wiring-it-up)
-- [Le moteur de tokens](#the-token-engine-jwtlifecycle) · [Rafraîchissement et rotation](#refresh-and-rotation)
-- [Révocation et le magasin de JTI](#revocation-and-the-jti-store) · [Claims personnalisés](#custom-claims)
-- [Notes et limites](#notes-and-limits)
+- [Le routeur intégré](#le-routeur-intégré) · [Le câblage](#le-câblage)
+- [Le moteur de tokens](#le-moteur-de-tokens-jwtlifecycle) · [Rafraîchissement et rotation](#rafraîchissement-et-rotation)
+- [Révocation et le magasin de JTI](#révocation-et-le-magasin-de-jti) · [Claims personnalisés](#claims-personnalisés)
+- [Notes et limites](#notes-et-limites)
 
 ---
 
@@ -249,7 +249,7 @@ sauf si vous utilisez `refresh_with`.
   d'authentification](auth-backends.md) pour authentifier des routes arbitraires
   à partir de l'en-tête `Authorization: Bearer`.
 - **Signature HS256**, plancher de clé de 32 octets — même algorithme et mêmes
-  contraintes que le [JWT autonome](auth-jwt.md#security-model).
+  contraintes que le [JWT autonome](auth-jwt.md#modèle-de-sécurité).
 
 
 ---

--- a/docs/fr/auth-jwt.md
+++ b/docs/fr/auth-jwt.md
@@ -27,10 +27,10 @@ HS256 en interne.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) · [Quand l'utiliser](#when-to-use-standalone-jwt)
-- [Construire des claims](#building-claims) · [Vérifier](#verifying-a-token)
-- [Modèle de sécurité](#security-model) — à lire · [Inspecter sans faire confiance](#inspecting-without-verifying)
-- [Notes et limites](#notes-and-limits)
+- [Démarrage rapide](#démarrage-rapide) · [Quand l'utiliser](#quand-utiliser-un-jwt-autonome)
+- [Construire des claims](#construire-des-claims) · [Vérifier](#vérifier-un-token)
+- [Modèle de sécurité](#modèle-de-sécurité) — à lire · [Inspecter sans faire confiance](#inspecter-sans-vérifier)
+- [Notes et limites](#notes-et-limites)
 
 ---
 

--- a/docs/fr/auth-passwords.md
+++ b/docs/fr/auth-passwords.md
@@ -27,10 +27,10 @@ jamais le texte en clair.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) · [Pourquoi argon2id](#why-argon2id)
-- [Hachage à l'inscription](#hashing-on-signup) · [Vérification à la connexion](#verifying-on-login)
-- [Connexions à temps constant](#timing-safe-logins-account-enumeration) · [Contrôles de robustesse](#strength-checks)
-- [Où vit le hash](#where-the-hash-lives) · [Remarques et limites](#notes-and-limits)
+- [Démarrage rapide](#démarrage-rapide) · [Pourquoi argon2id](#pourquoi-argon2id)
+- [Hachage à l'inscription](#hachage-à-linscription) · [Vérification à la connexion](#vérification-à-la-connexion)
+- [Connexions à temps constant](#connexions-à-temps-constant-énumération-de-comptes) · [Contrôles de robustesse](#contrôles-de-robustesse)
+- [Où vit le hash](#où-vit-le-hash) · [Remarques et limites](#remarques-et-limites)
 
 ---
 

--- a/docs/fr/auth-sessions.md
+++ b/docs/fr/auth-sessions.md
@@ -31,10 +31,10 @@ requête suivante.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) · [Sessions vs JWT](#sessions-vs-jwt)
-- [Le sac de session](#the-session-bag) · [Le cookie](#the-cookie)
-- [Choisir un backend](#picking-a-backend) · [Expiration et renouvellement glissant](#expiry-and-sliding-renewal)
-- [Modification en place](#updating-a-session-in-place) · [Remarques et limites](#notes-and-limits)
+- [Démarrage rapide](#démarrage-rapide) · [Sessions vs JWT](#sessions-vs-jwt)
+- [Le sac de session](#le-sac-de-session) · [Le cookie](#le-cookie)
+- [Choisir un backend](#choisir-un-backend) · [Expiration et renouvellement glissant](#expiration-et-renouvellement-glissant)
+- [Modification en place](#modification-dune-session-en-place) · [Remarques et limites](#remarques-et-limites)
 
 ---
 
@@ -113,7 +113,7 @@ dont un cookie de session a besoin :
 - **`HttpOnly`** — JavaScript ne peut pas le lire (émousse le vol de jeton par
   XSS).
 - **`SameSite=Lax`** — non envoyé sur les sous-requêtes intersites (défense CSRF ;
-  associez-le aux [jetons CSRF](security.md#protecting-against-csrf) pour les
+  associez-le aux [jetons CSRF](security.md#se-protéger-contre-le-csrf) pour les
   envois de formulaire).
 - **`Secure`** — HTTPS uniquement (à retirer seulement pour le développement HTTP
   local).

--- a/docs/fr/benchmarks.md
+++ b/docs/fr/benchmarks.md
@@ -12,7 +12,7 @@ runtime plus robuste : **Django** sur **gunicorn** (WSGI) et sur **Hypercorn**
 et Go sont chacun un unique binaire résident, il n'y en a donc qu'un de chaque.
 
 Chaque chiffre ci-dessous est **mesuré et reproductible**, issu d'une exécution cohérente d'un
-harnais en une seule commande (voir [Reproduce](#reproduce)). Rien ici n'est esquivé à la légère.
+harnais en une seule commande (voir [Reproduce](#reproduire)). Rien ici n'est esquivé à la légère.
 
 > **En bref.** Sur un matériel identique servant des pages HTML rendues identiques, les deux
 > runtimes **compilés et natifs** — **Rustango** et **Go** — laissent les

--- a/docs/fr/caching.md
+++ b/docs/fr/caching.md
@@ -26,15 +26,15 @@ Django ou la façade `Cache` de Laravel.
 
 ## Table des matières
 
-- [Étape 1 — Choisir un backend](#step-1--pick-a-backend)
-- [Étape 2 — get / set / delete](#step-2--get--set--delete)
-- [Étape 3 — get_or_set (cache-aside)](#step-3--get_or_set-cache-aside)
-- [Valeurs JSON typées](#typed-json-values)
-- [TTL et expiration](#ttl-and-expiry)
-- [Changer de backend](#swapping-backends)
-- [La mise en cache en multi-tenancy](#caching-under-multi-tenancy)
-- [Référence](#reference)
-- [Voir aussi](#see-also)
+- [Étape 1 — Choisir un backend](#étape-1--choisir-un-backend)
+- [Étape 2 — get / set / delete](#étape-2--get--set--delete)
+- [Étape 3 — get_or_set (cache-aside)](#étape-3--get_or_set-cache-aside)
+- [Valeurs JSON typées](#valeurs-json-typées)
+- [TTL et expiration](#ttl-et-expiration)
+- [Changer de backend](#changer-de-backend)
+- [La mise en cache en multi-tenancy](#la-mise-en-cache-en-multi-tenancy)
+- [Référence](#référence)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/email.md
+++ b/docs/fr/email.md
@@ -25,15 +25,15 @@ framework d'e-mail de Django.
 
 ## Table des matières
 
-- [Étape 1 — Construire un e-mail](#step-1--build-an-email)
-- [Étape 2 — Choisir un mailer](#step-2--pick-a-mailer)
-- [Étape 3 — L'envoyer](#step-3--send-it)
-- [Validation et protection contre l'injection d'en-têtes](#validation-and-header-injection-safety)
-- [Tester les e-mails](#testing-email)
+- [Étape 1 — Construire un e-mail](#étape-1--construire-un-e-mail)
+- [Étape 2 — Choisir un mailer](#étape-2--choisir-un-mailer)
+- [Étape 3 — L'envoyer](#étape-3--lenvoyer)
+- [Validation et protection contre l'injection d'en-têtes](#validation-et-protection-contre-linjection-den-têtes)
+- [Tester les e-mails](#tester-les-e-mails)
 - [Templates](#templates)
-- [L'envoyer en dehors de la requête](#send-it-off-the-request)
-- [Référence](#reference)
-- [Voir aussi](#see-also)
+- [L'envoyer en dehors de la requête](#lenvoyer-en-dehors-de-la-requête)
+- [Référence](#référence)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/files.md
+++ b/docs/fr/files.md
@@ -28,14 +28,14 @@ d'une ligne.
 
 ## Table des matières
 
-- [Étape 1 — Choisir un backend de stockage](#step-1--pick-a-storage-backend)
-- [Étape 2 — Enregistrer, charger et servir des fichiers](#step-2--save-load-and-serve-files)
-- [Étape 3 — Accepter un téléversement](#step-3--accept-an-upload)
-- [Noms de fichiers sûrs](#safe-filenames)
-- [Production : stockage compatible S3](#production-s3-compatible-storage)
-- [La médiathèque](#the-media-library)
-- [Référence](#reference)
-- [Voir aussi](#see-also)
+- [Étape 1 — Choisir un backend de stockage](#étape-1--choisir-un-backend-de-stockage)
+- [Étape 2 — Enregistrer, charger et servir des fichiers](#étape-2--enregistrer-charger-et-servir-des-fichiers)
+- [Étape 3 — Accepter un téléversement](#étape-3--accepter-un-téléversement)
+- [Noms de fichiers sûrs](#noms-de-fichiers-sûrs)
+- [Production : stockage compatible S3](#production--stockage-compatible-s3)
+- [La médiathèque](#la-médiathèque)
+- [Référence](#référence)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/glossary.md
+++ b/docs/fr/glossary.md
@@ -4,17 +4,17 @@ Une référence en langage simple des mots utilisés dans cette documentation. S
 terme d'un guide vous est inconnu, cherchez-le ici d'abord. Les définitions sont
 volontairement informelles — les guides approfondis donnent les détails précis.
 
-Si vous n'avez jamais construit d'API web auparavant, lisez [Les bases des API web](#web-api-basics)
+Si vous n'avez jamais construit d'API web auparavant, lisez [Les bases des API web](#les-bases-des-api-web)
 de haut en bas ; c'est une introduction de cinq minutes. Tout le reste est fait pour
 être consulté au fur et à mesure.
 
 ## Table des matières
 
-- [Les bases des API web](#web-api-basics) — ce qu'est une API, en termes de tous les jours
-- [Les briques de Rustango](#rustango-building-blocks) — les pièces que vous assemblez
-- [Les données et la base de données](#data-and-the-database)
-- [Quelques mots de Rust](#a-few-rust-words) — pour que les blocs de code ne fassent pas peur
-- [Frameworks auxquels nous comparons](#frameworks-we-compare-to)
+- [Les bases des API web](#les-bases-des-api-web) — ce qu'est une API, en termes de tous les jours
+- [Les briques de Rustango](#les-briques-de-rustango) — les pièces que vous assemblez
+- [Les données et la base de données](#les-données-et-la-base-de-données)
+- [Quelques mots de Rust](#quelques-mots-de-rust) — pour que les blocs de code ne fassent pas peur
+- [Frameworks auxquels nous comparons](#frameworks-auxquels-nous-comparons)
 
 ---
 

--- a/docs/fr/html-views.md
+++ b/docs/fr/html-views.md
@@ -30,15 +30,15 @@ ressources de Laravel qui renvoient des vues Blade. Elles effectuent leur rendu 
 
 ## Table des matières
 
-- [Vues API vs vues HTML — laquelle vous faut-il ?](#api-views-vs-html-views--which-do-you-want)
-- [Les cinq vues de modèle](#the-five-model-views)
+- [Vues API vs vues HTML — laquelle vous faut-il ?](#vues-api-vs-vues-html--laquelle-vous-faut-il-)
+- [Les cinq vues de modèle](#les-cinq-vues-de-modèle)
 - [ListView](#listview) · [DetailView](#detailview)
 - [CreateView, UpdateView, DeleteView](#createview-updateview-deleteview)
-- [Le contexte Tera](#the-tera-context)
-- [TemplateView et RedirectView](#templateview-and-redirectview)
-- [Mono-locataire vs multi-locataire](#single-tenant-vs-multi-tenant)
-- [Servir un modèle des deux façons](#serving-one-model-both-ways)
-- [Voir aussi](#see-also)
+- [Le contexte Tera](#le-contexte-tera)
+- [TemplateView et RedirectView](#templateview-et-redirectview)
+- [Mono-locataire vs multi-locataire](#mono-locataire-vs-multi-locataire)
+- [Servir un modèle des deux façons](#servir-un-modèle-des-deux-façons)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -59,7 +59,7 @@ C'est la première décision. Les deux transforment un modèle en points d'accè
 | Équivalent Django | DRF `ModelViewSet` | vues génériques basées sur les classes |
 
 Vous n'avez pas à choisir globalement — choisissez par ressource, et vous pouvez monter **les deux
-sur le même modèle** (voir [ci-dessous](#serving-one-model-both-ways)). Règles empiriques :
+sur le même modèle** (voir [ci-dessous](#servir-un-modèle-des-deux-façons)). Règles empiriques :
 
 - Vous construisez un **backend JSON** pour un framework frontend ou une application mobile → ViewSet.
 - Vous construisez un **site rendu côté serveur** (le serveur renvoie des pages HTML) → vues

--- a/docs/fr/i18n.md
+++ b/docs/fr/i18n.md
@@ -28,17 +28,17 @@ de Django, en Rust.
 
 ## Table des matières
 
-- [Les deux moitiés de l'i18n](#the-two-halves-of-i18n)
-- [Étape 1 — Construire un Translator](#step-1--build-a-translator)
-- [Étape 2 — Traduire des chaînes (gettext)](#step-2--translate-strings-gettext)
+- [Les deux moitiés de l'i18n](#les-deux-moitiés-de-li18n)
+- [Étape 1 — Construire un Translator](#étape-1--construire-un-translator)
+- [Étape 2 — Traduire des chaînes (gettext)](#étape-2--traduire-des-chaînes-gettext)
 - [Placeholders](#placeholders)
-- [Pluralisation](#pluralization)
-- [Ordre de repli](#fallback-order)
-- [Négocier la langue](#negotiating-the-language)
-- [Langues de droite à gauche](#right-to-left-languages)
-- [Traduire dans les templates (Tera)](#translating-in-templates-tera)
-- [Charger les catalogues + surcharges à l'exécution](#loading-catalogs--runtime-overrides)
-- [Voir aussi](#see-also)
+- [Pluralisation](#pluralisation)
+- [Ordre de repli](#ordre-de-repli)
+- [Négocier la langue](#négocier-la-langue)
+- [Langues de droite à gauche](#langues-de-droite-à-gauche)
+- [Traduire dans les templates (Tera)](#traduire-dans-les-templates-tera)
+- [Charger les catalogues + surcharges à l'exécution](#charger-les-catalogues--surcharges-à-lexécution)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -46,9 +46,9 @@ de Django, en Rust.
 
 | Préoccupation | Où | Ce que ça fait |
 |---|---|---|
-| **Résoudre** la locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#locale-aware-middleware) | choisit une locale par requête (cookie → Accept-Language → défaut) et expose l'extracteur `ActiveLocale` |
+| **Résoudre** la locale | [`i18n::middleware::LocaleMiddleware`](middleware.md#middleware-sensible-à-la-locale) | choisit une locale par requête (cookie → Accept-Language → défaut) et expose l'extracteur `ActiveLocale` |
 | **Traduire** les chaînes | `i18n::Translator` (ce guide) | recherche une clé de message dans le catalogue de la locale active |
-| Afficher les dates dans le fuseau horaire de l'utilisateur | [`i18n::timezone`](middleware.md#timezone-aware-middleware) | le filtre `{{ ts \| localtime }}` |
+| Afficher les dates dans le fuseau horaire de l'utilisateur | [`i18n::timezone`](middleware.md#middleware-sensible-au-fuseau-horaire) | le filtre `{{ ts \| localtime }}` |
 
 Vous branchez le middleware une seule fois, puis vous traduisez en utilisant la
 locale qu'il a résolue.
@@ -79,7 +79,7 @@ let translator = Translator::new(Locale::new("en"))   // default locale
 
 Conservez le `Translator` dans l'état de votre application (il est bon marché
 à cloner/partager) et recherchez les chaînes avec l'
-[`ActiveLocale`](middleware.md#locale-aware-middleware) résolue par le
+[`ActiveLocale`](middleware.md#middleware-sensible-à-la-locale) résolue par le
 middleware.
 
 ---
@@ -209,7 +209,7 @@ is_rtl_language("en");   // false
 
 Dans un template : `<html dir="{{ direction }}">`, alimenté depuis
 `ActiveLocale`. Voir la
-[note RTL dans Middleware](middleware.md#locale-aware-middleware).
+[note RTL dans Middleware](middleware.md#middleware-sensible-à-la-locale).
 
 ---
 

--- a/docs/fr/jobs.md
+++ b/docs/fr/jobs.md
@@ -28,18 +28,18 @@ de Laravel, en Rust.
 
 ## Table des matières
 
-- [Étape 1 — Définir une tâche](#step-1--define-a-job)
-- [Étape 2 — Démarrer une file](#step-2--start-a-queue)
-- [Étape 3 — Dispatcher depuis un handler](#step-3--dispatch-from-a-handler)
-- [Étape 4 — Câbler dans votre application](#step-4--wire-it-into-your-app) — l'exemple complet
-- [Faire tourner les workers (CLI + production)](#running-the-workers-cli--production)
-- [Nouvelles tentatives et backoff](#retries-and-backoff)
-- [Le handler dead-letter](#the-dead-letter-handler)
-- [La file persistante (production)](#the-persistent-queue-production)
-- [Les tâches en multi-tenancy](#jobs-under-multi-tenancy)
-- [Les balayages planifiés en multi-tenancy](#scheduled-sweeps-under-multi-tenancy)
-- [Référence](#reference)
-- [Voir aussi](#see-also)
+- [Étape 1 — Définir une tâche](#étape-1--définir-une-tâche)
+- [Étape 2 — Démarrer une file](#étape-2--démarrer-une-file)
+- [Étape 3 — Dispatcher depuis un handler](#étape-3--dispatcher-depuis-un-handler)
+- [Étape 4 — Câbler dans votre application](#étape-4--câbler-dans-votre-application) — l'exemple complet
+- [Faire tourner les workers (CLI + production)](#faire-tourner-les-workers-cli--production)
+- [Nouvelles tentatives et backoff](#nouvelles-tentatives-et-backoff)
+- [Le handler dead-letter](#le-handler-dead-letter)
+- [La file persistante (production)](#la-file-persistante-production)
+- [Les tâches en multi-tenancy](#les-tâches-en-multi-tenancy)
+- [Les balayages planifiés en multi-tenancy](#les-balayages-planifiés-en-multi-tenancy)
+- [Référence](#référence)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -110,7 +110,7 @@ les handlers puissent l'atteindre.
 
 > **In-memory signifie in-memory.** Les tâches en file ou en cours sont
 > **perdues au redémarrage**. Pour tout ce que vous ne pouvez pas vous permettre
-> de perdre, utilisez la [file persistante](#the-persistent-queue-production).
+> de perdre, utilisez la [file persistante](#la-file-persistante-production).
 
 ---
 
@@ -216,7 +216,7 @@ cargo run -- make:job WelcomeEmail   # scaffold a new job type
 À l'échelle, vous voulez souvent des workers **séparés** de la couche web — pour
 qu'un pic de trafic ne puisse pas affamer les tâches, et que vous mettiez à
 l'échelle chacun indépendamment. Avec la [file
-persistante](#the-persistent-queue-production), chaque processus tire de la même
+persistante](#la-file-persistante-production), chaque processus tire de la même
 table `rustango_jobs`, donc lancez simplement un second binaire, sans serveur,
 qui construit la file, la démarre, et bloque jusqu'à un signal :
 
@@ -244,7 +244,7 @@ Déployez-le comme son propre conteneur/service et mettez-le à l'échelle sur *
 réplicas** — ils tirent tous de la table partagée en toute sécurité. Le
 processus web n'a alors besoin que de `dispatch` (il n'a pas à `start()` de
 workers). Associez le worker à un balayage périodique
-[`reclaim_stuck_jobs_pool`](#the-persistent-queue-production) pour récupérer les
+[`reclaim_stuck_jobs_pool`](#la-file-persistante-production) pour récupérer les
 tâches d'un worker crashé.
 
 ---
@@ -519,5 +519,5 @@ acquire refusé est le résultat attendu, donc rien n'est journalisé. Suivi dan
   requêtes rapides.
 - [Signals](orm.md) — des hooks fire-and-forget qui *dispatchent* souvent une
   tâche.
-- [Commandes de tenancy](manage.md#tenancy-commands) — le provisionnement des
+- [Commandes de tenancy](manage.md#commandes-de-tenancy) — le provisionnement des
   tenants sur lesquels une file par tenant fait son fan-out.

--- a/docs/fr/mcp.md
+++ b/docs/fr/mcp.md
@@ -29,16 +29,16 @@ intégrés.
 
 ## Table des matières
 
-- [Ce que MCP vous apporte](#what-mcp-gives-you)
-- [Étape 1 — Activer la feature](#step-1--enable-the-feature)
-- [Étape 2 — Définir un tool](#step-2--define-a-tool)
-- [Étape 3 — Monter le serveur](#step-3--mount-the-server)
-- [Étape 4 — Autoriser les agents](#step-4--authorize-agents)
-- [Le protocole](#the-protocol)
-- [Réglages](#settings)
-- [Comment tester](#how-to-test) — [la suite](#a-the-test-suite) · [curl](#b-curl-the-json-rpc) · [le MCP Inspector visuel](#c-test-it-visually-with-the-mcp-inspector) · [un vrai client](#d-connect-a-real-mcp-client)
-- [Build optionnel vs. par défaut](#optional-vs-default-build)
-- [Voir aussi](#see-also)
+- [Ce que MCP vous apporte](#ce-que-mcp-vous-apporte)
+- [Étape 1 — Activer la feature](#étape-1--activer-la-feature)
+- [Étape 2 — Définir un tool](#étape-2--définir-un-tool)
+- [Étape 3 — Monter le serveur](#étape-3--monter-le-serveur)
+- [Étape 4 — Autoriser les agents](#étape-4--autoriser-les-agents)
+- [Le protocole](#le-protocole)
+- [Réglages](#réglages)
+- [Comment tester](#comment-tester) — [la suite](#a-la-suite-de-tests) · [curl](#b-curl-le-json-rpc) · [le MCP Inspector visuel](#c-testez-le-visuellement-avec-le-mcp-inspector) · [un vrai client](#d-connectez-un-vrai-client-mcp)
+- [Build optionnel vs. par défaut](#build-optionnel-vs-par-défaut)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -72,7 +72,7 @@ rustango = { version = "0.44", features = ["mcp"] }
 Elle tire `tenancy` (agents/skills), `sse` (le flux de notifications),
 `serializer` + `openapi` (les schémas d'entrée des tools) et `jwt` (les tokens
 d'agent). Un build **sans** la feature ne compile aucune partie du module MCP —
-voir [Build optionnel vs. par défaut](#optional-vs-default-build).
+voir [Build optionnel vs. par défaut](#build-optionnel-vs-par-défaut).
 
 ---
 

--- a/docs/fr/middleware.md
+++ b/docs/fr/middleware.md
@@ -30,15 +30,15 @@ le kernel HTTP — la même idée, rattachée à votre routeur.
 
 ## Table des matières
 
-- [Comment fonctionne le middleware dans Rustango](#how-middleware-works-in-rustango)
-- [L'ordre compte](#ordering-matters)
-- [Le catalogue intégré](#the-built-in-catalog)
-- [Middleware sensible à la locale](#locale-aware-middleware)
-- [Middleware sensible au fuseau horaire](#timezone-aware-middleware)
-- [En-têtes de sécurité](#security-headers)
-- [Protection CSRF](#csrf-protection)
-- [Écrire votre propre middleware](#writing-your-own-middleware)
-- [Voir aussi](#see-also)
+- [Comment fonctionne le middleware dans Rustango](#comment-fonctionne-le-middleware-dans-rustango)
+- [L'ordre compte](#lordre-compte)
+- [Le catalogue intégré](#le-catalogue-intégré)
+- [Middleware sensible à la locale](#middleware-sensible-à-la-locale)
+- [Middleware sensible au fuseau horaire](#middleware-sensible-au-fuseau-horaire)
+- [En-têtes de sécurité](#en-têtes-de-sécurité)
+- [Protection CSRF](#protection-csrf)
+- [Écrire votre propre middleware](#écrire-votre-propre-middleware)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -78,7 +78,7 @@ Il existe deux formes, et vous utiliserez les deux :
    d'en écrire un ponctuel. Vous recevez la `Request` et un `Next` ; vous
    appelez `next.run(req)` pour continuer, et vous pouvez faire du travail de
    part et d'autre de cet appel. L'[exemple de fuseau
-   horaire](#timezone-aware-middleware) ci-dessous est exactement cela.
+   horaire](#middleware-sensible-au-fuseau-horaire) ci-dessous est exactement cela.
 
 Les deux se composent librement — un middleware `from_fn` *est* un layer, donc
 il s'empile avec les composants intégrés dans la même chaîne `.layer(...)`.
@@ -157,7 +157,7 @@ obtenir la méthode.
 | Mise en cache de page | `CachePageLayer` | `.layer(..)` |
 | **Localisation** | | |
 | Négociation de locale | `LocaleMiddleware` | `.layer(..)` (+ extracteur `ActiveLocale`) |
-| Fuseau horaire actif | *(à composer avec `from_fn`)* | voir [ci-dessous](#timezone-aware-middleware) |
+| Fuseau horaire actif | *(à composer avec `from_fn`)* | voir [ci-dessous](#middleware-sensible-au-fuseau-horaire) |
 | **Développement** | | |
 | Rechargement à chaud | `LiveReloadLayer` | `.livereload(..)` |
 | Panneau de débogage | `DebugPanelLayer` | `.debug_panel(..)` |
@@ -387,7 +387,7 @@ sur chaque mutation, sans possibilité d'opt-out.
 ## Écrire votre propre middleware
 
 Vous avez déjà vu la forme rapide — le [middleware de fuseau
-horaire](#timezone-aware-middleware) est un exemple `from_fn` complet. Utilisez
+horaire](#middleware-sensible-au-fuseau-horaire) est un exemple `from_fn` complet. Utilisez
 `from_fn` chaque fois que la logique est spécifique à l'application et que vous
 n'avez pas besoin de la configurer :
 

--- a/docs/fr/models.md
+++ b/docs/fr/models.md
@@ -25,16 +25,16 @@ le [cookbook ORM](orm.md).
 
 ## Table des matières
 
-- [Anatomie d'un modèle](#anatomy-of-a-model)
-- [Types de champs](#field-types) · [Types spécifiques à PostgreSQL](#postgresql-only-types)
-- [Clés primaires](#primary-keys) — [PK personnalisées](#custom-primary-keys) · [composites](#composite-primary-keys)
-- [Relations](#relationships)
-- [Attributs de champ courants](#common-field-attributes)
-- [Index et contraintes](#indexes-and-constraints)
-- [Attributs de modèle courants](#common-model-attributes)
-- [L'API générée](#the-generated-api) — [save vs insert](#save-vs-insert)
-- [Référence complète des attributs](#full-attribute-reference)
-- [Voir aussi](#see-also)
+- [Anatomie d'un modèle](#anatomie-dun-modèle)
+- [Types de champs](#types-de-champs) · [Types spécifiques à PostgreSQL](#types-spécifiques-à-postgresql)
+- [Clés primaires](#clés-primaires) — [PK personnalisées](#clés-primaires-personnalisées) · [composites](#clés-primaires-composites)
+- [Relations](#relations)
+- [Attributs de champ courants](#attributs-de-champ-courants)
+- [Index et contraintes](#index-et-contraintes)
+- [Attributs de modèle courants](#attributs-de-modèle-courants)
+- [L'API générée](#lapi-générée) — [save vs insert](#save-vs-insert)
+- [Référence complète des attributs](#référence-complète-des-attributs)
+- [Voir aussi](#voir-aussi)
 
 ---
 
@@ -71,7 +71,7 @@ pub struct Post {
 - des **constantes de champ typées** (`Post::title`, `Post::author_id`) pour des
   filtres vérifiés à la compilation — `Post::objects().where_(Post::author_id.eq(42))` ;
 - des méthodes de ligne — **`save`**, **`find`**, **`delete`**, et plus (voir
-  [l'API générée](#the-generated-api)).
+  [l'API générée](#lapi-générée)).
 
 Le nom de la table prend par défaut le nom du modèle si vous omettez `table` ; les noms de colonnes
 prennent par défaut le nom du champ en snake_case sauf si vous définissez `column`.
@@ -262,7 +262,7 @@ pub author: ForeignKey<Author>,
 `ForeignKey<T>` prend par défaut `i64` comme type de clé ; si la PK du parent est d'un
 type différent, précisez-le : `ForeignKey<User, String>`. Le un-à-un utilise
 `#[rustango(o2o)]` ; le plusieurs-à-plusieurs est une table séparée — voir
-[cookbook ORM → Plusieurs-à-plusieurs](orm.md#many-to-many). Chargez les lignes liées de manière anticipée avec
+[cookbook ORM → Plusieurs-à-plusieurs](orm.md#plusieurs-à-plusieurs). Chargez les lignes liées de manière anticipée avec
 `select_related` (également dans le guide ORM).
 
 ---

--- a/docs/fr/openapi.md
+++ b/docs/fr/openapi.md
@@ -27,11 +27,11 @@ types permettent de construire n'importe quelle spécification à la main.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) — générer + servir en un seul écran
-- [Schémas depuis les serializers](#schemas-from-serializers) · [Chemins depuis les ViewSets](#paths-from-viewsets)
-- [Le servir](#serving-the-spec-swagger-ui--redoc) · [Construire une spec à la main](#hand-building-a-spec)
-- [Schémas de sécurité](#security-schemes) · [Le builder `Schema`](#the-schema-builder)
-- [Notes et limites](#notes-and-limits)
+- [Démarrage rapide](#démarrage-rapide) — générer + servir en un seul écran
+- [Schémas depuis les serializers](#schémas-depuis-les-serializers) · [Chemins depuis les ViewSets](#chemins-depuis-les-viewsets)
+- [Le servir](#servir-la-spec-swagger-ui--redoc) · [Construire une spec à la main](#construire-une-spec-à-la-main)
+- [Schémas de sécurité](#schémas-de-sécurité) · [Le builder `Schema`](#le-builder-schema)
+- [Notes et limites](#notes-et-limites)
 
 ---
 
@@ -113,7 +113,7 @@ impl rustango::openapi::OpenApiSchema for Money {
 }
 ```
 
-> Voir le [guide des Serializers](serializers.md#openapi-schemas) pour les
+> Voir le [guide des Serializers](serializers.md#schémas-openapi) pour les
 > attributs de champ qui façonnent la sortie.
 
 ---
@@ -227,7 +227,7 @@ Assistants : `SecurityScheme::bearer(fmt)`, `basic()`, `api_key_header(name)`,
 Sur une `Operation`, `.no_security()` marque un endpoint public et
 `.require_security(scheme, scopes)` surcharge la valeur globale par défaut. Ceux-ci
 s'alignent sur l'authentification propre de **Rustango** (voir le
-[guide de Sécurité](security.md#authenticating-users)) : JWT → `bearer`, clés
+[guide de Sécurité](security.md#authentifier-les-utilisateurs)) : JWT → `bearer`, clés
 d'API → `apiKey`, OAuth2 → `oauth2`.
 
 ---

--- a/docs/fr/orm.md
+++ b/docs/fr/orm.md
@@ -35,23 +35,23 @@ Le CHANGELOG contient l'index complet des tickets pour chaque version.
 
 ## Table des matières
 
-- [Requêtes](#querying)
-- [Valeurs calculées et fonctions de base de données](#computed-values--database-functions)
-- [Agrégations](#aggregations)
-- [Jointures et préchargement des lignes liées](#joins--preloading-related-rows)
-- [Opérations en masse](#bulk-operations)
-- [Insertion ou mise à jour (upsert)](#insert-or-update-upsert)
+- [Requêtes](#requêtes)
+- [Valeurs calculées et fonctions de base de données](#valeurs-calculées-et-fonctions-de-base-de-données)
+- [Agrégations](#agrégations)
+- [Jointures et préchargement des lignes liées](#jointures-et-préchargement-des-lignes-liées)
+- [Opérations en masse](#opérations-en-masse)
+- [Insertion ou mise à jour (upsert)](#insertion-ou-mise-à-jour-upsert)
 - [Transactions](#transactions)
-- [Plusieurs-à-plusieurs](#many-to-many)
+- [Plusieurs-à-plusieurs](#plusieurs-à-plusieurs)
 - [JSON / JSONB](#json--jsonb)
-- [Suppression logique](#soft-delete)
-- [Journal d'audit](#audit-trail)
-- [Échappatoire vers le SQL brut](#raw-sql-escape-hatch)
-- [Chargement paresseux des clés étrangères](#lazy-fk-loading)
-- [Quatre façons de filtrer](#four-ways-to-filter)
-- [Requêtes limitées au tenant](#tenant-scoped-queries)
-- [Signaux](#signals)
-- [Conseils de performance](#performance-tips)
+- [Suppression logique](#suppression-logique)
+- [Journal d'audit](#journal-daudit)
+- [Échappatoire vers le SQL brut](#échappatoire-vers-le-sql-brut)
+- [Chargement paresseux des clés étrangères](#chargement-paresseux-des-clés-étrangères)
+- [Quatre façons de filtrer](#quatre-façons-de-filtrer)
+- [Requêtes limitées au tenant](#requêtes-limitées-au-tenant)
+- [Signaux](#signaux)
+- [Conseils de performance](#conseils-de-performance)
 
 ---
 
@@ -866,7 +866,7 @@ let featured = Author::objects()
 
 ### Quand passer plutôt au SQL brut
 
-Les builders ci-dessus couvrent les cas courants. Pour ce qu'ils n'expriment pas encore — `Cast`, recherche plein texte, opérateurs de chemin JSON, fonctions de hachage, trigonométrie, fonctions de fenêtrage — voir la section [Échappatoire vers le SQL brut](#raw-sql-escape-hatch) ci-dessous, ou attendez les tickets de suivi qui étendent le même arbre d'expressions.
+Les builders ci-dessus couvrent les cas courants. Pour ce qu'ils n'expriment pas encore — `Cast`, recherche plein texte, opérateurs de chemin JSON, fonctions de hachage, trigonométrie, fonctions de fenêtrage — voir la section [Échappatoire vers le SQL brut](#échappatoire-vers-le-sql-brut) ci-dessous, ou attendez les tickets de suivi qui étendent le même arbre d'expressions.
 
 ---
 

--- a/docs/fr/security.md
+++ b/docs/fr/security.md
@@ -6,25 +6,25 @@ Ce guide couvre chaque fonctionnalité de sécurité fournie par **Rustango** et
 
 ## Table des matières
 
-- [La checklist de défense en profondeur](#the-defense-in-depth-checklist)
-- [Définir les en-têtes de sécurité](#setting-security-headers)
-- [Autoriser les requêtes cross-origin (CORS)](#allowing-cross-origin-requests-cors)
-- [Limiter le débit des requêtes](#rate-limiting-requests)
-- [Autoriser ou bloquer des IP](#allowing-or-blocking-ips)
-- [Se protéger contre le CSRF](#protecting-against-csrf)
-- [Prévenir le XSS](#preventing-xss)
-- [Prévenir l'injection SQL](#preventing-sql-injection)
-- [Authentifier les utilisateurs](#authenticating-users)
-- [Hacher et vérifier les mots de passe](#hashing-and-checking-passwords)
-- [Émettre et rafraîchir des JWT](#issuing-and-refreshing-jwts)
-- [S'authentifier avec des clés d'API](#authenticating-with-api-keys)
-- [Ajouter l'authentification à deux facteurs (TOTP)](#adding-two-factor-auth-totp)
-- [Envoyer des URL signées (liens magiques)](#sending-signed-urls-magic-links)
-- [Vérifier les webhooks entrants](#verifying-incoming-webhooks)
-- [Garder les secrets hors de vos journaux](#keeping-secrets-out-of-your-logs)
-- [Tracer les requêtes entre services](#tracing-requests-across-services)
-- [Gérer les secrets](#managing-secrets)
-- [Auditer avant de déployer](#auditing-before-you-deploy)
+- [La checklist de défense en profondeur](#la-checklist-de-défense-en-profondeur)
+- [Définir les en-têtes de sécurité](#définir-les-en-têtes-de-sécurité)
+- [Autoriser les requêtes cross-origin (CORS)](#autoriser-les-requêtes-cross-origin-cors)
+- [Limiter le débit des requêtes](#limiter-le-débit-des-requêtes)
+- [Autoriser ou bloquer des IP](#autoriser-ou-bloquer-des-ip)
+- [Se protéger contre le CSRF](#se-protéger-contre-le-csrf)
+- [Prévenir le XSS](#prévenir-le-xss)
+- [Prévenir l'injection SQL](#prévenir-linjection-sql)
+- [Authentifier les utilisateurs](#authentifier-les-utilisateurs)
+- [Hacher et vérifier les mots de passe](#hacher-et-vérifier-les-mots-de-passe)
+- [Émettre et rafraîchir des JWT](#émettre-et-rafraîchir-des-jwt)
+- [S'authentifier avec des clés d'API](#sauthentifier-avec-des-clés-dapi)
+- [Ajouter l'authentification à deux facteurs (TOTP)](#ajouter-lauthentification-à-deux-facteurs-totp)
+- [Envoyer des URL signées (liens magiques)](#envoyer-des-url-signées-liens-magiques)
+- [Vérifier les webhooks entrants](#vérifier-les-webhooks-entrants)
+- [Garder les secrets hors de vos journaux](#garder-les-secrets-hors-de-vos-journaux)
+- [Tracer les requêtes entre services](#tracer-les-requêtes-entre-services)
+- [Gérer les secrets](#gérer-les-secrets)
+- [Auditer avant de déployer](#auditer-avant-de-déployer)
 
 ---
 
@@ -247,7 +247,7 @@ let safe = html_escape(user_input);
 
 Remplace `&`, `<`, `>`, `"`, `'`. Convient pour le contenu d'éléments HTML + les attributs entre guillemets doubles.
 
-Pour une défense XSS basée sur le CSP, voir [Définir les en-têtes de sécurité](#setting-security-headers).
+Pour une défense XSS basée sur le CSP, voir [Définir les en-têtes de sécurité](#définir-les-en-têtes-de-sécurité).
 
 ---
 
@@ -654,14 +654,14 @@ Pour des vérifications au-delà de ce qui est fourni, étendez avec du code per
 Quelques flux de bout en bout ont encore besoin d'être assemblés à partir des primitives ci-dessous :
 
 - **Réinitialisation de mot de passe + vérification d'email** — les helpers d'émission/vérification de jeton existent (`auth_flows::confirm_password_reset_pool`, plus les allers-retours de vérification d'email) et le pipeline d'email est fourni séparément, mais il n'y a pas de cycle unique préconstruit vue + email + validation câblé pour vous.
-- **Masquage PII du corps de requête / des en-têtes** dans `access_log` — le masquage de journal au niveau des champs existe (voir [Garder les secrets hors de vos journaux](#keeping-secrets-out-of-your-logs)), mais pas le nettoyage automatique du corps de requête ou des en-têtes.
+- **Masquage PII du corps de requête / des en-têtes** dans `access_log` — le masquage de journal au niveau des champs existe (voir [Garder les secrets hors de vos journaux](#garder-les-secrets-hors-de-vos-journaux)), mais pas le nettoyage automatique du corps de requête ou des en-têtes.
 
 Déjà fournis (n'allez pas chercher un contournement) :
 
 - **Connexion sociale OAuth2 / OIDC** — `oauth2::providers` fournit les helpers Google, GitHub, Microsoft, GitLab et Discord (plus `OAuth2Provider::from_discovery` pour tout fournisseur OIDC), et `oauth2::router::oauth2_router` monte les routes de login + callback, crée l'enregistrement utilisateur et définit le cookie de session.
 - **Verrouillage par compte** — `rustango::account_lockout::Lockout` (adossé au cache ; `is_locked` / `record_failure` / `clear`, `max_attempts` + `lockout_duration` configurables).
 - **Endpoint de rapport CSP** — `security_headers::csp_report_router(path)` + `SecurityHeadersLayer::csp_report_uri(uri)`.
-- **Limitation de débit distribuée** — `rate_limit_cache::CacheRateLimitLayer` (voir [Limiter le débit des requêtes](#rate-limiting-requests)).
+- **Limitation de débit distribuée** — `rate_limit_cache::CacheRateLimitLayer` (voir [Limiter le débit des requêtes](#limiter-le-débit-des-requêtes)).
 
 Jusqu'à ce que les flux non fournis arrivent, assemblez-les à partir des primitives ci-dessus (`signed_url::sign` pour les jetons de réinitialisation de mot de passe, le pipeline d'email pour la livraison, etc.).
 

--- a/docs/fr/serializers.md
+++ b/docs/fr/serializers.md
@@ -34,13 +34,13 @@ travers* lui.
 ---
 
 ## Table des matières
-- [Démarrage rapide](#quick-start) · [Le trait `ModelSerializer`](#the-modelserializer-trait)
-- [Attributs de champ](#field-attributes) — la référence complète
-- [Champs calculés](#computed-fields) · [Serializers imbriqués](#nested-serializers) · [Collections](#collections-many) · [Champs slug](#slug-related-fields)
-- [Validation](#validation) · [Validation d'unicité combinée](#unique-together-validation)
-- [Sortie hyperliée](#hyperlinked-output) · [Sérialiser des listes](#serializing-lists)
-- [Utiliser un serializer avec un ViewSet](#using-a-serializer-with-a-viewset) · [Valider dans un handler personnalisé](#validating-in-a-custom-handler)
-- [OpenAPI](#openapi-schemas) · [Scaffolding](#scaffolding) · [Ajustements et limites](#tweaks-and-current-limits)
+- [Démarrage rapide](#démarrage-rapide) · [Le trait `ModelSerializer`](#le-trait-modelserializer)
+- [Attributs de champ](#attributs-de-champ) — la référence complète
+- [Champs calculés](#champs-calculés) · [Serializers imbriqués](#serializers-imbriqués) · [Collections](#collections-many) · [Champs slug](#champs-slug)
+- [Validation](#validation) · [Validation d'unicité combinée](#validation-dunicité-combinée)
+- [Sortie hyperliée](#sortie-hyperliée) · [Sérialiser des listes](#sérialiser-des-listes)
+- [Utiliser un serializer avec un ViewSet](#utiliser-un-serializer-avec-un-viewset) · [Valider dans un handler personnalisé](#valider-dans-un-handler-personnalisé)
+- [OpenAPI](#schémas-openapi) · [Scaffolding](#scaffolding) · [Ajustements et limites](#ajustements-et-limites-actuelles)
 
 ---
 
@@ -207,7 +207,7 @@ pub author: AuthorBrief,
 
 Les champs imbriqués sont en **lecture seule** dans la forme de sortie — les
 objets imbriqués accessibles en écriture ne sont pas encore pris en charge (voir
-[limites](#tweaks-and-current-limits)).
+[limites](#ajustements-et-limites-actuelles)).
 
 ---
 
@@ -439,7 +439,7 @@ pub struct PostViewSet;
 
 Le ViewSet pilote cela via trois méthodes `ModelSerializer` que le derive
 génère : `validate()`, `writable_source_fields()` et `from_writable_json()`. Voir
-le [guide des ViewSets](viewsets.md#the-serializer-marriage-input--output) pour le
+le [guide des ViewSets](viewsets.md#le-mariage-du-sérialiseur--entrée--sortie) pour le
 comportement complet et un exemple concret.
 
 On peut aussi utiliser un serializer **de façon autonome** — mettre une ligne en

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -25,13 +25,13 @@ Rust.
 
 ## Table des matières
 
-- [Étape 1 — Pilotez votre application avec TestClient](#step-1--drive-your-app-with-testclient)
-- [Étape 2 — Faites des assertions sur la réponse](#step-2--assert-on-the-response)
-- [Envoyer du JSON, des en-têtes et des corps](#sending-json-headers-and-bodies)
-- [Tester une vraie API](#testing-a-real-api)
-- [Tests de base de données avec rollback](#database-tests-with-rollback)
-- [Helpers d'assertion de réponse](#response-assertion-helpers)
-- [Voir aussi](#see-also)
+- [Étape 1 — Pilotez votre application avec TestClient](#étape-1--pilotez-votre-application-avec-testclient)
+- [Étape 2 — Faites des assertions sur la réponse](#étape-2--faites-des-assertions-sur-la-réponse)
+- [Envoyer du JSON, des en-têtes et des corps](#envoyer-du-json-des-en-têtes-et-des-corps)
+- [Tester une vraie API](#tester-une-vraie-api)
+- [Tests de base de données avec rollback](#tests-de-base-de-données-avec-rollback)
+- [Helpers d'assertion de réponse](#helpers-dassertion-de-réponse)
+- [Voir aussi](#voir-aussi)
 
 ---
 

--- a/docs/fr/urls.md
+++ b/docs/fr/urls.md
@@ -20,11 +20,11 @@ les templates avec `{{ url(...) }}`, et dans les redirections avec
 ---
 
 ## Table des matières
-- [Enregistrer une URL nommée](#register-a-named-url)
-- [Reverse en Rust](#reverse-in-rust) · [Reverse dans les templates](#reverse-in-templates)
-- [Rediriger par nom](#redirect-by-name) · [Namespacing](#namespacing)
-- [Inspecter la carte des URL](#inspect-the-url-map) · [Erreurs](#errors)
-- [Motifs regex & chemins typés](#regex--typed-path-patterns) · [Notes & limites](#notes-and-limits)
+- [Enregistrer une URL nommée](#enregistrer-une-url-nommée)
+- [Reverse en Rust](#reverse-en-rust) · [Reverse dans les templates](#reverse-dans-les-templates)
+- [Rediriger par nom](#rediriger-par-nom) · [Namespacing](#namespacing)
+- [Inspecter la carte des URL](#inspecter-la-carte-des-url) · [Erreurs](#erreurs)
+- [Motifs regex & chemins typés](#motifs-regex--chemins-typés) · [Notes & limites](#notes-et-limites)
 
 ---
 
@@ -75,7 +75,7 @@ let url = reverse_owned("post-detail", &owned_params)?;
 
 `reverse` est **strict** : un placeholder manquant, ou une clé `params`
 supplémentaire que le motif n'a pas, est une erreur (pas un décalage silencieux) —
-voir [Erreurs](#errors).
+voir [Erreurs](#erreurs).
 
 ---
 
@@ -285,7 +285,7 @@ une fois et la réutiliser à travers les requêtes.
   déposer dans un header `Location` ou un `href`.
 - **Pas de convertisseurs regex/typés** dans les motifs (le `<int:pk>` de Django) ;
   les placeholders sont de simples `{name}` et les valeurs sont substituées telles
-  quelles (après encodage). Voir [Motifs regex & chemins typés](#regex--typed-path-patterns)
+  quelles (après encodage). Voir [Motifs regex & chemins typés](#motifs-regex--chemins-typés)
   pour le pourquoi, et comment contraindre une route à la place.
 
 

--- a/docs/fr/viewsets.md
+++ b/docs/fr/viewsets.md
@@ -7,7 +7,7 @@ contrôleur de ressource d'API Laravel, si vous en avez déjà utilisé.)
 
 > **Nouveau dans les API REST ?** Ce guide suppose que vous savez ce qu'est un *endpoint*, un *verbe
 > HTTP* (GET / POST / …) et une *requête et réponse JSON*. Si l'un de ces concepts
-> est flou, le [glossaire](glossary.md#web-api-basics) en fait un tour d'horizon de cinq minutes —
+> est flou, le [glossaire](glossary.md#les-bases-des-api-web) en fait un tour d'horizon de cinq minutes —
 > lisez-le d'abord, puis revenez ici.
 
 Associez un ViewSet à un [sérialiseur](serializers.md) — la pièce qui façonne votre
@@ -38,15 +38,15 @@ est une référence pour chaque réglage.
 ---
 
 ## Table des matières
-- [Vues API vs vues HTML](#api-views-vs-html-views) — du JSON pour les clients, ou des pages HTML ?
-- [Construire une API REST de blog](#build-a-rest-blog-api) — la présentation complète
-- [Le mariage du sérialiseur : entrée + sortie](#the-serializer-marriage-input--output)
-- [Les deux façons de définir un ViewSet](#the-two-ways-to-define-a-viewset)
-- [Les endpoints CRUD](#the-crud-endpoints) · [Choisir lesquels exposer](#choosing-which-operations-to-expose)
-- [Référence `#[viewset(...)]`](#viewset-attribute-reference) · [Référence du builder](#builder-reference)
-- [Filtrage, recherche & tri](#filtering-search-and-ordering) · [Pagination](#pagination)
-- [Validation](#validation) · [Permissions & throttling](#permissions-and-throttling) · [Actions personnalisées](#custom-actions-beyond-crud)
-- [Montage](#mounting) · [Backends](#backend-support)
+- [Vues API vs vues HTML](#vues-api-vs-vues-html) — du JSON pour les clients, ou des pages HTML ?
+- [Construire une API REST de blog](#construire-une-api-rest-de-blog) — la présentation complète
+- [Le mariage du sérialiseur : entrée + sortie](#le-mariage-du-sérialiseur--entrée--sortie)
+- [Les deux façons de définir un ViewSet](#les-deux-façons-de-définir-un-viewset)
+- [Les endpoints CRUD](#les-endpoints-crud) · [Choisir lesquels exposer](#choisir-quelles-opérations-exposer)
+- [Référence `#[viewset(...)]`](#référence-de-lattribut-viewset) · [Référence du builder](#référence-du-builder)
+- [Filtrage, recherche & tri](#filtrage-recherche-et-tri) · [Pagination](#pagination)
+- [Validation](#validation) · [Permissions & throttling](#permissions-et-throttling) · [Actions personnalisées](#actions-personnalisées-au-delà-du-crud)
+- [Montage](#montage) · [Backends](#prise-en-charge-des-backends)
 
 ---
 
@@ -523,7 +523,7 @@ ViewSet::for_model(Post::SCHEMA).read_only()   // builder
 
 Il n'y a pas de bascule par verbe au-delà de read_only. Pour « tout sauf delete »,
 montez le ViewSet et surchargez la route unique avec votre propre handler (voir
-[Actions personnalisées](#custom-actions-beyond-crud)).
+[Actions personnalisées](#actions-personnalisées-au-delà-du-crud)).
 
 ---
 
@@ -532,7 +532,7 @@ montez le ViewSet et surchargez la route unique avec votre propre handler (voir
 | Clé | Exemple | Défaut | Ce qu'elle fait |
 |---|---|---|---|
 | `model` | `model = Post` | **requis** | Le modèle sur lequel la ressource est construite. |
-| `serializer` | `serializer = path::To::S` | aucun | Brancher un sérialiseur pour une **sortie + entrée** typées (voir [ci-dessus](#the-serializer-marriage-input--output)). |
+| `serializer` | `serializer = path::To::S` | aucun | Brancher un sérialiseur pour une **sortie + entrée** typées (voir [ci-dessus](#le-mariage-du-sérialiseur--entrée--sortie)). |
 | `fields` | `"id, title, body"` | tous les champs scalaires | Liste blanche pour la projection par défaut (non-sérialiseur) + les champs modifiables. |
 | `filter_fields` | `"author_id, status"` | aucun | Champs filtrables via `?field=value` (+ lookups). |
 | `search_fields` | `"title, body"` | aucun | Champs que la boîte `?search=` fait correspondre (OU insensible à la casse). |
@@ -633,7 +633,7 @@ pour les très grandes tables. `?cursor=<token>&page_size=20` :
 
 Avec un **sérialiseur branché**, le chemin create/update exécute les
 validateurs du sérialiseur et renvoie des `400` en forme DRF — la manière recommandée de valider (voir
-[le mariage](#the-serializer-marriage-input--output) et le
+[le mariage](#le-mariage-du-sérialiseur--entrée--sortie) et le
 [guide des sérialiseurs](serializers.md#validation)). Trois couches s'exécutent :
 
 - **Contraintes déclaratives** — `max_length` / `min_length` / `min` / `max`, et

--- a/docs/fr/websockets.md
+++ b/docs/fr/websockets.md
@@ -32,14 +32,14 @@ venez de Django, c'est Channels ; de Laravel, Echo/Reverb ; de Node,
 
 ## Table des matières
 
-- [SSE ou WebSocket — lequel ?](#sse-or-websocket--which)
-- [Le bus de diffusion](#the-broadcast-bus)
+- [SSE ou WebSocket — lequel ?](#sse-ou-websocket--lequel-)
+- [Le bus de diffusion](#le-bus-de-diffusion)
 - [Server-Sent Events](#server-sent-events)
 - [WebSockets](#websockets)
-- [Envoyer depuis ailleurs](#sending-from-elsewhere)
-- [Auth & multi-locataire](#auth--tenancy)
-- [Notes de mise à l'échelle](#scaling-notes)
-- [Drapeaux de fonctionnalités](#feature-flags)
+- [Envoyer depuis ailleurs](#envoyer-depuis-ailleurs)
+- [Auth & multi-locataire](#auth--multi-locataire)
+- [Notes de mise à l'échelle](#notes-de-mise-à-léchelle)
+- [Drapeaux de fonctionnalités](#drapeaux-de-fonctionnalités)
 
 ---
 


### PR DESCRIPTION
Refs #1354.

## The bug

The translations translated their **headings** and kept the **English anchors**. So every in-page link in `de` / `fr` / `es` pointed at an id that exists only in the English file:

```
docs/de/orm.md:  [Abfragen](#querying)      → no heading `#querying`, it's `## Abfragen`
docs/fr/auth-jwt.md: [Vérifier](#verifying-a-token) → the heading is `## Vérifier un token`
```

**930 dead links across 94 pages** — every table of contents, plus the cross-page links into `manage.md`, `glossary.md`, `orm.md` and friends. Clicking one puts a German reader at the top of the page with no indication anything went wrong.

## Why nobody caught it

`docs_links` skipped `#` fragments by design — it checked that the *file* resolved and stopped there. It no longer does.

`every_anchor_resolves_in_every_locale` derives a heading's id the way GitHub and the docs site both do: lowercase, drop punctuation but keep Unicode letters, spaces to hyphens, and a dropped separator leaves its spaces behind (`Auth & tenancy` → `auth--tenancy`).

That rule is not a guess. **The English pages resolve 100% under it — 0 failures out of ~1000 anchors.** That is what makes it safe to assert on translations whose headings nobody on the team can eyeball.

## The fix

Only the `(#...)` targets move; every visible label is untouched. Headings that happen to be identical across locales (`#many-to-many`, `#json--jsonb`, `#soft-delete`, `#audit-trail`) correctly stay put — the test proves it, since a wrong "fix" there would fail.

## Known gap, not addressed here

Four pages still carry untranslated English `##` headings, so their anchors resolve for the wrong reason:

| page | untranslated headings |
|---|---|
| `de` / `es` / `fr` `manage.md` | 81 of 113 |
| `es/viewsets.md` | 37 of 38 |
| `de/query-method.md` | 8 of 12 |

Their links are correct today and the test will catch it the moment those headings get translated. Translating them is separate work.