### PR TITLE
release: close the 0.57.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to rustango. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project loosely follows [SemVer](https://semver.org/) — with the caveat that nothing pre-1.0 has a stability guarantee.
 
-## [Unreleased]
+## [0.57.0] — 2026-09-12
 
 ### Added
 - **`cargo rustango new` picks a backend and extra features** (#1345).


### PR DESCRIPTION
2 of 3 from the release-docs scan. Stacked on #1366.

Every manifest has said `0.57.0` since the version-bump commit; `CHANGELOG.md` still said `## [Unreleased]`.

```diff
-## [Unreleased]
+## [0.57.0] — 2026-09-12
```

Dated to match the `— YYYY-MM-DD` form every section below it uses (`## [0.56.1] — 2026-09-04`).

One line, separate PR, because it is the one change here that is a *release* act rather than a docs fix — it declares 0.57.0 closed.