### PR TITLE
test(docs): sample output must show the version that is shipping

### DIFF
--- a/crates/rustango-renamed-smoke/README.md
+++ b/crates/rustango-renamed-smoke/README.md
@@ -8,7 +8,7 @@ The Cargo.toml renames the rustango dep to `orm`:
 
 ```toml
 [dependencies]
-orm = { package = "rustango", path = "../rustango", version = "0.42.0" }
+orm = { package = "rustango", path = "../rustango", version = "0.57.0" }
 ```
 
 …then uses every macro entry point through the renamed name and confirms the resulting code compiles + runs.

--- a/crates/rustango/src/template_extensions.rs
+++ b/crates/rustango/src/template_extensions.rs
@@ -37,7 +37,7 @@
 //!
 //! ```jinja
 //! {{ "hello" | shout }}      {# → HELLO! #}
-//! {{ build_version() }}      {# → 0.42.0 #}
+//! {{ build_version() }}      {# → the running crate's version #}
 //! ```
 //!
 //! Filters + functions register globally — every Tera instance the

--- a/crates/rustango/tests/docs_versions.rs
+++ b/crates/rustango/tests/docs_versions.rs
@@ -1,0 +1,343 @@
+//! Sample output in the docs must show the version that is actually
+//! shipping.
+//!
+//! `docs/manage.md` told readers that `manage version` prints
+//! `rustango 0.44.0`, and `docs/mcp.md` showed an MCP handshake
+//! answering `"version": "0.44.0"` — in all four locales, thirteen
+//! releases after 0.44.0. Nothing was wrong with the prose; the
+//! transcripts had simply been frozen when they were written.
+//!
+//! That is what a release checklist is bad at. It decays silently, and
+//! nobody notices, because the page still reads correctly. So this is a
+//! test instead.
+//!
+//! ## What counts as a version mention
+//!
+//! Only versions **rustango is claiming as its own**, which in practice
+//! means the token `rustango` sits next to them:
+//!
+//! ```text
+//! rustango 0.44.0                                    ← same line
+//! "name": "rustango", "version": "0.44.0"            ← same line
+//! rustango
+//!   version:        0.44.0                           ← `about` transcript
+//! ```
+//!
+//! Everything else in the docs is left alone, and deliberately. The
+//! pages are full of three-component numbers that have nothing to do
+//! with this crate's version — `OpenApiSpec::new("Blog API", "1.0.0")`
+//! is the *reader's* API version, `"openapi": "3.1.0"` is the spec,
+//! `MySQL 8.0.1+` is a database. A test that flagged those would be
+//! turned off within a week.
+//!
+//! Prose about old releases is also untouched, because it is correct:
+//! "before v0.24.2", "Introduced in 0.51.1", "0.51.0 and 0.51.1 were
+//! yanked" are all statements about history that do not change when a
+//! new version ships. None of them put `rustango` next to the number,
+//! which is what keeps them out.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// The version this build ships as — the string `manage version` prints.
+const CURRENT: &str = env!("CARGO_PKG_VERSION");
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("resolve repo root")
+}
+
+/// Pages the docs site publishes, per `docs/index.toml` — the same set
+/// `docs_links` checks.
+fn published_pages(root: &Path) -> HashSet<String> {
+    let toml = std::fs::read_to_string(root.join("docs/index.toml")).expect("read docs/index.toml");
+    let mut out = HashSet::new();
+    let mut rest = toml.as_str();
+    while let Some(i) = rest.find('"') {
+        rest = &rest[i + 1..];
+        let Some(j) = rest.find('"') else { break };
+        let val = &rest[..j];
+        rest = &rest[j + 1..];
+        if val.ends_with(".md") {
+            out.insert(val.to_owned());
+        }
+    }
+    assert!(!out.is_empty(), "parsed no pages out of docs/index.toml");
+    out
+}
+
+/// Does `line` use `rustango` as a word, rather than as part of a longer
+/// identifier?
+///
+/// `rustango 0.44.0` yes; `rustango::openapi` and `cargo-rustango` no —
+/// a `use` line naming a module is not the framework announcing its
+/// version, and that distinction is what keeps
+/// `OpenApiSpec::new("Blog API", "1.0.0")` out of the results.
+fn names_rustango(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+    let mut from = 0;
+    while let Some(hit) = lower[from..].find("rustango") {
+        let start = from + hit;
+        let end = start + "rustango".len();
+        let before_ok = start == 0 || !is_ident_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_ident_byte(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b':' || b == b'/'
+}
+
+/// Every `MAJOR.MINOR.PATCH` in `line` that is *labelled* as rustango's.
+///
+/// The label is the word immediately before the number, ignoring the
+/// quotes and punctuation between them — `rustango` or `version`, and
+/// nothing else. Requiring it is what separates
+///
+/// ```text
+/// rustango 0.44.0                    ← labelled `rustango`
+/// "name": "rustango", "version": "0.44.0"   ← labelled `version`
+/// ```
+///
+/// from a line that merely happens to mention the framework:
+///
+/// ```text
+/// …on every version **Rustango** supports … landed in MySQL 8.0.31.
+/// ```
+///
+/// which is labelled `MySQL` and is none of this test's business.
+///
+/// Three components on purpose: a two-component string is a dependency
+/// caret (`axum = "0.8"`) and says nothing about rustango. The
+/// neighbour checks drop anything inside a longer dotted run, which is
+/// how `0.0.0.0:8080` — the README's bind address — stays out.
+fn versions_in(line: &str) -> Vec<String> {
+    let b: Vec<char> = line.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < b.len() {
+        if !b[i].is_ascii_digit() || (i > 0 && (b[i - 1] == '.' || b[i - 1].is_ascii_digit())) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let mut j = i;
+        while j < b.len() && (b[j].is_ascii_digit() || b[j] == '.') {
+            j += 1;
+        }
+        // A trailing `.` is sentence punctuation, not part of the number.
+        let mut end = j;
+        while end > start && b[end - 1] == '.' {
+            end -= 1;
+        }
+        let s: String = b[start..end].iter().collect();
+        if s.split('.').count() == 3
+            && matches!(
+                label_before(&b, start).as_deref(),
+                Some("rustango" | "version")
+            )
+        {
+            out.push(s);
+        }
+        i = j.max(start + 1);
+    }
+    out
+}
+
+/// The word before position `start`, lowercased, skipping the quotes,
+/// colons, equals and whitespace that sit between a label and its value.
+fn label_before(b: &[char], start: usize) -> Option<String> {
+    let mut k = start;
+    while k > 0 && !b[k - 1].is_alphanumeric() {
+        k -= 1;
+    }
+    let word_end = k;
+    while k > 0 && b[k - 1].is_alphanumeric() {
+        k -= 1;
+    }
+    (k < word_end).then(|| {
+        b[k..word_end]
+            .iter()
+            .collect::<String>()
+            .to_ascii_lowercase()
+    })
+}
+
+/// Versions the page presents as rustango's own, with line numbers.
+fn claimed_versions(text: &str) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    // The `about` transcript prints a bare `rustango` line and then an
+    // indented `version:` field, so the subject is on a previous line.
+    // Scoped to the current fenced block so a stray `rustango` in prose
+    // cannot adopt an unrelated `version:` further down the page.
+    let mut in_fence = false;
+    let mut fence_names_rustango = false;
+
+    for (idx, line) in text.lines().enumerate() {
+        let lineno = idx + 1;
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            fence_names_rustango = false;
+            continue;
+        }
+        if in_fence && line.trim() == "rustango" {
+            fence_names_rustango = true;
+        }
+
+        let is_version_field = line.trim_start().starts_with("version:");
+        let claims = names_rustango(line) || (in_fence && fence_names_rustango && is_version_field);
+        if !claims {
+            continue;
+        }
+        for v in versions_in(line) {
+            out.push((lineno, v));
+        }
+    }
+    out
+}
+
+#[test]
+fn published_docs_show_the_version_that_is_shipping() {
+    let root = repo_root();
+    let published = published_pages(&root);
+    let mut problems = Vec::new();
+    let mut checked = 0usize;
+
+    let mut pages: Vec<String> = Vec::new();
+    for locale_dir in ["docs", "docs/de", "docs/es", "docs/fr"] {
+        for page in &published {
+            pages.push(format!("{locale_dir}/{page}"));
+        }
+    }
+    // Reader-facing prose outside `docs/`. The renamed-smoke README
+    // quotes its own `Cargo.toml`, and had drifted three releases from
+    // the file it was describing.
+    pages.push("README.md".to_owned());
+    pages.push("crates/rustango-renamed-smoke/README.md".to_owned());
+    pages.sort();
+
+    for rel in &pages {
+        let Ok(text) = std::fs::read_to_string(root.join(rel)) else {
+            continue;
+        };
+        checked += 1;
+        for (lineno, found) in claimed_versions(&text) {
+            if found != CURRENT {
+                problems.push(format!("{rel}:{lineno}: shows `{found}`"));
+            }
+        }
+    }
+
+    assert!(checked > 0, "checked no pages at all");
+    assert!(
+        problems.is_empty(),
+        "{} doc(s) present a rustango version that is not the one shipping ({CURRENT}):\n  {}\n\n\
+         These are transcripts of rustango's own output, so a frozen one reads as correct \
+         and is not. Update them to {CURRENT}. Prose *about* an older release is fine and \
+         is not checked — it is only flagged when `rustango` sits next to the number.",
+        problems.len(),
+        problems.join("\n  "),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{claimed_versions, names_rustango, versions_in};
+
+    #[test]
+    fn a_dependency_caret_is_not_a_version() {
+        assert!(versions_in(r#"axum = { version = "0.8" }"#).is_empty());
+    }
+
+    /// Four components, not three. This is the README's bind address,
+    /// and matching `0.0.0` inside it is the false positive that makes
+    /// a naive version regex useless.
+    #[test]
+    fn a_bind_address_is_not_a_version() {
+        assert!(versions_in(r#".serve("0.0.0.0:8080").await"#).is_empty());
+    }
+
+    #[test]
+    fn a_trailing_full_stop_is_not_part_of_the_version() {
+        assert_eq!(versions_in("rustango 1.2.3."), vec!["1.2.3".to_owned()]);
+    }
+
+    /// The label is what makes a number rustango's. `MySQL 8.0.31` on a
+    /// line that also says "Rustango" is about MySQL, and flagging it
+    /// would be the kind of noise that gets a test deleted.
+    #[test]
+    fn an_unlabelled_version_is_ignored_even_beside_the_word_rustango() {
+        let line = "…on every version **Rustango** supports. `INTERSECT` landed in MySQL 8.0.31.";
+        assert!(versions_in(line).is_empty());
+    }
+
+    #[test]
+    fn both_labels_are_recognized() {
+        assert_eq!(versions_in("rustango 0.57.0"), vec!["0.57.0".to_owned()]);
+        assert_eq!(
+            versions_in(r#""version": "0.57.0""#),
+            vec!["0.57.0".to_owned()]
+        );
+    }
+
+    #[test]
+    fn rustango_must_be_a_word_not_a_prefix() {
+        assert!(names_rustango("rustango 0.44.0"));
+        assert!(names_rustango(r#""name": "rustango", "version": "0.44.0""#));
+        // A module path or the scaffolder binary is not the framework
+        // announcing a version.
+        assert!(!names_rustango("use rustango::openapi::OpenApiSpec;"));
+        assert!(!names_rustango("cargo install cargo-rustango"));
+    }
+
+    #[test]
+    fn a_version_transcript_is_claimed() {
+        assert_eq!(
+            claimed_versions("```bash\n$ cargo run -- version\nrustango 0.44.0\n```"),
+            vec![(3, "0.44.0".to_owned())]
+        );
+    }
+
+    /// The `about` transcript names rustango on its own line and puts
+    /// the number on the next one.
+    #[test]
+    fn an_about_transcript_is_claimed_across_lines() {
+        let text = "```bash\n$ cargo run -- about\nrustango\n  version:        0.44.0\n```";
+        assert_eq!(claimed_versions(text), vec![(4, "0.44.0".to_owned())]);
+    }
+
+    /// The reader's own API version, in a fence that happens to import
+    /// rustango. Flagging this is what would get the test deleted.
+    #[test]
+    fn a_readers_own_api_version_is_not_claimed() {
+        let text = "```rust\nuse rustango::openapi::OpenApiSpec;\n\
+                    let spec = OpenApiSpec::new(\"Blog API\", \"1.0.0\");\n```";
+        assert!(claimed_versions(text).is_empty());
+    }
+
+    /// Prose about history is correct and must stay untouched.
+    #[test]
+    fn prose_about_an_older_release_is_not_claimed() {
+        assert!(claimed_versions("Introduced in 0.51.1; see the CHANGELOG.").is_empty());
+        assert!(claimed_versions("> **0.51.0 and 0.51.1 were yanked** — the").is_empty());
+        assert!(claimed_versions("Why the split matters: before v0.24.2, a plain").is_empty());
+        assert!(claimed_versions("## Tenant-pool tuning (v0.27.7+)").is_empty());
+    }
+
+    /// A `version:` field outside a rustango transcript stays out, even
+    /// in a fenced block.
+    #[test]
+    fn an_unrelated_version_field_is_not_claimed() {
+        let text = "```yaml\nservices:\n  version:        3.9.0\n```";
+        assert!(claimed_versions(text).is_empty());
+    }
+}

--- a/docs/de/manage.md
+++ b/docs/de/manage.md
@@ -556,7 +556,7 @@ Gibt die Version des **Rustango**-Frameworks aus.
 
 ```bash
 $ cargo run -- version
-rustango 0.44.0
+rustango 0.57.0
 ```
 
 ### `about`
@@ -568,7 +568,7 @@ Umgebungsvariablen. Legen Sie dies in Support-Tickets, wenn etwas nicht stimmt.
 ```bash
 $ cargo run -- about
 rustango
-  version:        0.44.0
+  version:        0.57.0
   models:         3 registered
   apps:           1 (blog)
   RUSTANGO_ENV:   local

--- a/docs/de/mcp.md
+++ b/docs/de/mcp.md
@@ -171,7 +171,7 @@ jedem Mount:
 // ← 200
 { "jsonrpc": "2.0", "id": 1, "result": {
     "protocolVersion": "2025-06-18",
-    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "serverInfo": { "name": "rustango", "version": "0.57.0" },
     "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
 ```
 

--- a/docs/es/manage.md
+++ b/docs/es/manage.md
@@ -546,7 +546,7 @@ Imprime la versión del framework **Rustango**.
 
 ```bash
 $ cargo run -- version
-rustango 0.44.0
+rustango 0.57.0
 ```
 
 ### `about`
@@ -558,7 +558,7 @@ Incluye esto en los tickets de soporte cuando algo va mal.
 ```bash
 $ cargo run -- about
 rustango
-  version:        0.44.0
+  version:        0.57.0
   models:         3 registered
   apps:           1 (blog)
   RUSTANGO_ENV:   local

--- a/docs/es/mcp.md
+++ b/docs/es/mcp.md
@@ -169,7 +169,7 @@ montaje:
 // ← 200
 { "jsonrpc": "2.0", "id": 1, "result": {
     "protocolVersion": "2025-06-18",
-    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "serverInfo": { "name": "rustango", "version": "0.57.0" },
     "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
 ```
 

--- a/docs/fr/manage.md
+++ b/docs/fr/manage.md
@@ -571,7 +571,7 @@ Affiche la version du framework **Rustango**.
 
 ```bash
 $ cargo run -- version
-rustango 0.44.0
+rustango 0.57.0
 ```
 
 ### `about`
@@ -584,7 +584,7 @@ support en cas de problème.
 ```bash
 $ cargo run -- about
 rustango
-  version:        0.44.0
+  version:        0.57.0
   models:         3 registered
   apps:           1 (blog)
   RUSTANGO_ENV:   local

--- a/docs/fr/mcp.md
+++ b/docs/fr/mcp.md
@@ -170,7 +170,7 @@ n'importe quel montage :
 // ← 200
 { "jsonrpc": "2.0", "id": 1, "result": {
     "protocolVersion": "2025-06-18",
-    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "serverInfo": { "name": "rustango", "version": "0.57.0" },
     "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
 ```
 

--- a/docs/manage.md
+++ b/docs/manage.md
@@ -546,7 +546,7 @@ Prints the **Rustango** framework version.
 
 ```bash
 $ cargo run -- version
-rustango 0.44.0
+rustango 0.57.0
 ```
 
 ### `about`
@@ -558,7 +558,7 @@ variables. Drop this into support tickets when something's wrong.
 ```bash
 $ cargo run -- about
 rustango
-  version:        0.44.0
+  version:        0.57.0
   models:         3 registered
   apps:           1 (blog)
   RUSTANGO_ENV:   local

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -164,7 +164,7 @@ The `initialize` handshake is a plain JSON-RPC POST and works on any mount:
 // ← 200
 { "jsonrpc": "2.0", "id": 1, "result": {
     "protocolVersion": "2025-06-18",
-    "serverInfo": { "name": "rustango", "version": "0.44.0" },
+    "serverInfo": { "name": "rustango", "version": "0.57.0" },
     "capabilities": { "tools": { "listChanged": true }, "prompts": {}, "resources": {} } } }
 ```
 


### PR DESCRIPTION
1 of 3 from the release-docs scan. The other two are stacked on this.

## The bug

`docs/manage.md` told readers that `manage version` prints:

```
rustango 0.44.0
```

…and `docs/mcp.md` showed an MCP handshake answering `"version": "0.44.0"` — **in all four locales, thirteen releases after 0.44.0**. The renamed-smoke README quoted its own `Cargo.toml` as `version = "0.42.0"` while the file said `0.57.0`.

Nothing was wrong with the prose. The transcripts were frozen when they were written, and a release checklist is exactly the wrong instrument for that: it decays silently, and nobody notices, because the page still reads correctly.

## So this is a test, not a checklist item

12 stale mentions fixed, and `published_docs_show_the_version_that_is_shipping` keeps them fixed — across `en` / `de` / `es` / `fr`, the same way `docs_links` works.

### What counts as a version mention

Only versions rustango presents as **its own** — the word immediately before the number is `rustango` or `version`:

```
rustango 0.44.0                           ← labelled `rustango`
"name": "rustango", "version": "0.44.0"   ← labelled `version`
rustango
  version:        0.44.0                  ← `about` transcript, subject on a previous line
```

**The label is what makes this usable.** The docs are full of three-component numbers that have nothing to do with this crate:

| in the docs | what it actually is |
|---|---|
| `OpenApiSpec::new("Blog API", "1.0.0")` | the *reader's* API version |
| `"openapi": "3.1.0"` | the OpenAPI spec version |
| `MySQL 8.0.31` | a database version |
| `0.0.0.0:8080` | a bind address |
| `axum = "0.8"` | a dependency caret |

My first cut flagged **41** of those. A test that noisy gets switched off within a week, so I narrowed the rule until it reported exactly the twelve real ones and nothing else. The hardest case was `…on every version **Rustango** supports … landed in MySQL 8.0.31.` — a line that mentions Rustango *and* an unrelated version, which is why the check is on the preceding word rather than the line.

### Prose about old releases is deliberately untouched

"before v0.24.2", "Introduced in 0.51.1", "**0.51.0 and 0.51.1 were yanked**" are statements about history that do not change when a new version ships. Pinning them to the current version would make them false. None of them put `rustango` next to the number, so they stay out **without needing an allow-list** — which is why there isn't one.

### One doc stopped naming a version instead

`template_extensions.rs` showed `{{ build_version() }}  {# → 0.42.0 #}`. Rather than bend the matcher around a single `//!` comment, the example now says it renders *the running crate's version*. That is both more accurate and unrottable.

## Not covered, on purpose

Verified as self-maintaining rather than assumed:

- **Scaffolded projects** pin `rustango = "0.57"` derived from `env!("CARGO_PKG_VERSION")` at compile time (`mm_version()`), so they follow the release automatically.
- **`cargo install cargo-rustango`** is unpinned in all four locales.

## Tests

12 unit tests pin the matcher's judgement calls — the bind address, the dependency caret, the reader's own API version, the unlabelled MySQL version next to the word Rustango, and each of the four prose-history forms. `docs_links` still green.