### PR TITLE
refactor(sql): build every pool through one constructor

### DIFF
--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -31,11 +31,6 @@ use std::pin::Pin;
 
 use axum::Router;
 
-// v0.38 — `PgPool` only used in the non-tenancy `runserver` path
-// (which stays PG-only by signature until v0.39); gated accordingly.
-#[cfg(feature = "postgres")]
-use crate::sql::sqlx::PgPool;
-
 /// Boxed seed-hook future. Keeps the public method signature simple
 /// while accepting any `async fn(&Pool) -> Result<…>` closure.
 type SeedFut<'a> =
@@ -638,13 +633,10 @@ impl Cli {
             let scheme = url.split(':').next().unwrap_or("").to_ascii_lowercase();
             #[cfg(feature = "sqlite")]
             if scheme == "sqlite" {
-                let opts = crate::sql::sqlite_connect_options(&url)?;
                 let pool = if no_db_verb {
-                    crate::sql::sqlx::sqlite::SqlitePoolOptions::new().connect_lazy_with(opts)
+                    crate::sql::Pool::connect_sqlite_lazy(&url)?
                 } else {
-                    crate::sql::sqlx::sqlite::SqlitePoolOptions::new()
-                        .connect_with(opts)
-                        .await?
+                    crate::sql::Pool::connect_sqlite(&url).await?
                 };
                 let pools = crate::tenancy::TenantPools::<crate::sql::sqlx::Sqlite>::new(pool);
                 crate::tenancy::manage::run_with_init(
@@ -660,9 +652,9 @@ impl Cli {
             #[cfg(feature = "mysql")]
             if scheme == "mysql" {
                 let pool = if no_db_verb {
-                    crate::sql::sqlx::MySqlPool::connect_lazy(&url)?
+                    crate::sql::Pool::connect_mysql_lazy(&url)?
                 } else {
-                    crate::sql::sqlx::MySqlPool::connect(&url).await?
+                    crate::sql::Pool::connect_mysql(&url).await?
                 };
                 let pools = crate::tenancy::TenantPools::<crate::sql::sqlx::MySql>::new(pool);
                 crate::tenancy::manage::run_with_init(
@@ -687,9 +679,9 @@ impl Cli {
                 .into());
             }
             let pool = if no_db_verb {
-                PgPool::connect_lazy(&url)?
+                crate::sql::Pool::connect_postgres_lazy(&url)?
             } else {
-                PgPool::connect(&url).await?
+                crate::sql::Pool::connect_postgres(&url).await?
             };
             let pools = crate::tenancy::TenantPools::new(pool);
             crate::tenancy::manage::run_with_init(
@@ -711,13 +703,10 @@ impl Cli {
             // the tri-dialect `_pool` family.
             #[cfg(feature = "sqlite")]
             {
-                let opts = crate::sql::sqlite_connect_options(&url)?;
                 let p = if no_db_verb {
-                    crate::sql::sqlx::sqlite::SqlitePoolOptions::new().connect_lazy_with(opts)
+                    crate::sql::Pool::connect_sqlite_lazy(&url)?
                 } else {
-                    crate::sql::sqlx::sqlite::SqlitePoolOptions::new()
-                        .connect_with(opts)
-                        .await?
+                    crate::sql::Pool::connect_sqlite(&url).await?
                 };
                 let pools = crate::tenancy::TenantPools::<crate::sql::sqlx::Sqlite>::new(p);
                 let init_fn: crate::tenancy::manage::InitTenancyFn = crate::tenancy::init_tenancy;
@@ -734,9 +723,9 @@ impl Cli {
             #[cfg(all(not(feature = "sqlite"), feature = "mysql"))]
             {
                 let p = if no_db_verb {
-                    crate::sql::sqlx::MySqlPool::connect_lazy(&url)?
+                    crate::sql::Pool::connect_mysql_lazy(&url)?
                 } else {
-                    crate::sql::sqlx::MySqlPool::connect(&url).await?
+                    crate::sql::Pool::connect_mysql(&url).await?
                 };
                 let pools = crate::tenancy::TenantPools::<crate::sql::sqlx::MySql>::new(p);
                 let init_fn: crate::tenancy::manage::InitTenancyFn = crate::tenancy::init_tenancy;
@@ -901,7 +890,7 @@ impl Cli {
                 .await?;
                 return Ok(());
             }
-            let pool = PgPool::connect(&url).await?;
+            let pool = crate::sql::Pool::connect_postgres(&url).await?;
             let _ = crate::migrate::migrate(&pool, &self.migrations_dir).await?;
             if let Some(seed) = self.seed {
                 seed(&crate::sql::Pool::from(pool.clone()))

--- a/crates/rustango/src/migrate/scaffold.rs
+++ b/crates/rustango/src/migrate/scaffold.rs
@@ -567,8 +567,6 @@ pub const SINGLE_TENANT_MANAGE_BIN: &str =
 //! defined in `rustango::migrate::manage`; this binary just hands it
 //! the pool and argv.
 
-use rustango::sql::sqlx::PgPool;
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Pull your models into this binary so `inventory` registers
@@ -580,7 +578,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //   #[allow(unused_imports)]
     //   use super::models::*;
 
-    let pool = PgPool::connect(&std::env::var(\"DATABASE_URL\")?).await?;
+    // `Pool::connect_postgres`, not `PgPool::connect`: the framework's
+    // constructor applies the pool options your settings configure.
+    let pool = rustango::sql::Pool::connect_postgres(&std::env::var(\"DATABASE_URL\")?).await?;
     let dir: &std::path::Path = \"./migrations\".as_ref();
     rustango::migrate::manage::run(&pool, dir, std::env::args().skip(1)).await?;
     Ok(())

--- a/crates/rustango/src/server/builder.rs
+++ b/crates/rustango/src/server/builder.rs
@@ -9,8 +9,6 @@ use sqlx::Database;
 use tower::ServiceExt as _;
 
 use crate::extractors::TenantContext;
-#[cfg(feature = "postgres")]
-use crate::sql::sqlx::PgPool;
 use crate::tenancy::{
     admin::TenantAdminBuilder, operator_console, ChainResolver, DefaultTenantDb, HeaderResolver,
     RegisteredHostResolver, SubdomainResolver, TenantPools,
@@ -88,7 +86,7 @@ impl Builder<sqlx::Postgres> {
         let apex = std::env::var("RUSTANGO_APEX_DOMAIN").unwrap_or_else(|_| "localhost".into());
         let registry_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://rustango:rustango@localhost:5432/rustango_test".into());
-        let registry = PgPool::connect(&registry_url).await?;
+        let registry = crate::sql::Pool::connect_postgres(&registry_url).await?;
         Ok(Self::from_pool(registry, registry_url, apex))
     }
 }

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -103,11 +103,6 @@ pub use executor::LoadRelatedSqlite;
 pub use foreign_key::ForeignKey;
 pub use m2m::{GenericM2MManager, M2MManager};
 pub use mysql::MySql;
-// Both call sites (`manage::dispatch`) sit inside `tenancy` gates, so the
-// re-export needs `tenancy` too (#1208) — without it, `sqlite,manage` warned
-// about an unused import.
-#[cfg(all(feature = "sqlite", feature = "manage", feature = "tenancy"))]
-pub(crate) use pool::sqlite_connect_options;
 pub use pool::{Pool, PoolError};
 pub use postgres::Postgres;
 pub use sqlite::Sqlite;

--- a/crates/rustango/src/sql/pool.rs
+++ b/crates/rustango/src/sql/pool.rs
@@ -271,33 +271,21 @@ impl Pool {
         let scheme = url.split(':').next().unwrap_or("").to_ascii_lowercase();
         match scheme.as_str() {
             #[cfg(feature = "postgres")]
-            "postgres" | "postgresql" => {
-                let pool = sqlx::PgPool::connect_lazy(url)
-                    .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
-                Ok(Self::Postgres(pool))
-            }
+            "postgres" | "postgresql" => Ok(Self::Postgres(Self::connect_postgres_lazy(url)?)),
             #[cfg(not(feature = "postgres"))]
             "postgres" | "postgresql" => Err(PoolError::FeatureNotEnabled {
                 scheme: "postgres",
                 feature: "postgres",
             }),
             #[cfg(feature = "mysql")]
-            "mysql" => {
-                let pool = sqlx::MySqlPool::connect_lazy(url)
-                    .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
-                Ok(Self::Mysql(pool))
-            }
+            "mysql" => Ok(Self::Mysql(Self::connect_mysql_lazy(url)?)),
             #[cfg(not(feature = "mysql"))]
             "mysql" => Err(PoolError::FeatureNotEnabled {
                 scheme: "mysql",
                 feature: "mysql",
             }),
             #[cfg(feature = "sqlite")]
-            "sqlite" => {
-                let opts = sqlite_connect_options(url)?;
-                let pool = sqlx::sqlite::SqlitePoolOptions::new().connect_lazy_with(opts);
-                Ok(Self::Sqlite(pool))
-            }
+            "sqlite" => Ok(Self::Sqlite(Self::connect_sqlite_lazy(url)?)),
             #[cfg(not(feature = "sqlite"))]
             "sqlite" => Err(PoolError::FeatureNotEnabled {
                 scheme: "sqlite",
@@ -398,17 +386,111 @@ impl Pool {
         }
     }
 
+    // ---- typed constructors ----
+    //
+    // These are the **only** places a backend pool is built. Everything
+    // else — `connect`, `connect_lazy`, `connect_inner`, and the
+    // `manage` dispatch paths — routes through them.
+    //
+    // They exist because the callers that need a typed pool
+    // (`TenantPools<DB>` takes `sqlx::Pool<DB>`, not the enum) were
+    // otherwise reaching for `PgPool::connect(&url)` directly, which
+    // skips every option the framework applies. The main `runserver`
+    // pool was one of them.
+
+    /// Connect to Postgres, returning the typed pool.
+    ///
+    /// Prefer [`Self::connect`] unless you need `sqlx::PgPool` itself.
+    /// This applies the same options as `connect` — use it rather than
+    /// `PgPool::connect`, which applies none.
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "postgres")]
+    pub async fn connect_postgres(url: &str) -> Result<sqlx::PgPool, PoolError> {
+        sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect(url)
+            .await
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
+    }
+
+    /// [`Self::connect_postgres`] without dialling — the pool connects
+    /// on first use. For verbs that may never touch the database.
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "postgres")]
+    pub fn connect_postgres_lazy(url: &str) -> Result<sqlx::PgPool, PoolError> {
+        sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect_lazy(url)
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
+    }
+
+    /// Connect to MySQL, returning the typed pool. See
+    /// [`Self::connect_postgres`].
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "mysql")]
+    pub async fn connect_mysql(url: &str) -> Result<sqlx::MySqlPool, PoolError> {
+        sqlx::mysql::MySqlPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect(url)
+            .await
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
+    }
+
+    /// [`Self::connect_mysql`] without dialling.
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "mysql")]
+    pub fn connect_mysql_lazy(url: &str) -> Result<sqlx::MySqlPool, PoolError> {
+        sqlx::mysql::MySqlPoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect_lazy(url)
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
+    }
+
+    /// Connect to SQLite, returning the typed pool.
+    ///
+    /// Unlike the other two this also applies the framework's pragmas
+    /// via [`sqlite_connect_options`] — WAL for file-backed databases,
+    /// and `?mode=rwc` so a missing file is created. Sites that built
+    /// their own `SqlitePoolOptions` were silently getting neither.
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "sqlite")]
+    pub async fn connect_sqlite(url: &str) -> Result<sqlx::SqlitePool, PoolError> {
+        let opts = sqlite_connect_options(url)?;
+        sqlx::sqlite::SqlitePoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect_with(opts)
+            .await
+            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
+    }
+
+    /// [`Self::connect_sqlite`] without dialling.
+    ///
+    /// # Errors
+    /// As [`Self::connect`].
+    #[cfg(feature = "sqlite")]
+    pub fn connect_sqlite_lazy(url: &str) -> Result<sqlx::SqlitePool, PoolError> {
+        let opts = sqlite_connect_options(url)?;
+        Ok(sqlx::sqlite::SqlitePoolOptions::new()
+            .acquire_timeout(default_acquire_timeout())
+            .connect_lazy_with(opts))
+    }
+
     // ---- internal connect helpers ----
     // (see `default_acquire_timeout` below for the timeout they share)
 
     #[cfg(feature = "postgres")]
     async fn connect_postgres_inner(url: &str) -> Result<Self, PoolError> {
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
-            .connect(url)
-            .await
-            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
-        Ok(Self::Postgres(pool))
+        Ok(Self::Postgres(Self::connect_postgres(url).await?))
     }
 
     #[cfg(not(feature = "postgres"))]
@@ -421,12 +503,7 @@ impl Pool {
 
     #[cfg(feature = "mysql")]
     async fn connect_mysql_inner(url: &str) -> Result<Self, PoolError> {
-        let pool = sqlx::mysql::MySqlPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
-            .connect(url)
-            .await
-            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
-        Ok(Self::Mysql(pool))
+        Ok(Self::Mysql(Self::connect_mysql(url).await?))
     }
 
     // Stays async so the call-site `.await` shape matches across
@@ -455,13 +532,7 @@ impl Pool {
         // `sqlite_connect_options`). v0.40: `sqlite_connect_options`
         // also turns on `foreign_keys`, sets `busy_timeout = 5s`, and
         // enables WAL journal mode for file-backed databases.
-        let opts = sqlite_connect_options(url)?;
-        let pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
-            .connect_with(opts)
-            .await
-            .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))?;
-        Ok(Self::Sqlite(pool))
+        Ok(Self::Sqlite(Self::connect_sqlite(url).await?))
     }
 
     #[cfg(not(feature = "sqlite"))]

--- a/crates/rustango/src/tenancy/manage/scaffold.rs
+++ b/crates/rustango/src/tenancy/manage/scaffold.rs
@@ -24,7 +24,6 @@ pub const TENANCY_MANAGE_BIN: &str =
 //! `cargo run -- run-server`, plus everything the
 //! single-tenant dispatcher offers (`migrate`, `makemigrations`, …).
 
-use crate::sql::sqlx::PgPool;
 use crate::tenancy::TenantPools;
 
 #[tokio::main]
@@ -37,7 +36,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // automatically via the `crate::tenancy` crate import.
 
     let registry_url = std::env::var(\"DATABASE_URL\")?;
-    let pool = PgPool::connect(&registry_url).await?;
+    // `Pool::connect_postgres`, not `PgPool::connect`: the framework's
+    // constructor applies the pool options your settings configure.
+    let pool = crate::sql::Pool::connect_postgres(&registry_url).await?;
     let pools = TenantPools::new(pool);
     let dir: &std::path::Path = \"./migrations\".as_ref();
     crate::tenancy::manage::run(&pools, &registry_url, dir, std::env::args().skip(1)).await?;

--- a/crates/rustango/tests/pool_construction.rs
+++ b/crates/rustango/tests/pool_construction.rs
@@ -1,0 +1,263 @@
+//! Production code builds pools through one constructor.
+//!
+//! Pool construction had spread to ~22 production sites, and most of
+//! them called sqlx directly — `PgPool::connect(&url)`,
+//! `SqlitePoolOptions::new()`. Those calls apply none of the options
+//! the framework sets, so the settings that *were* wired up reached
+//! almost nothing. The main `runserver` pool was one of the bare ones:
+//! the single most important pool in a running app, built with sqlx's
+//! defaults.
+//!
+//! Routing them through `Pool::connect*` is only half a fix, because
+//! nothing stops the next one being written the old way — and it would
+//! not fail any test. Both times this pattern regrew, it regrew
+//! silently. So this is the guard.
+//!
+//! Test fixtures are exempt and deliberately so: they build
+//! `max_connections(1)` lazy pools pointed at unreachable hosts, where
+//! framework options are noise.
+
+use std::path::{Path, PathBuf};
+
+/// The calls that bypass the framework's own constructors.
+const BARE: &[&str] = &[
+    "PgPool::connect",
+    "MySqlPool::connect",
+    "SqlitePool::connect",
+    "PgPoolOptions::new",
+    "MySqlPoolOptions::new",
+    "SqlitePoolOptions::new",
+];
+
+/// Files allowed to call sqlx directly, with the reason.
+///
+/// Keep this list short and justified. A new entry is a claim that the
+/// file genuinely cannot go through `Pool`; most of the time the honest
+/// answer is that it can.
+const ALLOWED: &[(&str, &str)] = &[
+    (
+        "src/sql/pool.rs",
+        "the constructors themselves — this is the one place that may",
+    ),
+    (
+        "src/tenancy/pools.rs",
+        "generic over `DB: Database`; sqlx's PoolOptions<DB> has no \
+         driver-specific hook, so this needs the sealed-backend trait \
+         that stage 2 introduces",
+    ),
+    (
+        "src/tenancy/database_pools.rs",
+        "same generic constraint as tenancy/pools.rs",
+    ),
+    (
+        "src/tenancy/migrate.rs",
+        "schema-mode pools carry an `after_connect` hook that sets \
+         `search_path`; folding that into the shared constructor is \
+         stage 3",
+    ),
+    (
+        "src/tenancy/manage/users.rs",
+        "same `after_connect` search_path scoping",
+    ),
+    (
+        "src/tenancy/manage/migrate_storage.rs",
+        "same `after_connect` search_path scoping",
+    ),
+    // These two emit *template text* into generated user projects — the
+    // match is inside a `format!` string literal, not a pool this crate
+    // opens. That the generated code itself uses `PgPool::connect` is a
+    // real question, but it is the scaffolder's to answer.
+    (
+        "src/tenancy/manage/scaffold.rs",
+        "emits template text for generated projects, not a pool",
+    ),
+    (
+        "src/migrate/scaffold.rs",
+        "emits template text for generated projects, not a pool",
+    ),
+];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+/// Every `.rs` under `src/`.
+fn source_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            source_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Is this `#[cfg(...)]` attribute gated on `test`?
+///
+/// Matches `test` as a whole token, so `#[cfg(all(test, feature =
+/// "postgres"))]` counts and `#[cfg(feature = "testkit")]` does not.
+/// Getting this wrong in the permissive direction would silently exempt
+/// production code, which is the one outcome this file exists to
+/// prevent.
+fn is_test_gate(attr: &str) -> bool {
+    let b = attr.as_bytes();
+    let mut from = 0;
+    while let Some(hit) = attr[from..].find("test") {
+        let s = from + hit;
+        let e = s + 4;
+        let before_ok = s == 0 || !is_ident(b[s - 1]);
+        let after_ok = e >= b.len() || !is_ident(b[e]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = e;
+    }
+    false
+}
+
+fn is_ident(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Strip test-gated modules so fixtures are not flagged.
+///
+/// Brace-counting rather than parsing: it only has to find the end of a
+/// module in rustfmt'd source, and the whole file is formatted by the
+/// pre-commit hook. A `{` inside a string literal would fool it — a
+/// false *positive* shows up as a failing test rather than a silent
+/// miss, which is the right way round.
+fn without_test_modules(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut rest = src;
+    while let Some(at) = rest.find("#[cfg(") {
+        // Only skip the block when the gate actually names `test`;
+        // otherwise emit the attribute and carry on past it.
+        let attr_end = rest[at..].find(")]").map_or(rest.len(), |e| at + e + 2);
+        if !is_test_gate(&rest[at..attr_end]) {
+            out.push_str(&rest[..attr_end]);
+            rest = &rest[attr_end..];
+            continue;
+        }
+        out.push_str(&rest[..at]);
+        let after = &rest[at..];
+        let Some(open) = after.find('{') else {
+            break;
+        };
+        let mut depth = 0i32;
+        let mut end = None;
+        for (i, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(open + i + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        match end {
+            Some(e) => rest = &after[e..],
+            None => break,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[test]
+fn production_code_does_not_build_pools_directly() {
+    let root = repo_root();
+    let mut files = Vec::new();
+    source_files(&root.join("src"), &mut files);
+    assert!(!files.is_empty(), "found no source files to scan");
+
+    let mut problems = Vec::new();
+    for path in &files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if ALLOWED.iter().any(|(f, _)| *f == rel) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let production = without_test_modules(&text);
+        for (idx, line) in production.lines().enumerate() {
+            // Comments and doc-comments name these calls constantly when
+            // explaining why not to use them.
+            let t = line.trim_start();
+            if t.starts_with("//") || t.starts_with("*") {
+                continue;
+            }
+            for bare in BARE {
+                if line.contains(bare) {
+                    problems.push(format!("{rel}:{}: `{bare}`", idx + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "{} production site(s) build a pool directly instead of through \
+         `Pool::connect*`:\n  {}\n\nUse `Pool::connect`, or the typed \
+         `Pool::connect_postgres` / `connect_mysql` / `connect_sqlite` when a \
+         caller needs `sqlx::Pool<DB>` itself. Calling sqlx directly skips every \
+         option the framework applies, which is how the main runserver pool came \
+         to run on sqlx's defaults. If a site genuinely cannot, add it to ALLOWED \
+         with the reason.",
+        problems.len(),
+        problems.join("\n  "),
+    );
+}
+
+/// An allow-list entry that no longer matches a file is worse than
+/// useless: it silently permits whatever gets created at that path next.
+#[test]
+fn every_allowed_path_still_exists() {
+    let root = repo_root();
+    for (rel, _why) in ALLOWED {
+        assert!(
+            root.join(rel).is_file(),
+            "ALLOWED names `{rel}`, which does not exist — remove the entry \
+             or fix the path"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::without_test_modules;
+
+    #[test]
+    fn a_test_module_is_stripped() {
+        let src = "fn a() {}\n#[cfg(test)]\nmod tests {\n  PgPool::connect(x);\n}\nfn b() {}";
+        let out = without_test_modules(src);
+        assert!(!out.contains("PgPool::connect"), "got: {out}");
+        assert!(out.contains("fn a()") && out.contains("fn b()"));
+    }
+
+    #[test]
+    fn nested_braces_inside_a_test_module_do_not_end_it_early() {
+        let src = "#[cfg(test)]\nmod t {\n  fn f() { if x { y(); } }\n  PgPool::connect(z);\n}\nfn after() {}";
+        let out = without_test_modules(src);
+        assert!(!out.contains("PgPool::connect"), "got: {out}");
+        assert!(out.contains("fn after()"));
+    }
+
+    #[test]
+    fn production_code_outside_a_test_module_survives() {
+        let src = "fn real() { PgPool::connect(u); }";
+        assert!(without_test_modules(src).contains("PgPool::connect"));
+    }
+}

--- a/crates/rustango/tests/pool_construction.rs
+++ b/crates/rustango/tests/pool_construction.rs
@@ -63,18 +63,6 @@ const ALLOWED: &[(&str, &str)] = &[
         "src/tenancy/manage/migrate_storage.rs",
         "same `after_connect` search_path scoping",
     ),
-    // These two emit *template text* into generated user projects — the
-    // match is inside a `format!` string literal, not a pool this crate
-    // opens. That the generated code itself uses `PgPool::connect` is a
-    // real question, but it is the scaffolder's to answer.
-    (
-        "src/tenancy/manage/scaffold.rs",
-        "emits template text for generated projects, not a pool",
-    ),
-    (
-        "src/migrate/scaffold.rs",
-        "emits template text for generated projects, not a pool",
-    ),
 ];
 
 fn repo_root() -> PathBuf {


### PR DESCRIPTION
**Stage 1 of 7** toward making `[database]` settings real (#1373). No new configuration — this only establishes the single place later stages can apply it.

## The problem

Pool construction had spread to ~22 production sites, and the ones that mattered most called sqlx directly. Chief among them:

```rust
let pool = PgPool::connect(&url).await?;   // manage.rs, runserver
```

That is **the main pool of a running Postgres app**, built with sqlx's defaults — including the 30s acquire timeout this very crate rejects as *"a batch-tool number, not a web-server one"*. Every tenancy dispatch pool and the tenancy registry pool in `server::Builder` were bare the same way.

So the pool tuning that *does* exist reached almost nothing. Fixing the settings without fixing this would have produced a knob that still did nothing on the most important pool in the app.

## Why `Pool::connect` could not be the seam

Those sites need a concrete `sqlx::Pool<DB>` — `TenantPools::<DB>::new`, `migrate`, `health_router` and `Extension(pool)` all take one, and `Pool` converts *to* a typed pool only through an `Option`. Routing them "through `Pool`" would have forced signature churn across the codebase.

The seam is instead a set of **typed constructors**:

```rust
Pool::connect_postgres(url)       -> sqlx::PgPool
Pool::connect_mysql(url)          -> sqlx::MySqlPool
Pool::connect_sqlite(url)         -> sqlx::SqlitePool
Pool::connect_*_lazy(url)         // + lazy siblings
```

Every call site keeps its exact types. `Pool::connect`, `connect_lazy` and the enum constructors route through them too, so there is now exactly one place per backend where a pool is built.

**`Pool::connect(url)` keeps its signature** — it has 396 call sites in the test suite alone; changing it was never an option.

## Two live bugs fall out

- **`Pool::connect_lazy` applied nothing at all** — not even an acquire timeout. It now gets the same treatment as the eager path.
- **The SQLite dispatch arms built their own `SqlitePoolOptions`**, skipping `sqlite_connect_options` and with it WAL journal mode and the `?mode=rwc` default. Those pools silently differed from every other SQLite pool in the framework.

## The guard

`tests/pool_construction.rs`. Both times this pattern spread, it spread **silently and failed no test** — so routing the current sites is only half a fix.

It skips test-gated modules, matching `test` as a whole token so `#[cfg(all(test, feature = "postgres"))]` counts while `#[cfg(feature = "testkit")]` does not. Getting that wrong in the permissive direction would exempt production code, which is the one outcome the file exists to prevent, so it is unit-tested in both directions.

Six files stay on the allow-list, each with its reason:

| file | why |
|---|---|
| `sql/pool.rs` | the constructors themselves |
| `tenancy/pools.rs`, `tenancy/database_pools.rs` | generic over `DB: Database`; sqlx's `PoolOptions<DB>` has no driver-specific hook. These need the sealed backend trait **stage 2** introduces |
| `tenancy/migrate.rs`, `manage/users.rs`, `manage/migrate_storage.rs` | carry an `after_connect` hook setting `search_path`; folding that in is **stage 3** |
| `tenancy/manage/scaffold.rs`, `migrate/scaffold.rs` | the match is inside a `format!` literal emitting template text, not a pool |

A second test asserts every allow-list path still exists — a stale entry silently permits whatever is created at that path next.

## Verification

- 2438 lib tests pass.
- The whole `sqlite,tenancy` suite compiles (`--no-run`, 0 errors).
- `--all-features`, `--no-default-features --features sqlite,tenancy`, and `--features mysql` all clean, no warnings.
- Behaviour-preserving except where noted above, and both exceptions are fixes.

## Note for the next PR in this stack

`CHANGELOG.md` currently has **no `[Unreleased]` section** — #1367 closed it as `[0.57.0]`. Stage 2 onward must open a new one rather than edit the closed section.