### PR TITLE
fix(docs): publish the docs under the version that is shipping

### DIFF
--- a/crates/rustango/tests/docs_versions.rs
+++ b/crates/rustango/tests/docs_versions.rs
@@ -249,6 +249,43 @@ fn published_docs_show_the_version_that_is_shipping() {
     );
 }
 
+/// `docs/index.toml`'s `version` is the label the site publishes these
+/// pages **under**: they are served at `/<version>/<section>/<slug>`.
+///
+/// It is checked separately from the prose above because it is a
+/// different kind of claim and a different shape — `major.minor`, no
+/// patch, and the whole file is one line of TOML rather than a
+/// transcript. It had drifted to `0.53` while 0.57.0 was shipping, which
+/// does not read as wrong anywhere: the pages are correct, the nav is
+/// correct, and the current documentation is quietly served under a
+/// four-release-old URL.
+#[test]
+fn the_docs_manifest_publishes_under_the_shipping_version() {
+    let root = repo_root();
+    let toml = std::fs::read_to_string(root.join("docs/index.toml")).expect("read docs/index.toml");
+
+    let declared = toml
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("version"))
+        .and_then(|rest| rest.trim().strip_prefix('='))
+        .map(|rest| rest.trim().trim_matches('"').to_owned())
+        .expect("docs/index.toml declares a `version`");
+
+    // The manifest labels a doc *series*, not a point release, so it
+    // carries major.minor: 0.57.1 still publishes under /0.57.
+    let expected: String = CURRENT.rsplit_once('.').map_or_else(
+        || CURRENT.to_owned(),
+        |(major_minor, _patch)| major_minor.to_owned(),
+    );
+
+    assert_eq!(
+        declared, expected,
+        "docs/index.toml publishes under `/{declared}/` but this build ships {CURRENT}. \
+         Set it to \"{expected}\" — otherwise the current documentation is served at a \
+         stale URL and no page looks wrong."
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::{claimed_versions, names_rustango, versions_in};

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -5,7 +5,12 @@
 # becomes one documentation page, rendered in the order listed here. Files
 # not listed below are not published (e.g. internal audits / inventories).
 
-version = "0.53"
+# The version label the site publishes these pages under: they are served
+# at `/<version>/<section>/<slug>`. `RUSTANGO_DOCS_VERSION` overrides it at
+# deploy time, and "dev" is the fallback if neither is set — so a stale
+# value here silently publishes current docs under an old URL.
+# Guarded by `docs_versions`; keep it at the shipping major.minor.
+version = "0.57"
 
 [[section]]
 title = "Getting started"


### PR DESCRIPTION
`docs/index.toml` said `version = "0.53"` while 0.57.0 was shipping.

**That field is not decorative.** rustangodocs serves pages at `/<version>/<section>/<slug>`, and the label resolves as:

```
RUSTANGO_DOCS_VERSION  →  this manifest  →  "dev"
```

So unless the deploy happens to set the env var, four releases of current documentation publish under a `/0.53/` URL.

It is the worst shape a docs bug can take: **nothing looks wrong.** The pages are right, the nav is right, every link resolves — the whole tree is just filed under the wrong number. No reader report would ever surface it.

## Why a second test rather than extending the first

`docs_versions` already checks prose transcripts. This is a different kind of claim and a different shape:

| | transcripts | the manifest |
|---|---|---|
| shape | `0.57.0` (three components) | `0.57` (major.minor, no patch) |
| claim | "this is what the tool printed" | "publish these pages under this label" |
| on a patch release | must change | must **not** change — 0.57.1 still publishes under `/0.57` |

Extending the first test would have meant teaching it two incompatible rules. The new one derives `major.minor` from `CARGO_PKG_VERSION` and compares directly.

## Not fixed here — it needs the other repo

`DOC_TAGS` in `rustangodocs/src/docs/fetch.rs` still has **0.56** as its newest entry, and that is what drives the version switcher and `/` → latest. Correcting this manifest is necessary but not sufficient; the site will not offer 0.57 until that list gains an entry.

That change is prepared as a **draft** at ujeenet/rustango-docs#100, held back because it has two hard prerequisites: `v0.57.0` must be tagged, and `rustango-cms@main` must widen `rustango = { version = "0.56" }` — a pre-1.0 caret pins the minor, so `^0.56` excludes 0.57.0 and `[patch.crates-io]` cannot widen a requirement.