### PR TITLE
fix(tenancy): do not print a generated password in a test failure

### DIFF
--- a/crates/rustango/src/tenancy/operator_console/operators.rs
+++ b/crates/rustango/src/tenancy/operator_console/operators.rs
@@ -469,7 +469,14 @@ mod tests {
     #[test]
     fn a_generated_password_needs_no_typing_and_refuses_both() {
         let p = chosen_password(true, "", "").expect("generate");
-        assert!(p.chars().count() >= 20, "should be long: {p}");
+        // Report the length, not the password: when the assertion is
+        // about length that is the useful half, and a generated
+        // credential has no business in a failure message.
+        assert!(
+            p.chars().count() >= 20,
+            "generated password should be at least 20 chars, got {}",
+            p.chars().count()
+        );
         assert!(
             chosen_password(true, "typed", "typed").is_err(),
             "supplying both is ambiguous and should be refused"


### PR DESCRIPTION
Clears one of the two CodeQL alerts blocking #1365.

CodeQL flagged `rust/cleartext-logging` at [operators.rs:472](https://github.com/ujeenet/rustango/blob/release/v0.57.0/crates/rustango/src/tenancy/operator_console/operators.rs#L472):

```rust
let p = chosen_password(true, "", "").expect("generate");
assert!(p.chars().count() >= 20, "should be long: {p}");
```

It is a `#[cfg(test)]` assertion (the module opens at line 465), the value is a throwaway, and the message only prints on failure — so this is not an exploitable finding.

**It is still worth fixing, and the fix is better test code regardless of the alert.** The assertion is about *length*, so the length is the half worth reporting. Printing the password made you count characters by eye to learn what the failure already knew:

```rust
assert!(
    p.chars().count() >= 20,
    "generated password should be at least 20 chars, got {}",
    p.chars().count()
);
```

A framework's own source is also read as an example, and "print the credential you just generated" is not a pattern worth modelling.

## The other alert is not fixed here

The second one — `rust/cleartext-logging` at `manage_operators_sqlite_live.rs:77` — is a genuine false positive and needs a decision rather than a patch:

```rust
.unwrap_or_else(|e| panic!("create {username}: {e}"));
```

`username` is the hardcoded fixture `"ada"` / `"grace"`. CodeQL taints it because it sits in the same argv array as `--password`, whose value is the literal `"correct-horse-42"`. Naming which operator failed is real debugging value, and the alternatives are both worse than the finding: dropping it loses information, and renaming the binding to dodge the heuristic games the linter without changing anything. That one wants dismissal as a false positive, which is a maintainer call.

Note there is no CodeQL config in the repo — this is GitHub's default setup — so `paths-ignore` for test code is not available without switching to advanced setup.