### PR TITLE
fix(tenancy): derive a tenant URL from a bare-filename SQLite registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,16 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   `.env` said otherwise. The line is commented out with the length requirement
   beside it, and an unusable secret now warns instead of vanishing.
 
+- **A SQLite registry named by a bare filename derived no tenant URL** (#1332).
+  `tenant_url_on_registry_server` found the sibling directory with
+  `rsplit_once('/')`, which a `sqlite://app.db` registry has none of — so the
+  console showed no derived URL and the submit asked the operator to type one,
+  for the one backend where the answer is most obvious. A bare filename is now
+  read as the working directory, an in-memory registry still derives nothing
+  (there is no directory to be a sibling of), and a database already named
+  `acme.db` no longer becomes `acme.db.db`. The derivation now has direct tests
+  on all three dialects, which #1332's acceptance asked for and it never had.
+
 - **Every in-page link in the `de` / `fr` / `es` docs pointed at an English
   anchor** (#1354). The translations translated their headings and kept the
   English `#fragment`s, so 930 links across 94 pages — every table of contents,

--- a/crates/rustango/src/tenancy/provision.rs
+++ b/crates/rustango/src/tenancy/provision.rs
@@ -1083,8 +1083,28 @@ pub fn tenant_url_on_registry_server(registry_url: &str, database: &str) -> Opti
     // database" means a sibling file.
     if let Some(path) = registry_url.strip_prefix("sqlite://") {
         let path = path.split('?').next().unwrap_or(path);
-        let (dir, _) = path.rsplit_once('/')?;
-        return Some(format!("sqlite://{dir}/{database}.db?mode=rwc"));
+        // An in-memory registry has no directory to put a sibling in.
+        if path.is_empty() || path.starts_with(":memory:") {
+            return None;
+        }
+        // A bare filename is relative to the working directory, which
+        // is exactly where the sibling belongs. `rsplit_once` alone
+        // returned `None` for it, so a `sqlite://app.db` registry
+        // derived nothing at all.
+        let dir = path.rsplit_once('/').map_or(".", |(d, _)| d);
+        // The operator names a database, but a sqlite database is a
+        // file — so `acme` becomes `acme.db` and `acme.db` stays put.
+        // Case-insensitively: `acme.DB` is already the extension, and
+        // on a case-insensitive filesystem it is the very same file.
+        let file = if std::path::Path::new(database)
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("db"))
+        {
+            database.to_owned()
+        } else {
+            format!("{database}.db")
+        };
+        return Some(format!("sqlite://{dir}/{file}?mode=rwc"));
     }
 
     let (scheme, rest) = registry_url.split_once("://")?;
@@ -1682,6 +1702,107 @@ mod validation_tests {
             assert!(
                 refuse_registry_url(ok, registry).is_ok(),
                 "`{ok}` is a different database and should be allowed"
+            );
+        }
+    }
+
+    /// #1332 asked for the derivation to be exercised on every dialect,
+    /// because "same server, another database" is a different shape in
+    /// each: a path segment on a server, a sibling file on sqlite.
+    #[test]
+    fn a_server_url_keeps_everything_but_the_database() {
+        assert_eq!(
+            tenant_url_on_registry_server(
+                "postgres://app:pw@db.internal:5432/orgdemo_dev",
+                "tenant_acme"
+            )
+            .as_deref(),
+            Some("postgres://app:pw@db.internal:5432/tenant_acme")
+        );
+        assert_eq!(
+            tenant_url_on_registry_server("mysql://app:pw@db.internal:3306/orgdemo_dev", "t_acme")
+                .as_deref(),
+            Some("mysql://app:pw@db.internal:3306/t_acme")
+        );
+    }
+
+    /// sqlite has no server, so the sibling is a file in the registry
+    /// file's own directory — including the `./` form the scaffolder
+    /// writes into every generated `.env.example`.
+    #[test]
+    fn a_sqlite_url_derives_a_sibling_file() {
+        for (registry, want) in [
+            (
+                "sqlite://./demo_dev.db?mode=rwc",
+                "sqlite://./tenant_acme.db?mode=rwc",
+            ),
+            (
+                "sqlite:///var/app/reg.db",
+                "sqlite:///var/app/tenant_acme.db?mode=rwc",
+            ),
+            // A bare filename is relative to the working directory.
+            // This derived nothing at all before, so a registry
+            // configured that way fell back to "type a URL yourself".
+            ("sqlite://reg.db", "sqlite://./tenant_acme.db?mode=rwc"),
+        ] {
+            assert_eq!(
+                tenant_url_on_registry_server(registry, "tenant_acme").as_deref(),
+                Some(want),
+                "registry `{registry}`"
+            );
+        }
+    }
+
+    /// An operator naming the database `acme.db` means the file
+    /// `acme.db`, not `acme.db.db`.
+    #[test]
+    fn a_sqlite_database_name_is_not_given_two_extensions() {
+        for named in ["acme.db", "acme.DB"] {
+            assert_eq!(
+                tenant_url_on_registry_server("sqlite://./reg.db", named).as_deref(),
+                Some(format!("sqlite://./{named}?mode=rwc")).as_deref(),
+                "database name `{named}`"
+            );
+        }
+        // A dot that is not the extension still gets one.
+        assert_eq!(
+            tenant_url_on_registry_server("sqlite://./reg.db", "acme.v2").as_deref(),
+            Some("sqlite://./acme.v2.db?mode=rwc")
+        );
+    }
+
+    /// Shapes with nowhere to put a tenant. The caller renders the
+    /// "supply a full URL instead" escape hatch for these rather than
+    /// guessing.
+    #[test]
+    fn a_url_with_no_database_to_replace_derives_nothing() {
+        for undrivable in [
+            "sqlite://:memory:",    // no directory to be a sibling of
+            "sqlite://",            // no path at all
+            "postgres://localhost", // no database segment
+            "not a url",            // no scheme
+            "postgres:///orgdemo",  // no authority
+        ] {
+            assert!(
+                tenant_url_on_registry_server(undrivable, "tenant_acme").is_none(),
+                "`{undrivable}` should not derive a URL"
+            );
+        }
+    }
+
+    /// The derivation and the registry-collision guard have to agree:
+    /// a derived URL must never be the one it was derived from.
+    #[test]
+    fn a_derived_url_is_never_the_registry_itself() {
+        for registry in [
+            "postgres://app:pw@db.internal:5432/orgdemo_dev",
+            "sqlite://./demo_dev.db?mode=rwc",
+        ] {
+            let derived =
+                tenant_url_on_registry_server(registry, "tenant_acme").expect("derivable registry");
+            assert!(
+                refuse_registry_url(&derived, registry).is_ok(),
+                "derived `{derived}` collided with registry `{registry}`"
             );
         }
     }


### PR DESCRIPTION
Refs #1332. Stacked on #1361.

#1332 shipped in #1329, but only its server-backed acceptance criteria were exercised. Its last bullet — *"Tested on a SQLite registry too, where 'same server, different database' means a sibling file rather than a database name — this derivation is dialect-shaped and must not assume Postgres"* — had no test, and the SQLite branch had a hole.

## The hole

```rust
let (dir, _) = path.rsplit_once('/')?;   // `app.db` has no '/' → None
```

A `sqlite://app.db` registry is a legal config with no `/` in it, so the derivation returned `None`: the form showed no derived URL and the submit answered *"Could not derive a URL … supply a full URL instead."* On the one backend where "the database next to this one" is most obvious.

It degraded safely — a clear message and a working escape hatch — so this is a usability hole, not a correctness one. Notably the *scaffolder's* own output (`sqlite://./demo_dev.db?mode=rwc`) does have a `/` and always worked, which is why nothing caught it.

## The fix

A bare filename reads as the working directory. Two adjacent cases fell out of writing the tests:

| case | before | after |
|---|---|---|
| `sqlite://app.db` | `None` | `sqlite://./tenant_acme.db?mode=rwc` |
| `sqlite://:memory:` | `None` | `None` — deliberately |
| database named `acme.db` | `acme.db.db` | `acme.db` |
| database named `acme.DB` | `acme.DB.db` | `acme.DB` |

An in-memory registry keeps deriving nothing: there is no directory to be a sibling of, and quietly materializing a file on disk from a `:memory:` registry would be a surprising place to put a tenant. The `.db` check is case-insensitive because on a case-insensitive filesystem `acme.DB` *is* the same file.

## Tests

Five new cases in `validation_tests`, covering all three dialects — including the `sqlite://./x.db?mode=rwc` form the scaffolder writes into every generated `.env.example`. One of them asserts a derived URL never collides with the registry it came from, tying the derivation to the `refuse_registry_url` guard that exists to catch exactly that (the #1329 finding where tenant migrations ran into the registry).

`cargo test -p rustango --all-features --lib tenancy::` — 245 pass. Clippy clean on the changed file.

## Note on the epic

#1330's sub-issues are all implemented as of #1329, but that commit's closing line reads `Addresses #1331, #1333, #1334, #1335, #1336` — **#1332 is missing from it**, though the commit does implement it. Worth closing the whole set by hand once the stack merges.