### PR TITLE
fix(sql): ungate the tri-dialect emitters so selective-feature tests compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check -p rustango --no-default-features --features sqlite,tenancy
       - run: cargo clippy -p rustango --no-default-features --features sqlite,tenancy --lib --no-deps
+      # Compile *every* test target, not just the ones enumerated below
+      # (#1363). `check` and `clippy --lib` above both stop at the
+      # library, so for a long time no job compiled a test binary
+      # without Postgres — and the enumeration grew stale silently every
+      # time a test file was added. `--no-run` needs no databases.
+      - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --no-run
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test sqlite_pragmas_live
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_fk_no_postgres
       - run: cargo test -p rustango --no-default-features --features sqlite,tenancy --test macro_choices
@@ -386,9 +392,11 @@ jobs:
   # service container is needed; tests create per-test files / `:memory:`
   # databases.
   #
-  # Listing `--test` files explicitly prevents the test harness from
-  # compiling PG-typed test binaries that don't compile under
-  # `--no-default-features`.
+  # `--test` files are listed explicitly because this job *runs* them,
+  # and only the sqlite-live ones are worth running here. It is no
+  # longer a workaround for test binaries that would not compile: since
+  # #1363 the whole suite compiles under `--no-default-features`, and
+  # `sqlite_litmus` asserts that with `--no-run`.
   sqlite_live:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   crates. Both files are now packaged into all four published crates.
 
 ### Changed
+- **The MySQL and SQLite dialect emitters are no longer gated on their drivers**
+  (#1363). `sql::MySql` and `sql::Sqlite` are pure `Clause` IR → string
+  compilation — no `sqlx`, no `#[cfg]` — exactly like `sql::Postgres`, which was
+  always ungated. Gating them meant a tri-dialect *emission* test could not
+  compile unless the binary also linked all three database drivers, which is
+  backwards: emission is the part with no driver. Both are now unconditional;
+  only the `DIALECT` statics stay gated, since their callers are `Pool` arms
+  that need the driver. Nothing about a built binary changes — this only widens
+  what a selective-feature build can name.
+
 - **Operator activation rules moved out of the console handler** into
   `tenancy::operators`, which both surfaces now call (#1344). "You cannot
   deactivate yourself" and "you cannot deactivate the last active operator"
@@ -83,6 +93,21 @@ All notable changes to rustango. The format follows [Keep a Changelog](https://k
   every SQLite and MySQL deployment.
 
 ### Fixed
+- **`cargo test --no-default-features --features sqlite,tenancy` did not
+  compile** (#1363). The canonical no-Postgres litmus had been broken for a
+  long time: two emission tests wanted `sql::MySql` (see Changed), 36 files used
+  `rustango::testkit` without asking for the feature, and two used
+  `rustango::cache` the same way. `testkit` is now a self dev-dependency
+  (`default-features = false`, so it cannot smuggle `postgres` back in) rather
+  than 36 edited gates; the cache tests declare `feature = "cache"`.
+
+  CI never caught it because both no-Postgres jobs enumerate test targets by
+  hand — 68 and 60 of the crate's 526 test files — while `cargo check` and
+  `cargo clippy --lib` stop at the library. The enumeration was itself a
+  documented workaround for this defect, so it had been quietly masking a gap
+  that grew with every new test file. `sqlite_litmus` now compiles the whole
+  suite with `--no-run`, which needs no databases.
+
 - **A tenant created from the CLI left no provisioning run** (#1344).
   `create-tenant` called `provision_tenant` rather than
   `provision_tenant_recorded`, so the run history — and the console's run list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "reqwest",
  "rpassword",
  "rust_decimal",
+ "rustango",
  "rustango-macros",
  "serde",
  "serde_json",

--- a/crates/rustango/Cargo.toml
+++ b/crates/rustango/Cargo.toml
@@ -574,6 +574,13 @@ tracing-appender = { workspace = true, optional = true }
 time = { workspace = true }
 
 [dev-dependencies]
+# Self dev-dependency, for `testkit` alone. Integration tests are
+# external crates, so `crate::testkit` is only public API with the
+# feature on — and 36 test files used it without asking for it, so
+# every selective-feature test build failed on a missing module.
+# `default-features = false` matters: without it this would quietly
+# re-enable postgres and make `--no-default-features` meaningless.
+rustango       = { path = ".", default-features = false, features = ["testkit"] }
 tokio          = { workspace = true }
 chrono         = { workspace = true }
 uuid           = { workspace = true }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -22,12 +22,15 @@ mod hstore;
 pub mod m2m;
 #[doc(hidden)]
 pub mod model_shortcuts;
-#[cfg(feature = "mysql")]
+// The three dialect emitters are pure IR-to-string compilation — no
+// driver, no sqlx. Gating them on their driver feature made a
+// tri-dialect *emission* test impossible to compile unless the binary
+// also linked all three drivers, which is the opposite of the point.
+// `postgres` was always ungated; these two now match it.
 mod mysql;
 mod pool;
 mod postgres;
 mod range;
-#[cfg(feature = "sqlite")]
 mod sqlite;
 mod vector;
 mod writers;
@@ -99,7 +102,6 @@ pub use executor::LoadRelatedMy;
 pub use executor::LoadRelatedSqlite;
 pub use foreign_key::ForeignKey;
 pub use m2m::{GenericM2MManager, M2MManager};
-#[cfg(feature = "mysql")]
 pub use mysql::MySql;
 // Both call sites (`manage::dispatch`) sit inside `tenancy` gates, so the
 // re-export needs `tenancy` too (#1208) — without it, `sqlite,manage` warned
@@ -108,7 +110,6 @@ pub use mysql::MySql;
 pub(crate) use pool::sqlite_connect_options;
 pub use pool::{Pool, PoolError};
 pub use postgres::Postgres;
-#[cfg(feature = "sqlite")]
 pub use sqlite::Sqlite;
 
 /// Re-exported so `#[derive(Model)]` output can name `sqlx` types without

--- a/crates/rustango/src/sql/mysql.rs
+++ b/crates/rustango/src/sql/mysql.rs
@@ -40,6 +40,10 @@ pub struct MySql;
 /// `'static` reference to the singleton [`MySql`] dialect, symmetric
 /// with [`super::postgres::DIALECT`]. Used by [`crate::sql::Pool::dialect`]
 /// to hand back a `&'static dyn Dialect` regardless of pool variant.
+///
+/// Gated where the emitter above is not: every caller is a `Pool` arm
+/// that only exists with the driver linked.
+#[cfg(feature = "mysql")]
 pub static DIALECT: &MySql = &MySql;
 
 impl Dialect for MySql {

--- a/crates/rustango/src/sql/sqlite.rs
+++ b/crates/rustango/src/sql/sqlite.rs
@@ -43,6 +43,10 @@ pub struct Sqlite;
 /// with [`super::postgres::DIALECT`] / [`super::mysql::DIALECT`]. Used
 /// by [`crate::sql::Pool::dialect`] (Phase 2) to hand back a
 /// `&'static dyn Dialect` regardless of pool variant.
+///
+/// Gated where the emitter above is not: every caller is a `Pool` arm
+/// that only exists with the driver linked.
+#[cfg(feature = "sqlite")]
 pub static DIALECT: &Sqlite = &Sqlite;
 
 impl Dialect for Sqlite {

--- a/crates/rustango/src/sql/writers.rs
+++ b/crates/rustango/src/sql/writers.rs
@@ -3358,7 +3358,6 @@ pub(super) fn write_delete(b: &mut Sql<'_>, query: &DeleteQuery) -> Result<(), S
 /// `near "(": syntax error` at the alias parens. The
 /// CTE + correlated-subquery shape below parses everywhere
 /// SQLite has supported CTEs (3.8.3, 2014).
-#[cfg(feature = "sqlite")]
 pub(super) fn write_bulk_update_sqlite(
     b: &mut Sql<'_>,
     query: &BulkUpdateQuery,

--- a/crates/rustango/tests/cache_db_backend_add_live.rs
+++ b/crates/rustango/tests/cache_db_backend_add_live.rs
@@ -17,6 +17,10 @@
 //!
 //! Each backend skips silently when its env var is unset.
 
+// The per-backend tests below carry their own gates; this one is for
+// the `rustango::cache` import they share.
+#![cfg(feature = "cache")]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/rustango/tests/cache_db_backend_sqlite_live.rs
+++ b/crates/rustango/tests/cache_db_backend_sqlite_live.rs
@@ -4,7 +4,7 @@
 //! sqlite hits the `ON CONFLICT` arm; the MySQL `ON DUPLICATE KEY
 //! UPDATE` arm is covered by inspection (see `db_backend.rs::set`).
 
-#![cfg(feature = "sqlite")]
+#![cfg(all(feature = "sqlite", feature = "cache"))]
 
 use std::time::Duration;
 


### PR DESCRIPTION
Fixes #1363. Stacked on #1362.

`cargo test -p rustango --no-default-features --features sqlite,tenancy` — the canonical no-Postgres litmus — did not compile, and had not for a long time.

## The emitters were gated on their drivers

```rust
#[cfg(feature = "mysql")]   mod mysql;
#[cfg(feature = "sqlite")]  mod sqlite;
                            mod postgres;   // ← correctly ungated
```

`mysql.rs` and `sqlite.rs` contain **zero** `#[cfg]` and **zero** `sqlx::` — they are pure `Clause` IR → string compilation, exactly like `postgres.rs`. Gating them meant a tri-dialect *emission* test could not compile unless the binary also linked all three database drivers, which is backwards: emission is the part with no driver.

It broke `json_array_length` and `pg_aggregates`, both pure `compile_select` assertions that touch no database.

`postgres.rs` already demonstrated the right shape, so this copies it: module and struct unconditional, and only the `DIALECT` statics keep a gate, since every caller is a `Pool` arm that needs the driver. `write_bulk_update_sqlite` in `writers.rs` comes along for the same reason.

**No built binary changes.** This only widens what a selective-feature build may name.

## And 38 test files used features they never declared

36 on `rustango::testkit`, 2 on `rustango::cache`.

`testkit = []` is an empty marker feature that exists only because integration tests are external crates and need the module public — its own comment says it "pulls in nothing and costs a normal build nothing". So it becomes a self dev-dependency rather than 36 edited gates:

```toml
rustango = { path = ".", default-features = false, features = ["testkit"] }
```

`default-features = false` is **load-bearing**: without it this silently re-enables `postgres` and makes every `--no-default-features` invocation in the repo meaningless. `cache` is a real feature with real dependencies, so those two tests declare it normally.

## Why CI never saw it

| job | enumerated `--test` targets |
|---|---|
| `sqlite_litmus` | 68 |
| `sqlite_live` | 60 |
| **test files in the crate** | **526** |

`cargo check` and `cargo clippy --lib` both stop at the library, so no job ever compiled a test binary without Postgres. And the enumeration was itself a documented workaround for this defect — `ci.yml` said so above `sqlite_live`:

> Listing `--test` files explicitly prevents the test harness from compiling PG-typed test binaries that don't compile under `--no-default-features`.

So the workaround had been holding the door shut on a gap that grew every time a test file was added. `sqlite_litmus` now compiles the whole suite with `--no-run` (no databases needed), and that stale comment is corrected.

## Verification

- `sqlite,tenancy`: **527 test binaries, 4517 tests, 0 failures** — a suite that previously did not build at all.
- Six feature combinations (`postgres`, `mysql`, `sqlite`, `sqlite,tenancy`, `postgres,tenancy`, `postgres,mysql,sqlite`) build with zero errors and zero warnings.
- `--all-features` and the default build unchanged.

## Disclosure

`cargo clippy --lib` under `sqlite,tenancy` goes from 2002 to 2043 warnings. All 41 are pre-existing `match_same_arms` and `doc_markdown` lints **in `mysql.rs` / `sqlite.rs`, which I did not touch** — this feature set simply never linted those files before. The `clippy` job runs without `-D warnings` deliberately (its comment explains that the `-D` form surfaced ~70 pedantic errors the pre-push hook treats as warnings), so nothing fails. I left them rather than pad this diff with unrelated lint fixes.

## Out of scope

`--no-default-features --features sqlite` **alone**, without `tenancy`, still fails with 65 errors — a long-standing separate gap where many tests assume `tenancy`. The canonical litmus has always been `sqlite,tenancy`. Noted in #1363; worth its own issue.