### PR TITLE
feat(sql): apply the database pool settings that were being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to rustango. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project loosely follows [SemVer](https://semver.org/) — with the caveat that nothing pre-1.0 has a stability guarantee.
 
+## [Unreleased]
+
+### Fixed
+- **`[database]` pool settings are applied.** `pool_max_size` and `pool_min_size` were parsed, type-checked and unit-tested — and reached no pool at all. Setting them did nothing, which is worse than not offering them: a pool sized for production silently ran on sqlx's default of 10, with no error and nothing in the logs to explain it (#1373).
+- **Every pool is built through one constructor.** Construction had spread to ~22 production sites, most calling sqlx directly. The main Postgres `runserver` pool was among them, so it ran on sqlx's 30s acquire timeout — the value this crate elsewhere rejects as "a batch-tool number, not a web-server one". `tests/pool_construction.rs` keeps it from regrowing.
+- **`Pool::connect_lazy` applied no options at all**, not even an acquire timeout.
+- **SQLite pools built by the `manage` dispatch skipped the framework's pragmas**, so they got neither WAL journal mode nor the `?mode=rwc` default that every other SQLite pool gets.
+- **Generated `manage` binaries** (`manage startapp --with-manage-bin`) emitted `PgPool::connect`, so a scaffolded project's own binary bypassed the pool options its settings configured.
+
+### Added
+- `[database]` gains `pool_acquire_timeout_secs`, `pool_idle_timeout_secs` and `pool_max_lifetime_secs`, plus `RUSTANGO_DB_MAX_CONNECTIONS`, `RUSTANGO_DB_MIN_CONNECTIONS`, `RUSTANGO_DB_IDLE_TIMEOUT_SECS` and `RUSTANGO_DB_MAX_LIFETIME_SECS` as environment overrides. Environment wins over TOML, so a deploy can retune a pool without a config push.
+- `Pool::connect_postgres` / `connect_mysql` / `connect_sqlite` (and `_lazy` siblings) for callers that need a typed `sqlx::Pool<DB>` — `TenantPools::<DB>::new`, `migrate` and `health_router` all take one. Use these rather than sqlx's constructors, which apply none of the framework's options.
+- `sql::PoolTuning` and `sql::configure_pools`, called from `Cli::with_settings`.
+
 ## [0.57.0] — 2026-09-12
 
 ### Added

--- a/crates/rustango/src/config/sections.rs
+++ b/crates/rustango/src/config/sections.rs
@@ -277,11 +277,50 @@ pub struct DatabaseSettings {
     /// an override.
     pub backend: Option<String>,
     /// Maximum number of pooled connections. `None` means use sqlx's
-    /// default.
+    /// default of 10 — usually too small for a web server under load,
+    /// and far more than a SQLite file can use.
     pub pool_max_size: Option<u32>,
     /// Minimum number of pooled connections kept warm. `None` =
-    /// driver default.
+    /// driver default of 0, so the first request after a quiet period
+    /// pays the connect round-trip.
     pub pool_min_size: Option<u32>,
+    /// Seconds a caller waits for a pooled connection before erroring —
+    /// covers both dialling a new connection and queueing for a free
+    /// one. `None` uses rustango's 5s default, deliberately tighter
+    /// than sqlx's 30s: on a request path, 30s means one unreachable
+    /// database pins a worker for half a minute per request and
+    /// saturates the server.
+    pub pool_acquire_timeout_secs: Option<u64>,
+    /// Seconds a connection may sit idle before it is closed. Defends
+    /// against a load balancer or `idle_in_transaction_session_timeout`
+    /// cutting it from the other end. `None` leaves sqlx's default.
+    pub pool_idle_timeout_secs: Option<u64>,
+    /// Seconds a connection may live regardless of use. The knob that
+    /// matters behind a failover or a credential rotation: without it a
+    /// pool can keep connections to a server that is no longer current,
+    /// or with credentials that have since been revoked. `None` leaves
+    /// sqlx's default.
+    pub pool_max_lifetime_secs: Option<u64>,
+}
+
+impl DatabaseSettings {
+    /// This section as pool tuning, for [`crate::sql::configure_pools`].
+    ///
+    /// Lives next to the fields it reads on purpose: adding a knob to
+    /// the section and forgetting to forward it here is exactly how
+    /// `pool_max_size` came to be parsed, tested, and applied to
+    /// nothing at all (#1373).
+    #[must_use]
+    pub fn pool_tuning(&self) -> crate::sql::PoolTuning {
+        use std::time::Duration;
+        crate::sql::PoolTuning {
+            max_connections: self.pool_max_size,
+            min_connections: self.pool_min_size,
+            acquire_timeout: self.pool_acquire_timeout_secs.map(Duration::from_secs),
+            idle_timeout: self.pool_idle_timeout_secs.map(Duration::from_secs),
+            max_lifetime: self.pool_max_lifetime_secs.map(Duration::from_secs),
+        }
+    }
 }
 
 impl DatabaseSettings {

--- a/crates/rustango/src/manage.rs
+++ b/crates/rustango/src/manage.rs
@@ -413,6 +413,18 @@ impl Cli {
             }
         }
 
+        // Pool sizing + timeouts, applied by every pool this process
+        // opens. Process-wide and first-call-wins, like the cookie
+        // policy below, because the pools it tunes are built later by
+        // verbs that never see `Settings`. Env wins over these values —
+        // the same precedence `bind` uses just above.
+        //
+        // Call this as early as possible: a pool opened before it lands
+        // runs on environment defaults, and `configure_pools` warns when
+        // that has happened rather than leaving it to be discovered
+        // under load (#1373).
+        let _ = crate::sql::configure_pools(s.database.pool_tuning());
+
         // Settings.routes → RouteConfig. Build the right preset
         // (friendly default / legacy v0.28) and apply per-field
         // overrides on top, so the TOML can mix-and-match.

--- a/crates/rustango/src/sql/mod.rs
+++ b/crates/rustango/src/sql/mod.rs
@@ -103,7 +103,7 @@ pub use executor::LoadRelatedSqlite;
 pub use foreign_key::ForeignKey;
 pub use m2m::{GenericM2MManager, M2MManager};
 pub use mysql::MySql;
-pub use pool::{Pool, PoolError};
+pub use pool::{configure_pools, Pool, PoolError, PoolTuning};
 pub use postgres::Postgres;
 pub use sqlite::Sqlite;
 

--- a/crates/rustango/src/sql/pool.rs
+++ b/crates/rustango/src/sql/pool.rs
@@ -989,13 +989,28 @@ mod tuning_tests {
         std::env::set_var(MIN_CONNECTIONS_ENV, "3");
         std::env::set_var(ACQUIRE_TIMEOUT_ENV, "11");
 
+        // Compare the pool against the tuning actually in force, not
+        // against the env vars just set. Another test in this binary
+        // may have sealed the tuning already — every `with_settings`
+        // test does — and asserting on `37` would then pass or fail by
+        // test order. That `merge_env_over` reads these vars is proved
+        // by the pure tests above; what is proved *here* is that
+        // whatever tuning says reaches the pool.
+        let expect = tuning();
         let pool = Pool::connect_sqlite_lazy("sqlite::memory:").expect("build a lazy pool");
         let opts = pool.options();
-        assert_eq!(opts.get_max_connections(), 37, "max_connections");
-        assert_eq!(opts.get_min_connections(), 3, "min_connections");
+
+        if let Some(n) = expect.max_connections {
+            assert_eq!(opts.get_max_connections(), n, "max_connections");
+        }
+        if let Some(n) = expect.min_connections {
+            assert_eq!(opts.get_min_connections(), n, "min_connections");
+        }
         assert_eq!(
             opts.get_acquire_timeout(),
-            Duration::from_secs(11),
+            expect
+                .acquire_timeout
+                .unwrap_or_else(|| Duration::from_secs(ACQUIRE_TIMEOUT_DEFAULT_SECS)),
             "acquire_timeout"
         );
         clear();
@@ -1008,15 +1023,22 @@ mod tuning_tests {
     #[test]
     fn reading_the_tuning_leaves_it_configurable() {
         let _g = env_lock();
-        clear();
-        let before = tuning();
-        assert_eq!(before.max_connections, None);
-        // The cell must still be empty, i.e. still settable. Asserting
-        // on `TUNING.get()` rather than calling `configure_pools`,
-        // which would seal it for every other test in this binary.
-        assert!(
-            TUNING.get().is_none(),
-            "a read sealed the tuning cell — settings applied later would be ignored"
+        // Assert the *property* — a read does not change whether the
+        // cell is set — rather than its absolute state. Another test in
+        // this binary may legitimately have called `configure_pools`
+        // already (any `with_settings` test does), and under some
+        // feature sets it runs first. An assertion on
+        // `TUNING.get().is_none()` passes or fails by test order, which
+        // is a flaky test dressed up as a real one.
+        let set_before = TUNING.get().is_some();
+        let _ = tuning();
+        let _ = tuning();
+        assert_eq!(
+            TUNING.get().is_some(),
+            set_before,
+            "reading the tuning changed whether it was set — with `get_or_init` a read \
+             sealed the cell, so any pool built before `with_settings` silently froze \
+             the whole process on environment defaults"
         );
     }
 }

--- a/crates/rustango/src/sql/pool.rs
+++ b/crates/rustango/src/sql/pool.rs
@@ -114,6 +114,39 @@ pub enum Pool {
     Sqlite(sqlx::SqlitePool),
 }
 
+/// Apply [`tuning`] to a `PoolOptions` of any backend.
+///
+/// A macro rather than a generic function because sqlx's three
+/// `PoolOptions` types share no trait — the builder methods have the
+/// same names on each, but nothing relates them. Defined here because
+/// `macro_rules!` must precede its call sites.
+#[allow(unused_macros)]
+macro_rules! tuned {
+    ($opts:expr) => {{
+        let t = tuning();
+        let mut o = $opts.acquire_timeout(
+            t.acquire_timeout
+                .unwrap_or_else(|| Duration::from_secs(ACQUIRE_TIMEOUT_DEFAULT_SECS)),
+        );
+        if let Some(n) = t.max_connections {
+            o = o.max_connections(n);
+        }
+        if let Some(n) = t.min_connections {
+            o = o.min_connections(n);
+        }
+        // These two already take `Option`, where `None` means "no
+        // bound" — the same thing `None` means in `PoolTuning`, so an
+        // unset knob is left entirely alone rather than set to nothing.
+        if t.idle_timeout.is_some() {
+            o = o.idle_timeout(t.idle_timeout);
+        }
+        if t.max_lifetime.is_some() {
+            o = o.max_lifetime(t.max_lifetime);
+        }
+        o
+    }};
+}
+
 impl Pool {
     /// Connect to a database from a URL. Recognized schemes:
     ///
@@ -192,6 +225,11 @@ impl Pool {
     /// classified failure and a scheme/feature failure distinct, so
     /// each public wrapper can render whichever shape it promises.
     async fn connect_inner(url: &str, timeout: Duration) -> Result<Self, ConnectFail> {
+        // Deliberately *not* tuned beyond the caller's timeout. The only
+        // users of this path are one-shot probes — tenant preflight opens
+        // a pool, asks whether the database answers, and closes it. Giving
+        // a probe the application's sizing would have it eagerly open
+        // `min_connections` connections it is about to throw away.
         let scheme = url.split(':').next().unwrap_or("").to_ascii_lowercase();
         match scheme.as_str() {
             #[cfg(feature = "postgres")]
@@ -388,6 +426,10 @@ impl Pool {
 
     // ---- typed constructors ----
     //
+    // Stage 1 made these the single place a pool is built; the `tuned!`
+    // macro below is what that bought — one edit reaches every pool in
+    // the process, including the ones that used to call sqlx directly.
+    //
     // These are the **only** places a backend pool is built. Everything
     // else — `connect`, `connect_lazy`, `connect_inner`, and the
     // `manage` dispatch paths — routes through them.
@@ -408,8 +450,7 @@ impl Pool {
     /// As [`Self::connect`].
     #[cfg(feature = "postgres")]
     pub async fn connect_postgres(url: &str) -> Result<sqlx::PgPool, PoolError> {
-        sqlx::postgres::PgPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
+        tuned!(sqlx::postgres::PgPoolOptions::new())
             .connect(url)
             .await
             .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
@@ -422,8 +463,7 @@ impl Pool {
     /// As [`Self::connect`].
     #[cfg(feature = "postgres")]
     pub fn connect_postgres_lazy(url: &str) -> Result<sqlx::PgPool, PoolError> {
-        sqlx::postgres::PgPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
+        tuned!(sqlx::postgres::PgPoolOptions::new())
             .connect_lazy(url)
             .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
     }
@@ -435,8 +475,7 @@ impl Pool {
     /// As [`Self::connect`].
     #[cfg(feature = "mysql")]
     pub async fn connect_mysql(url: &str) -> Result<sqlx::MySqlPool, PoolError> {
-        sqlx::mysql::MySqlPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
+        tuned!(sqlx::mysql::MySqlPoolOptions::new())
             .connect(url)
             .await
             .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
@@ -448,8 +487,7 @@ impl Pool {
     /// As [`Self::connect`].
     #[cfg(feature = "mysql")]
     pub fn connect_mysql_lazy(url: &str) -> Result<sqlx::MySqlPool, PoolError> {
-        sqlx::mysql::MySqlPoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
+        tuned!(sqlx::mysql::MySqlPoolOptions::new())
             .connect_lazy(url)
             .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
     }
@@ -466,8 +504,7 @@ impl Pool {
     #[cfg(feature = "sqlite")]
     pub async fn connect_sqlite(url: &str) -> Result<sqlx::SqlitePool, PoolError> {
         let opts = sqlite_connect_options(url)?;
-        sqlx::sqlite::SqlitePoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
+        tuned!(sqlx::sqlite::SqlitePoolOptions::new())
             .connect_with(opts)
             .await
             .map_err(|e| PoolError::Connect(ConnectDiagnosis::of(url, &e).to_string()))
@@ -480,9 +517,7 @@ impl Pool {
     #[cfg(feature = "sqlite")]
     pub fn connect_sqlite_lazy(url: &str) -> Result<sqlx::SqlitePool, PoolError> {
         let opts = sqlite_connect_options(url)?;
-        Ok(sqlx::sqlite::SqlitePoolOptions::new()
-            .acquire_timeout(default_acquire_timeout())
-            .connect_lazy_with(opts))
+        Ok(tuned!(sqlx::sqlite::SqlitePoolOptions::new()).connect_lazy_with(opts))
     }
 
     // ---- internal connect helpers ----
@@ -559,36 +594,139 @@ pub const ACQUIRE_TIMEOUT_ENV: &str = "RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS";
 /// an unreachable one six times sooner.
 const ACQUIRE_TIMEOUT_DEFAULT_SECS: u64 = 5;
 
-/// How long [`Pool::connect`] lets a caller wait for a connection.
+/// Env overrides for the rest of the pool knobs. Same shape and same
+/// reason as [`ACQUIRE_TIMEOUT_ENV`]: a deploy can retune a pool without
+/// a config push and a restart of the config pipeline.
+pub const MAX_CONNECTIONS_ENV: &str = "RUSTANGO_DB_MAX_CONNECTIONS";
+/// See [`MAX_CONNECTIONS_ENV`].
+pub const MIN_CONNECTIONS_ENV: &str = "RUSTANGO_DB_MIN_CONNECTIONS";
+/// See [`MAX_CONNECTIONS_ENV`].
+pub const IDLE_TIMEOUT_ENV: &str = "RUSTANGO_DB_IDLE_TIMEOUT_SECS";
+/// See [`MAX_CONNECTIONS_ENV`].
+pub const MAX_LIFETIME_ENV: &str = "RUSTANGO_DB_MAX_LIFETIME_SECS";
+
+/// How every pool this process opens is sized and timed.
 ///
-/// Note this bounds **both** dialing a new connection and queueing for a
-/// free one, so it cannot be set arbitrarily low: under a legitimate
-/// traffic spike the queue wait is real work, and too tight a bound
-/// converts a slow moment into errors. Tune with
-/// [`ACQUIRE_TIMEOUT_ENV`] rather than guessing here.
+/// `None` means "leave sqlx's default alone", not "zero" — a knob nobody
+/// set must behave exactly as it did before the knob existed.
 ///
-/// Read once — parsing an env var per connection would be silly, and
-/// the value cannot change without a restart anyway.
-fn default_acquire_timeout() -> Duration {
-    static CACHED: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        let secs = match std::env::var(ACQUIRE_TIMEOUT_ENV) {
-            Ok(raw) => match raw.trim().parse::<u64>() {
-                Ok(0) | Err(_) => {
-                    tracing::warn!(
-                        target: "rustango::sql",
-                        value = %raw,
-                        "{ACQUIRE_TIMEOUT_ENV} must be a positive whole number of \
-                         seconds; using the {ACQUIRE_TIMEOUT_DEFAULT_SECS}s default"
-                    );
-                    ACQUIRE_TIMEOUT_DEFAULT_SECS
-                }
-                Ok(n) => n,
-            },
-            Err(_) => ACQUIRE_TIMEOUT_DEFAULT_SECS,
-        };
-        Duration::from_secs(secs)
-    })
+/// Installed once at boot by [`configure_pools`], which
+/// [`crate::manage::Cli::with_settings`] calls from `[database]`. Read by
+/// every constructor on [`Pool`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PoolTuning {
+    /// Upper bound on pooled connections. sqlx defaults to 10, which is
+    /// usually too small for a web server and far too large for SQLite.
+    pub max_connections: Option<u32>,
+    /// Connections kept open even when idle. sqlx defaults to 0, so the
+    /// first request after a quiet period pays the connect round-trip.
+    pub min_connections: Option<u32>,
+    /// How long a caller waits for a connection — both dialling a new
+    /// one and queueing for a free one. See
+    /// [`ACQUIRE_TIMEOUT_DEFAULT_SECS`] for why this one has a rustango
+    /// default rather than sqlx's.
+    pub acquire_timeout: Option<Duration>,
+    /// Close a connection that has sat idle this long. Defends against
+    /// a load balancer or `idle_in_transaction_session_timeout` cutting
+    /// it from the other end, which surfaces as a broken connection on
+    /// the next unlucky request.
+    pub idle_timeout: Option<Duration>,
+    /// Close a connection this old regardless of use. The knob that
+    /// matters behind a failover or a credential rotation: without it a
+    /// pool can hold connections to a server that is no longer the one
+    /// you want, or with credentials that have since been revoked.
+    pub max_lifetime: Option<Duration>,
+}
+
+static TUNING: std::sync::OnceLock<PoolTuning> = std::sync::OnceLock::new();
+
+/// Pools opened before anything called [`configure_pools`].
+///
+/// Counted rather than ignored because those pools silently ran on
+/// env-only tuning, and the operator who configured `[database]` has no
+/// other way to find out.
+static POOLS_BEFORE_CONFIG: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Install the pool tuning for this process. **First call wins**, like
+/// the other boot globals, so a library cannot retune an application's
+/// pools out from under it.
+///
+/// Returns `false` if tuning was already set and this call changed
+/// nothing.
+///
+/// Env vars win over the values passed here — the same precedence
+/// `with_settings` uses for `bind`, so a deploy-time override does not
+/// need a config push.
+pub fn configure_pools(from_settings: PoolTuning) -> bool {
+    let installed = TUNING.set(merge_env_over(from_settings)).is_ok();
+    let missed = POOLS_BEFORE_CONFIG.load(std::sync::atomic::Ordering::Relaxed);
+    if installed && missed > 0 {
+        tracing::warn!(
+            target: "rustango::sql",
+            pools = missed,
+            "{missed} database pool(s) were opened before settings were applied \
+             and are running on environment defaults — move `.with_settings(…)` \
+             ahead of any pool construction"
+        );
+    }
+    installed
+}
+
+/// The tuning in force.
+///
+/// **Reading must never seal the cell.** An earlier cut used
+/// `get_or_init`, which meant any pool opened before `with_settings` —
+/// an app connecting in `main()`, a second test in the same binary —
+/// permanently froze env-only tuning for the whole process, silently.
+/// Now a read falls back without writing, and notes that it happened.
+fn tuning() -> PoolTuning {
+    match TUNING.get() {
+        Some(t) => *t,
+        None => {
+            POOLS_BEFORE_CONFIG.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            merge_env_over(PoolTuning::default())
+        }
+    }
+}
+
+/// Overlay the env vars onto `base`, warning about values that do not
+/// parse rather than failing a boot over a typo'd knob.
+fn merge_env_over(base: PoolTuning) -> PoolTuning {
+    PoolTuning {
+        max_connections: parse_env(MAX_CONNECTIONS_ENV).or(base.max_connections),
+        min_connections: parse_env(MIN_CONNECTIONS_ENV).or(base.min_connections),
+        // The one knob with a rustango default rather than an sqlx one,
+        // so it is never `None`.
+        acquire_timeout: Some(
+            env_secs(ACQUIRE_TIMEOUT_ENV)
+                .or(base.acquire_timeout)
+                .unwrap_or_else(|| Duration::from_secs(ACQUIRE_TIMEOUT_DEFAULT_SECS)),
+        ),
+        idle_timeout: env_secs(IDLE_TIMEOUT_ENV).or(base.idle_timeout),
+        max_lifetime: env_secs(MAX_LIFETIME_ENV).or(base.max_lifetime),
+    }
+}
+
+fn env_secs(key: &str) -> Option<Duration> {
+    parse_env::<u64>(key).map(Duration::from_secs)
+}
+
+/// Parse a positive whole number from `key`, warning and ignoring
+/// anything else. Zero is rejected: every knob here is a bound, and a
+/// bound of zero is a mistake rather than an instruction.
+fn parse_env<T: std::str::FromStr + PartialEq + Default>(key: &str) -> Option<T> {
+    let raw = std::env::var(key).ok()?;
+    match raw.trim().parse::<T>() {
+        Ok(v) if v != T::default() => Some(v),
+        _ => {
+            tracing::warn!(
+                target: "rustango::sql",
+                value = %raw,
+                "{key} must be a positive whole number; ignoring it"
+            );
+            None
+        }
+    }
 }
 
 /// v0.40 — build a `SqliteConnectOptions` with the pragmas every
@@ -732,6 +870,154 @@ impl From<sqlx::MySqlPool> for Pool {
 impl From<sqlx::SqlitePool> for Pool {
     fn from(p: sqlx::SqlitePool) -> Self {
         Pool::Sqlite(p)
+    }
+}
+
+#[cfg(test)]
+mod tuning_tests {
+    use super::*;
+
+    /// The env knobs are process-global, so these serialize.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn clear() {
+        for k in [
+            MAX_CONNECTIONS_ENV,
+            MIN_CONNECTIONS_ENV,
+            IDLE_TIMEOUT_ENV,
+            MAX_LIFETIME_ENV,
+            ACQUIRE_TIMEOUT_ENV,
+        ] {
+            std::env::remove_var(k);
+        }
+    }
+
+    /// Unconfigured, every knob stays `None` so sqlx keeps its own
+    /// defaults — except the acquire timeout, which rustango
+    /// deliberately tightens from 30s to 5s.
+    #[test]
+    fn an_unconfigured_process_changes_nothing_but_the_acquire_timeout() {
+        let _g = env_lock();
+        clear();
+        let t = merge_env_over(PoolTuning::default());
+        assert_eq!(t.max_connections, None);
+        assert_eq!(t.min_connections, None);
+        assert_eq!(t.idle_timeout, None);
+        assert_eq!(t.max_lifetime, None);
+        assert_eq!(
+            t.acquire_timeout,
+            Some(Duration::from_secs(ACQUIRE_TIMEOUT_DEFAULT_SECS))
+        );
+    }
+
+    #[test]
+    fn settings_are_carried_through_when_no_env_is_set() {
+        let _g = env_lock();
+        clear();
+        let from_toml = PoolTuning {
+            max_connections: Some(50),
+            min_connections: Some(5),
+            acquire_timeout: Some(Duration::from_secs(9)),
+            idle_timeout: Some(Duration::from_secs(600)),
+            max_lifetime: Some(Duration::from_secs(1800)),
+        };
+        assert_eq!(merge_env_over(from_toml), from_toml);
+    }
+
+    /// Same precedence `with_settings` uses for `bind`: a deploy-time
+    /// override must not need a config push and a restart.
+    #[test]
+    fn env_wins_over_settings() {
+        let _g = env_lock();
+        clear();
+        std::env::set_var(MAX_CONNECTIONS_ENV, "99");
+        let t = merge_env_over(PoolTuning {
+            max_connections: Some(50),
+            ..PoolTuning::default()
+        });
+        clear();
+        assert_eq!(t.max_connections, Some(99));
+    }
+
+    /// A typo'd knob must not take a bound to zero or fail the boot.
+    #[test]
+    fn an_unparseable_or_zero_value_is_ignored_not_obeyed() {
+        let _g = env_lock();
+        clear();
+        for bad in ["nonsense", "0", "-1", ""] {
+            std::env::set_var(MAX_CONNECTIONS_ENV, bad);
+            let t = merge_env_over(PoolTuning {
+                max_connections: Some(20),
+                ..PoolTuning::default()
+            });
+            assert_eq!(t.max_connections, Some(20), "{bad:?} should be ignored");
+        }
+        clear();
+    }
+
+    #[test]
+    fn seconds_become_durations() {
+        let _g = env_lock();
+        clear();
+        std::env::set_var(IDLE_TIMEOUT_ENV, "300");
+        let t = merge_env_over(PoolTuning::default());
+        clear();
+        assert_eq!(t.idle_timeout, Some(Duration::from_secs(300)));
+    }
+
+    /// **The assertion nobody wrote the first time.** `pool_max_size`
+    /// was parsed, type-checked and unit-tested for years while
+    /// reaching no pool at all, because every test asserted the
+    /// *parsed value* and none asserted the *effect*.
+    ///
+    /// A lazy pool is enough: `connect_lazy` builds the pool without
+    /// dialling, so the options are observable with no database — but
+    /// sqlx still wants a runtime to hang the pool's reaper on, hence
+    /// `#[tokio::test]`.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn a_configured_size_reaches_the_pool_itself() {
+        let _g = env_lock();
+        clear();
+        std::env::set_var(MAX_CONNECTIONS_ENV, "37");
+        std::env::set_var(MIN_CONNECTIONS_ENV, "3");
+        std::env::set_var(ACQUIRE_TIMEOUT_ENV, "11");
+
+        let pool = Pool::connect_sqlite_lazy("sqlite::memory:").expect("build a lazy pool");
+        let opts = pool.options();
+        assert_eq!(opts.get_max_connections(), 37, "max_connections");
+        assert_eq!(opts.get_min_connections(), 3, "min_connections");
+        assert_eq!(
+            opts.get_acquire_timeout(),
+            Duration::from_secs(11),
+            "acquire_timeout"
+        );
+        clear();
+    }
+
+    /// Reading the tuning must not seal it. An earlier cut used
+    /// `get_or_init`, so a pool opened before `with_settings` froze
+    /// env-only tuning for the entire process — silently, and for
+    /// every pool after it.
+    #[test]
+    fn reading_the_tuning_leaves_it_configurable() {
+        let _g = env_lock();
+        clear();
+        let before = tuning();
+        assert_eq!(before.max_connections, None);
+        // The cell must still be empty, i.e. still settable. Asserting
+        // on `TUNING.get()` rather than calling `configure_pools`,
+        // which would seal it for every other test in this binary.
+        assert!(
+            TUNING.get().is_none(),
+            "a read sealed the tuning cell — settings applied later would be ignored"
+        );
     }
 }
 

--- a/docs/database-tuning.md
+++ b/docs/database-tuning.md
@@ -1,0 +1,197 @@
+# Database tuning
+
+Every database connection your app makes comes from a **pool** — a set of
+connections kept open and handed out to requests. The pool's defaults are
+chosen by the driver, not by your workload, and the defaults are wrong for
+most production deployments in at least one way.
+
+This page explains what each knob does, what goes wrong when it is left
+alone, and where to set it.
+
+## Why tune at all
+
+Four failures, each caused by a different default:
+
+**Your tenth concurrent request waits.** The driver's default pool holds
+**10** connections. Request eleven does not fail — it *queues*, and your
+p99 latency climbs while CPU sits idle. Nothing in the logs says "pool
+exhausted"; you see slow requests.
+
+**One unreachable database takes down the whole server.** When a
+connection cannot be acquired, the caller waits. The driver's default is
+30 seconds, which is a batch-tool number: on a request path it means a
+worker is pinned for half a minute per request, so an outage of one
+database saturates every worker and takes down surfaces that never touch
+it. Rustango defaults this to **5 seconds** for that reason.
+
+**Connections die quietly and the next request pays.** A load balancer,
+a firewall, or PostgreSQL's own `idle_in_transaction_session_timeout`
+will close a connection that has sat idle. Your pool does not know. The
+next request to borrow it gets a broken pipe — intermittently, under low
+traffic, which is the hardest kind of bug to reproduce.
+
+**A failover or a credential rotation does not take effect.** Pooled
+connections are long-lived by design. After a failover, or after a
+rotated password, a pool can keep using connections opened against the
+old server or the old credentials until something forces them closed.
+
+## Where to set it
+
+Three places. **Higher in this list wins**, so a deploy-time emergency
+override never needs a config push and a restart of your config pipeline.
+
+| | where | use it for |
+|---|---|---|
+| 1 | environment variables | per-deployment overrides, secrets managers, emergency retuning |
+| 2 | `[database]` in your settings tier | the values your project normally runs with, in version control |
+| 3 | framework defaults | what you get when you set nothing |
+
+### In a settings tier
+
+Settings live in `config/*_settings.toml`, one file per environment.
+Put the values your project normally runs with in the tier they belong
+to — development values in `dev_settings.toml`, production values in
+`prod_settings.toml`:
+
+```toml
+[database]
+pool_max_size             = 50
+pool_min_size             = 5
+pool_acquire_timeout_secs = 5
+pool_idle_timeout_secs    = 600
+pool_max_lifetime_secs    = 1800
+```
+
+### As environment variables
+
+Every knob has an environment override, which takes precedence over the
+TOML:
+
+```bash
+RUSTANGO_DB_MAX_CONNECTIONS=50
+RUSTANGO_DB_MIN_CONNECTIONS=5
+RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS=5
+RUSTANGO_DB_IDLE_TIMEOUT_SECS=600
+RUSTANGO_DB_MAX_LIFETIME_SECS=1800
+```
+
+A value that is not a positive whole number is **ignored with a warning**
+rather than obeyed — a typo should not silently take a bound to zero, and
+should not fail a boot either.
+
+### One ordering rule
+
+Settings are applied to pools by `Cli::with_settings(...)`. Call it
+**before** anything opens a database connection. A pool built earlier
+runs on environment defaults, and the framework logs a warning naming how
+many pools that happened to, rather than leaving you to discover it under
+load.
+
+## The parameters
+
+| setting | environment variable | default | what it does |
+|---|---|---|---|
+| `pool_max_size` | `RUSTANGO_DB_MAX_CONNECTIONS` | 10 (driver) | Most connections the pool will open. Requests beyond this queue. |
+| `pool_min_size` | `RUSTANGO_DB_MIN_CONNECTIONS` | 0 (driver) | Connections kept open even when idle. |
+| `pool_acquire_timeout_secs` | `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS` | 5 | How long a caller waits for a connection before erroring. |
+| `pool_idle_timeout_secs` | `RUSTANGO_DB_IDLE_TIMEOUT_SECS` | driver default | Close a connection that has sat idle this long. |
+| `pool_max_lifetime_secs` | `RUSTANGO_DB_MAX_LIFETIME_SECS` | driver default | Close a connection this old regardless of use. |
+
+Leaving a knob unset is not the same as setting it to zero. Unset means
+*the driver's own default applies* — the behaviour you had before the
+knob existed.
+
+### `pool_max_size`
+
+The ceiling on concurrent database work. Raise it when requests are
+queueing for connections; the symptom is latency that grows with traffic
+while the database itself is not busy.
+
+**It is a ceiling, not a target** — the pool opens connections on demand
+and only up to this number.
+
+The important constraint is on the *other* side: your database server has
+its own connection limit (PostgreSQL's `max_connections`, typically 100).
+The sum of every pool across every replica must stay under it, or new
+connections are refused. Ten pods with `pool_max_size = 50` is 500
+connections against a server that allows 100.
+
+### `pool_min_size`
+
+Connections kept open even when nothing is using them. The point is
+latency: with `0`, the first request after a quiet period pays the full
+TCP, TLS and authentication round-trip before any query runs.
+
+Set it to cover your idle baseline, not your peak. Connections held open
+cost resources on the server too.
+
+### `pool_acquire_timeout_secs`
+
+How long a caller waits for a connection before giving up — covering
+**both** dialling a new connection and queueing for a free one.
+
+This is the knob that decides how your app behaves when the database is
+unreachable. Too high and workers pin waiting on a database that will
+never answer; too low and a legitimate traffic spike, where queueing is
+real and productive work, turns into errors.
+
+The default of 5 seconds is deliberately tighter than the driver's 30.
+Raise it if you have long-running queries and a saturated-but-healthy
+pool; lower it if you would rather shed load quickly.
+
+### `pool_idle_timeout_secs`
+
+Closes connections that have sat unused. Set this **below** whatever the
+shortest idle timeout is on the path between your app and the database —
+a load balancer, a proxy, a firewall's connection table, or the database
+server's own idle timeouts. If something else closes the connection
+first, your pool hands out a dead one.
+
+10 minutes is a common starting point.
+
+### `pool_max_lifetime_secs`
+
+Closes connections after a fixed age, whether or not they are healthy.
+This is the knob that makes failovers and credential rotations actually
+take effect: without it, a pool can keep talking to the server it
+connected to at boot.
+
+30 minutes is a common starting point. Shorter if you lease credentials
+from a secrets manager with a short TTL.
+
+## Backends differ
+
+**SQLite is not a server**, and pool sizing does not mean the same thing.
+SQLite serialises writers globally — one writer at a time, whatever the
+pool size — so raising `pool_max_size` adds read concurrency but never
+write concurrency. With an in-memory database, additional connections are
+worse than useless: each one is a *separate empty database* unless the
+URL sets `cache=shared`.
+
+**PostgreSQL and MySQL** both enforce a server-side connection limit.
+Size your pools against that budget across all replicas, and remember
+that connection poolers such as PgBouncer change the arithmetic.
+
+## Connection options, which are a different thing
+
+The knobs above are about the *pool*. Options about a single
+*connection* — TLS, connection timeouts, the application name the server
+sees — travel in the connection URL:
+
+```
+postgres://user:pw@host:5432/db?sslmode=require&connect_timeout=10&application_name=myapp
+mysql://user:pw@host:3306/db?ssl-mode=REQUIRED
+sqlite://./dev.db?mode=rwc
+```
+
+These are passed through to the driver, so anything the driver's URL
+parser accepts works.
+
+## Tenant pools
+
+In a multi-tenant app, each database-mode tenant gets its own pool, and
+those are configured separately through `TenantPoolsConfig` — see
+[Tenant-pool tuning](manage.md) in the `manage` guide. Their defaults
+differ from the primary pool's; in particular the tenant acquire timeout
+is more generous, which is worth reviewing if you run many tenants
+against databases that can become unreachable independently.

--- a/docs/de/database-tuning.md
+++ b/docs/de/database-tuning.md
@@ -1,0 +1,210 @@
+# Datenbank-Tuning
+
+Jede Datenbankverbindung Ihrer Anwendung stammt aus einem **Pool** —
+einer Menge offen gehaltener Verbindungen, die an Requests ausgegeben
+werden. Die Voreinstellungen des Pools kommen vom Treiber, nicht von
+Ihrer Last, und sie sind für die meisten Produktivsysteme in mindestens
+einem Punkt falsch.
+
+Diese Seite erklärt, was jeder Parameter bewirkt, was schiefgeht, wenn
+man ihn unangetastet lässt, und wo man ihn setzt.
+
+## Warum überhaupt tunen
+
+Vier Fehlerbilder, jedes durch eine andere Voreinstellung verursacht:
+
+**Ihr zehnter gleichzeitiger Request wartet.** Der Standard-Pool des
+Treibers hält **10** Verbindungen. Request elf schlägt nicht fehl — er
+*wartet in der Schlange*, und Ihre p99-Latenz steigt, während die CPU
+untätig ist. Nichts im Log sagt „Pool erschöpft"; Sie sehen langsame
+Requests.
+
+**Eine nicht erreichbare Datenbank legt den ganzen Server lahm.** Kann
+keine Verbindung geholt werden, wartet der Aufrufer. Die Voreinstellung
+des Treibers sind 30 Sekunden — eine Zahl für Batch-Werkzeuge: auf dem
+Request-Pfad bedeutet sie, dass ein Worker pro Request eine halbe Minute
+blockiert ist. Der Ausfall *einer* Datenbank sättigt so alle Worker und
+reißt Oberflächen mit, die diese Datenbank nie anfassen. Rustango setzt
+deshalb **5 Sekunden** als Voreinstellung.
+
+**Verbindungen sterben unbemerkt, und der nächste Request zahlt dafür.**
+Ein Load Balancer, eine Firewall oder PostgreSQLs eigenes
+`idle_in_transaction_session_timeout` schließt eine untätige Verbindung.
+Ihr Pool weiß davon nichts. Der nächste Request, der sie ausleiht,
+bekommt einen Broken Pipe — sporadisch und bei geringer Last, also genau
+die Sorte Fehler, die sich am schlechtesten reproduzieren lässt.
+
+**Ein Failover oder eine Passwortrotation greift nicht.** Gepoolte
+Verbindungen sind bewusst langlebig. Nach einem Failover oder einem
+rotierten Passwort kann ein Pool weiter Verbindungen zum alten Server
+oder mit den alten Zugangsdaten benutzen, bis etwas sie schließt.
+
+## Wo Sie es einstellen
+
+Drei Orte. **Weiter oben gewinnt**, damit ein Notfall-Override zur
+Deploy-Zeit niemals einen Config-Push und einen Neustart Ihrer
+Config-Pipeline braucht.
+
+| | wo | wofür |
+|---|---|---|
+| 1 | Umgebungsvariablen | Overrides pro Deployment, Secrets-Manager, Nachjustieren im Notfall |
+| 2 | `[database]` in Ihrer Settings-Stufe | die Werte, mit denen Ihr Projekt normalerweise läuft, in der Versionsverwaltung |
+| 3 | Framework-Voreinstellungen | was Sie bekommen, wenn Sie nichts setzen |
+
+### In einer Settings-Stufe
+
+Settings liegen in `config/*_settings.toml`, eine Datei pro Umgebung.
+Tragen Sie die Werte in die Stufe ein, zu der sie gehören —
+Entwicklungswerte in `dev_settings.toml`, Produktionswerte in
+`prod_settings.toml`:
+
+```toml
+[database]
+pool_max_size             = 50
+pool_min_size             = 5
+pool_acquire_timeout_secs = 5
+pool_idle_timeout_secs    = 600
+pool_max_lifetime_secs    = 1800
+```
+
+### Als Umgebungsvariablen
+
+Jeder Parameter hat ein Umgebungs-Override, das Vorrang vor dem TOML hat:
+
+```bash
+RUSTANGO_DB_MAX_CONNECTIONS=50
+RUSTANGO_DB_MIN_CONNECTIONS=5
+RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS=5
+RUSTANGO_DB_IDLE_TIMEOUT_SECS=600
+RUSTANGO_DB_MAX_LIFETIME_SECS=1800
+```
+
+Ein Wert, der keine positive ganze Zahl ist, wird **mit einer Warnung
+ignoriert** statt befolgt — ein Tippfehler soll weder stillschweigend
+eine Grenze auf null setzen noch den Start abbrechen.
+
+### Eine Reihenfolgeregel
+
+Die Settings werden von `Cli::with_settings(...)` auf die Pools
+angewendet. Rufen Sie das auf, **bevor** irgendetwas eine
+Datenbankverbindung öffnet. Ein früher gebauter Pool läuft mit den
+Umgebungs-Voreinstellungen, und das Framework protokolliert eine Warnung
+mit der Anzahl betroffener Pools, statt Sie das unter Last entdecken zu
+lassen.
+
+## Die Parameter
+
+| Setting | Umgebungsvariable | Voreinstellung | Wirkung |
+|---|---|---|---|
+| `pool_max_size` | `RUSTANGO_DB_MAX_CONNECTIONS` | 10 (Treiber) | Höchstzahl geöffneter Verbindungen. Weitere Requests warten. |
+| `pool_min_size` | `RUSTANGO_DB_MIN_CONNECTIONS` | 0 (Treiber) | Verbindungen, die auch im Leerlauf offen bleiben. |
+| `pool_acquire_timeout_secs` | `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS` | 5 | Wie lange ein Aufrufer auf eine Verbindung wartet, bevor er scheitert. |
+| `pool_idle_timeout_secs` | `RUSTANGO_DB_IDLE_TIMEOUT_SECS` | Treiber-Voreinstellung | Schließt Verbindungen, die so lange untätig waren. |
+| `pool_max_lifetime_secs` | `RUSTANGO_DB_MAX_LIFETIME_SECS` | Treiber-Voreinstellung | Schließt Verbindungen ab diesem Alter, unabhängig von der Nutzung. |
+
+Einen Parameter nicht zu setzen ist nicht dasselbe, wie ihn auf null zu
+setzen. Nicht gesetzt heißt: *die Voreinstellung des Treibers gilt* —
+also das Verhalten, das Sie hatten, bevor es den Parameter gab.
+
+### `pool_max_size`
+
+Die Obergrenze für gleichzeitige Datenbankarbeit. Erhöhen Sie sie, wenn
+Requests auf Verbindungen warten; das Symptom ist Latenz, die mit dem
+Verkehr wächst, während die Datenbank selbst nicht ausgelastet ist.
+
+**Es ist eine Obergrenze, kein Zielwert** — der Pool öffnet Verbindungen
+nach Bedarf und nur bis zu dieser Zahl.
+
+Die wichtige Nebenbedingung liegt auf der *anderen* Seite: Ihr
+Datenbankserver hat sein eigenes Verbindungslimit (PostgreSQLs
+`max_connections`, typischerweise 100). Die Summe aller Pools über alle
+Repliken muss darunter bleiben, sonst werden neue Verbindungen
+abgewiesen. Zehn Pods mit `pool_max_size = 50` sind 500 Verbindungen
+gegen einen Server, der 100 erlaubt.
+
+### `pool_min_size`
+
+Verbindungen, die offen bleiben, auch wenn sie niemand benutzt. Es geht
+um Latenz: bei `0` zahlt der erste Request nach einer ruhigen Phase den
+vollen TCP-, TLS- und Authentifizierungs-Roundtrip, bevor irgendeine
+Query läuft.
+
+Bemessen Sie den Wert nach Ihrer Grundlast, nicht nach der Spitze.
+Offen gehaltene Verbindungen kosten auch auf dem Server Ressourcen.
+
+### `pool_acquire_timeout_secs`
+
+Wie lange ein Aufrufer auf eine Verbindung wartet, bevor er aufgibt —
+das umfasst **sowohl** den Aufbau einer neuen Verbindung **als auch** das
+Anstehen für eine freie.
+
+Dieser Parameter entscheidet, wie sich Ihre Anwendung verhält, wenn die
+Datenbank nicht erreichbar ist. Zu hoch, und Worker blockieren an einer
+Datenbank, die nie antworten wird; zu niedrig, und eine legitime
+Lastspitze — bei der Anstehen echte, produktive Arbeit ist — wird zu
+Fehlern.
+
+Die Voreinstellung von 5 Sekunden ist bewusst enger als die 30 des
+Treibers. Erhöhen Sie sie bei langlaufenden Queries und einem
+ausgelasteten, aber gesunden Pool; senken Sie sie, wenn Sie Last lieber
+schnell abweisen.
+
+### `pool_idle_timeout_secs`
+
+Schließt Verbindungen, die ungenutzt herumlagen. Setzen Sie den Wert
+**unter** das kürzeste Idle-Timeout auf dem Weg zwischen Anwendung und
+Datenbank — Load Balancer, Proxy, Connection-Tabelle einer Firewall oder
+die Idle-Timeouts des Datenbankservers selbst. Schließt etwas anderes die
+Verbindung zuerst, gibt Ihr Pool eine tote Verbindung aus.
+
+10 Minuten sind ein gängiger Startwert.
+
+### `pool_max_lifetime_secs`
+
+Schließt Verbindungen ab einem festen Alter, ob gesund oder nicht. Das
+ist der Parameter, der Failover und Passwortrotation überhaupt erst
+wirksam macht: ohne ihn kann ein Pool weiter mit dem Server sprechen, zu
+dem er beim Start verbunden hat.
+
+30 Minuten sind ein gängiger Startwert. Kürzer, wenn Sie Zugangsdaten mit
+kurzer Gültigkeit aus einem Secrets-Manager beziehen.
+
+## Backends unterscheiden sich
+
+**SQLite ist kein Server**, und Pool-Größen bedeuten dort etwas anderes.
+SQLite serialisiert Schreiber global — immer nur ein Schreiber,
+unabhängig von der Pool-Größe — ein höheres `pool_max_size` bringt also
+Lese-, aber nie Schreibparallelität. Bei einer In-Memory-Datenbank sind
+zusätzliche Verbindungen schlimmer als nutzlos: jede ist eine *eigene
+leere Datenbank*, sofern die URL nicht `cache=shared` setzt.
+
+**PostgreSQL und MySQL** erzwingen beide ein serverseitiges
+Verbindungslimit. Bemessen Sie Ihre Pools an diesem Budget über alle
+Repliken hinweg, und denken Sie daran, dass Connection-Pooler wie
+PgBouncer die Rechnung verändern.
+
+## Verbindungsoptionen sind etwas anderes
+
+Die obigen Parameter betreffen den *Pool*. Optionen für eine einzelne
+*Verbindung* — TLS, Verbindungs-Timeouts, der Anwendungsname, den der
+Server sieht — reisen in der Verbindungs-URL mit:
+
+```
+postgres://user:pw@host:5432/db?sslmode=require&connect_timeout=10&application_name=myapp
+mysql://user:pw@host:3306/db?ssl-mode=REQUIRED
+sqlite://./dev.db?mode=rwc
+```
+
+Diese werden an den Treiber durchgereicht; alles, was dessen URL-Parser
+akzeptiert, funktioniert.
+
+## Tenant-Pools
+
+In einer mandantenfähigen Anwendung bekommt jeder Tenant im
+Datenbank-Modus seinen eigenen Pool, und diese werden separat über
+`TenantPoolsConfig` konfiguriert — siehe
+[Tenant-Pool-Tuning](manage.md) in der `manage`-Anleitung. Ihre
+Voreinstellungen weichen von denen des primären Pools ab; insbesondere
+ist das Acquire-Timeout der Tenants großzügiger, was einen Blick wert
+ist, wenn Sie viele Tenants gegen Datenbanken betreiben, die unabhängig
+voneinander ausfallen können.

--- a/docs/de/index.toml
+++ b/docs/de/index.toml
@@ -9,7 +9,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Anleitungen"
 slug = "anleitungen"
-pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "database-tuning.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Authentifizierung"

--- a/docs/es/database-tuning.md
+++ b/docs/es/database-tuning.md
@@ -1,0 +1,207 @@
+# Ajuste de la base de datos
+
+Cada conexión a la base de datos que hace tu aplicación sale de un
+**pool**: un conjunto de conexiones que se mantienen abiertas y se
+reparten entre las peticiones. Los valores por defecto del pool los
+elige el driver, no tu carga de trabajo, y en la mayoría de despliegues
+en producción son incorrectos en al menos un aspecto.
+
+Esta página explica qué hace cada parámetro, qué falla si lo dejas como
+está, y dónde configurarlo.
+
+## Por qué ajustarlo
+
+Cuatro fallos, cada uno causado por un valor por defecto distinto:
+
+**Tu décima petición simultánea espera.** El pool por defecto del driver
+mantiene **10** conexiones. La petición once no falla: *hace cola*, y tu
+latencia p99 sube mientras la CPU está ociosa. Nada en los logs dice
+«pool agotado»; solo ves peticiones lentas.
+
+**Una base de datos inalcanzable tumba el servidor entero.** Cuando no se
+puede obtener una conexión, quien la pide espera. El valor por defecto
+del driver son 30 segundos, que es una cifra de herramienta por lotes: en
+la ruta de una petición significa que un worker queda bloqueado medio
+minuto por petición, así que la caída de *una* base de datos satura todos
+los workers y se lleva por delante superficies que ni la tocan. Por eso
+rustango usa **5 segundos**.
+
+**Las conexiones mueren en silencio y la paga la petición siguiente.** Un
+balanceador, un cortafuegos o el propio
+`idle_in_transaction_session_timeout` de PostgreSQL cierra una conexión
+que lleva rato inactiva. Tu pool no se entera. La siguiente petición que
+la toma prestada recibe un *broken pipe*, de forma intermitente y con
+poco tráfico, que es el tipo de error más difícil de reproducir.
+
+**Un failover o una rotación de credenciales no surte efecto.** Las
+conexiones en pool son de vida larga por diseño. Tras un failover, o tras
+rotar una contraseña, un pool puede seguir usando conexiones abiertas
+contra el servidor antiguo o con las credenciales antiguas hasta que algo
+las cierre.
+
+## Dónde configurarlo
+
+Tres sitios. **Gana el que está más arriba**, de modo que una anulación
+de emergencia en el despliegue nunca necesite un *push* de configuración
+ni reiniciar tu canalización de configuración.
+
+| | dónde | para qué |
+|---|---|---|
+| 1 | variables de entorno | anulaciones por despliegue, gestores de secretos, reajuste de emergencia |
+| 2 | `[database]` en tu nivel de settings | los valores con los que tu proyecto funciona normalmente, en control de versiones |
+| 3 | valores por defecto del framework | lo que obtienes si no configuras nada |
+
+### En un nivel de settings
+
+Los settings viven en `config/*_settings.toml`, un archivo por entorno.
+Pon los valores en el nivel al que pertenecen: los de desarrollo en
+`dev_settings.toml`, los de producción en `prod_settings.toml`:
+
+```toml
+[database]
+pool_max_size             = 50
+pool_min_size             = 5
+pool_acquire_timeout_secs = 5
+pool_idle_timeout_secs    = 600
+pool_max_lifetime_secs    = 1800
+```
+
+### Como variables de entorno
+
+Cada parámetro tiene una anulación por entorno, que tiene prioridad sobre
+el TOML:
+
+```bash
+RUSTANGO_DB_MAX_CONNECTIONS=50
+RUSTANGO_DB_MIN_CONNECTIONS=5
+RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS=5
+RUSTANGO_DB_IDLE_TIMEOUT_SECS=600
+RUSTANGO_DB_MAX_LIFETIME_SECS=1800
+```
+
+Un valor que no sea un entero positivo se **ignora con una advertencia**
+en lugar de obedecerse: una errata no debe poner un límite a cero en
+silencio, ni tampoco abortar el arranque.
+
+### Una regla de orden
+
+Los settings los aplica a los pools `Cli::with_settings(...)`. Llámalo
+**antes** de que nada abra una conexión. Un pool construido antes
+funciona con los valores del entorno, y el framework registra una
+advertencia diciendo a cuántos pools le ha pasado, en vez de dejar que lo
+descubras bajo carga.
+
+## Los parámetros
+
+| setting | variable de entorno | por defecto | qué hace |
+|---|---|---|---|
+| `pool_max_size` | `RUSTANGO_DB_MAX_CONNECTIONS` | 10 (driver) | Máximo de conexiones que abrirá el pool. Las peticiones de más hacen cola. |
+| `pool_min_size` | `RUSTANGO_DB_MIN_CONNECTIONS` | 0 (driver) | Conexiones que siguen abiertas aunque estén ociosas. |
+| `pool_acquire_timeout_secs` | `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS` | 5 | Cuánto espera quien pide una conexión antes de fallar. |
+| `pool_idle_timeout_secs` | `RUSTANGO_DB_IDLE_TIMEOUT_SECS` | por defecto del driver | Cierra conexiones que llevan este tiempo ociosas. |
+| `pool_max_lifetime_secs` | `RUSTANGO_DB_MAX_LIFETIME_SECS` | por defecto del driver | Cierra conexiones con esta antigüedad, se usen o no. |
+
+Dejar un parámetro sin configurar no es lo mismo que ponerlo a cero. Sin
+configurar significa *se aplica el valor por defecto del driver*: el
+comportamiento que tenías antes de que el parámetro existiera.
+
+### `pool_max_size`
+
+El techo del trabajo simultáneo contra la base de datos. Súbelo cuando
+las peticiones hagan cola esperando conexiones; el síntoma es latencia
+que crece con el tráfico mientras la base de datos no está ocupada.
+
+**Es un techo, no un objetivo**: el pool abre conexiones según demanda y
+solo hasta ese número.
+
+La restricción importante está al *otro* lado: tu servidor de base de
+datos tiene su propio límite de conexiones (`max_connections` de
+PostgreSQL, típicamente 100). La suma de todos los pools de todas las
+réplicas debe quedar por debajo, o se rechazarán conexiones nuevas. Diez
+pods con `pool_max_size = 50` son 500 conexiones contra un servidor que
+permite 100.
+
+### `pool_min_size`
+
+Conexiones que siguen abiertas aunque nadie las use. El objetivo es la
+latencia: con `0`, la primera petición tras un rato de calma paga el
+viaje completo de TCP, TLS y autenticación antes de ejecutar consulta
+alguna.
+
+Dimensiónalo para tu carga base, no para el pico. Las conexiones abiertas
+también cuestan recursos en el servidor.
+
+### `pool_acquire_timeout_secs`
+
+Cuánto espera quien pide una conexión antes de rendirse, cubriendo
+**tanto** abrir una nueva **como** hacer cola por una libre.
+
+Este parámetro decide cómo se comporta tu aplicación cuando la base de
+datos no responde. Demasiado alto y los workers se bloquean contra una
+base de datos que nunca contestará; demasiado bajo y un pico de tráfico
+legítimo —donde hacer cola es trabajo real y productivo— se convierte en
+errores.
+
+Los 5 segundos por defecto son deliberadamente más estrictos que los 30
+del driver. Súbelo si tienes consultas largas y un pool saturado pero
+sano; bájalo si prefieres rechazar carga rápido.
+
+### `pool_idle_timeout_secs`
+
+Cierra conexiones que han estado sin usar. Ponlo **por debajo** del
+tiempo de inactividad más corto que haya en el camino entre tu aplicación
+y la base de datos: un balanceador, un proxy, la tabla de conexiones de
+un cortafuegos, o los propios timeouts del servidor. Si algo cierra la
+conexión antes, tu pool reparte una conexión muerta.
+
+10 minutos es un punto de partida habitual.
+
+### `pool_max_lifetime_secs`
+
+Cierra conexiones a partir de cierta antigüedad, estén sanas o no. Es el
+parámetro que hace que los failover y las rotaciones de credenciales
+surtan efecto de verdad: sin él, un pool puede seguir hablando con el
+servidor al que se conectó al arrancar.
+
+30 minutos es un punto de partida habitual. Menos si obtienes
+credenciales de un gestor de secretos con una vigencia corta.
+
+## Los backends no son iguales
+
+**SQLite no es un servidor**, y dimensionar el pool no significa lo
+mismo. SQLite serializa los escritores de forma global —un escritor cada
+vez, sea cual sea el tamaño del pool—, así que subir `pool_max_size` añade
+concurrencia de lectura pero nunca de escritura. Con una base de datos en
+memoria, las conexiones adicionales son peor que inútiles: cada una es
+una *base de datos vacía distinta* salvo que la URL indique
+`cache=shared`.
+
+**PostgreSQL y MySQL** imponen un límite de conexiones del lado del
+servidor. Dimensiona tus pools contra ese presupuesto sumando todas las
+réplicas, y recuerda que los *poolers* como PgBouncer cambian las
+cuentas.
+
+## Las opciones de conexión son otra cosa
+
+Los parámetros anteriores son del *pool*. Las opciones de una *conexión*
+concreta —TLS, timeouts de conexión, el nombre de aplicación que ve el
+servidor— viajan en la URL de conexión:
+
+```
+postgres://user:pw@host:5432/db?sslmode=require&connect_timeout=10&application_name=myapp
+mysql://user:pw@host:3306/db?ssl-mode=REQUIRED
+sqlite://./dev.db?mode=rwc
+```
+
+Se pasan tal cual al driver, así que funciona todo lo que acepte su
+analizador de URL.
+
+## Pools de tenant
+
+En una aplicación multi-tenant, cada tenant en modo base de datos tiene
+su propio pool, y esos se configuran aparte mediante `TenantPoolsConfig`
+—consulta [Ajuste de pools de tenant](manage.md) en la guía de `manage`—.
+Sus valores por defecto difieren de los del pool principal; en concreto,
+el timeout de adquisición de los tenants es más generoso, algo que
+conviene revisar si ejecutas muchos tenants contra bases de datos que
+pueden caerse de forma independiente.

--- a/docs/es/index.toml
+++ b/docs/es/index.toml
@@ -9,7 +9,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Guías"
 slug = "guias"
-pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "database-tuning.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Autenticación"

--- a/docs/fr/database-tuning.md
+++ b/docs/fr/database-tuning.md
@@ -1,0 +1,210 @@
+# Réglage de la base de données
+
+Chaque connexion à la base de données que fait votre application vient
+d'un **pool** : un ensemble de connexions maintenues ouvertes et
+distribuées aux requêtes. Les valeurs par défaut du pool sont choisies
+par le driver, pas par votre charge, et elles sont mauvaises pour la
+plupart des déploiements en production sur au moins un point.
+
+Cette page explique ce que fait chaque paramètre, ce qui casse quand on
+n'y touche pas, et où le régler.
+
+## Pourquoi régler quoi que ce soit
+
+Quatre pannes, chacune causée par une valeur par défaut différente :
+
+**Votre dixième requête simultanée attend.** Le pool par défaut du driver
+garde **10** connexions. La onzième requête n'échoue pas — elle *fait la
+queue*, et votre latence p99 monte pendant que le CPU ne fait rien. Rien
+dans les logs ne dit « pool épuisé » ; vous voyez des requêtes lentes.
+
+**Une base de données injoignable met à terre le serveur entier.**
+Lorsqu'une connexion ne peut pas être obtenue, l'appelant attend. La
+valeur par défaut du driver est de 30 secondes, un chiffre d'outil de
+traitement par lots : sur le chemin d'une requête, cela veut dire qu'un
+worker est bloqué une demi-minute par requête, donc la panne d'*une* base
+sature tous les workers et emporte des surfaces qui n'y touchent jamais.
+C'est pourquoi rustango met **5 secondes** par défaut.
+
+**Les connexions meurent en silence et la requête suivante paie.** Un
+répartiteur de charge, un pare-feu ou le propre
+`idle_in_transaction_session_timeout` de PostgreSQL ferme une connexion
+restée inactive. Votre pool ne le sait pas. La requête suivante qui
+l'emprunte reçoit un *broken pipe* — par intermittence, à faible trafic,
+c'est-à-dire le type de bug le plus difficile à reproduire.
+
+**Un basculement ou une rotation d'identifiants ne prend pas effet.** Les
+connexions d'un pool sont durables par conception. Après un basculement,
+ou après une rotation de mot de passe, un pool peut continuer à utiliser
+des connexions ouvertes vers l'ancien serveur ou avec les anciens
+identifiants jusqu'à ce que quelque chose les ferme.
+
+## Où le régler
+
+Trois endroits. **Le plus haut l'emporte**, pour qu'une surcharge
+d'urgence au déploiement n'exige jamais un *push* de configuration ni un
+redémarrage de votre chaîne de configuration.
+
+| | où | à quoi ça sert |
+|---|---|---|
+| 1 | variables d'environnement | surcharges par déploiement, gestionnaires de secrets, réglage d'urgence |
+| 2 | `[database]` dans votre palier de settings | les valeurs avec lesquelles votre projet tourne normalement, versionnées |
+| 3 | valeurs par défaut du framework | ce que vous obtenez si vous ne réglez rien |
+
+### Dans un palier de settings
+
+Les settings vivent dans `config/*_settings.toml`, un fichier par
+environnement. Mettez les valeurs dans le palier auquel elles
+appartiennent — celles de développement dans `dev_settings.toml`, celles
+de production dans `prod_settings.toml` :
+
+```toml
+[database]
+pool_max_size             = 50
+pool_min_size             = 5
+pool_acquire_timeout_secs = 5
+pool_idle_timeout_secs    = 600
+pool_max_lifetime_secs    = 1800
+```
+
+### En variables d'environnement
+
+Chaque paramètre a une surcharge par environnement, qui prime sur le
+TOML :
+
+```bash
+RUSTANGO_DB_MAX_CONNECTIONS=50
+RUSTANGO_DB_MIN_CONNECTIONS=5
+RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS=5
+RUSTANGO_DB_IDLE_TIMEOUT_SECS=600
+RUSTANGO_DB_MAX_LIFETIME_SECS=1800
+```
+
+Une valeur qui n'est pas un entier positif est **ignorée avec un
+avertissement** plutôt qu'obéie : une faute de frappe ne doit ni mettre
+silencieusement une borne à zéro, ni faire échouer un démarrage.
+
+### Une règle d'ordre
+
+Les settings sont appliqués aux pools par `Cli::with_settings(...)`.
+Appelez-le **avant** que quoi que ce soit n'ouvre une connexion. Un pool
+construit plus tôt tourne avec les valeurs de l'environnement, et le
+framework journalise un avertissement indiquant combien de pools sont
+concernés, plutôt que de vous laisser le découvrir sous charge.
+
+## Les paramètres
+
+| setting | variable d'environnement | par défaut | effet |
+|---|---|---|---|
+| `pool_max_size` | `RUSTANGO_DB_MAX_CONNECTIONS` | 10 (driver) | Nombre maximal de connexions ouvertes. Les requêtes en trop font la queue. |
+| `pool_min_size` | `RUSTANGO_DB_MIN_CONNECTIONS` | 0 (driver) | Connexions maintenues ouvertes même au repos. |
+| `pool_acquire_timeout_secs` | `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS` | 5 | Combien de temps un appelant attend une connexion avant d'échouer. |
+| `pool_idle_timeout_secs` | `RUSTANGO_DB_IDLE_TIMEOUT_SECS` | défaut du driver | Ferme les connexions inactives depuis cette durée. |
+| `pool_max_lifetime_secs` | `RUSTANGO_DB_MAX_LIFETIME_SECS` | défaut du driver | Ferme les connexions de cet âge, utilisées ou non. |
+
+Ne pas régler un paramètre n'est pas la même chose que le mettre à zéro.
+Non réglé signifie *la valeur par défaut du driver s'applique* — le
+comportement que vous aviez avant que le paramètre existe.
+
+### `pool_max_size`
+
+Le plafond du travail simultané sur la base. Augmentez-le quand les
+requêtes font la queue pour une connexion ; le symptôme est une latence
+qui croît avec le trafic alors que la base elle-même n'est pas chargée.
+
+**C'est un plafond, pas une cible** — le pool ouvre des connexions à la
+demande et seulement jusqu'à ce nombre.
+
+La contrainte importante est de l'*autre* côté : votre serveur de base de
+données a sa propre limite de connexions (le `max_connections` de
+PostgreSQL, typiquement 100). La somme de tous les pools sur toutes les
+répliques doit rester en dessous, sinon les nouvelles connexions sont
+refusées. Dix pods avec `pool_max_size = 50`, cela fait 500 connexions
+contre un serveur qui en autorise 100.
+
+### `pool_min_size`
+
+Des connexions maintenues ouvertes même quand personne ne s'en sert.
+L'enjeu est la latence : à `0`, la première requête après une période
+calme paie l'aller-retour complet TCP, TLS et authentification avant la
+moindre requête SQL.
+
+Dimensionnez-le sur votre charge de fond, pas sur votre pic. Les
+connexions maintenues coûtent aussi des ressources côté serveur.
+
+### `pool_acquire_timeout_secs`
+
+Combien de temps un appelant attend une connexion avant d'abandonner —
+ce qui couvre **à la fois** l'ouverture d'une nouvelle connexion **et**
+l'attente d'une connexion libre.
+
+C'est ce paramètre qui décide du comportement de votre application quand
+la base est injoignable. Trop élevé, et les workers se bloquent sur une
+base qui ne répondra jamais ; trop bas, et un pic de trafic légitime — où
+faire la queue est un travail réel et productif — se transforme en
+erreurs.
+
+Les 5 secondes par défaut sont délibérément plus serrées que les 30 du
+driver. Augmentez-les si vous avez des requêtes longues et un pool
+saturé mais sain ; baissez-les si vous préférez rejeter la charge vite.
+
+### `pool_idle_timeout_secs`
+
+Ferme les connexions restées inutilisées. Réglez-le **en dessous** du
+plus court délai d'inactivité présent sur le chemin entre votre
+application et la base : un répartiteur de charge, un proxy, la table de
+connexions d'un pare-feu, ou les délais du serveur lui-même. Si autre
+chose ferme la connexion en premier, votre pool distribue une connexion
+morte.
+
+10 minutes est un point de départ courant.
+
+### `pool_max_lifetime_secs`
+
+Ferme les connexions au-delà d'un âge fixe, saines ou non. C'est le
+paramètre qui fait que les basculements et les rotations d'identifiants
+prennent réellement effet : sans lui, un pool peut continuer à parler au
+serveur auquel il s'est connecté au démarrage.
+
+30 minutes est un point de départ courant. Moins si vous obtenez des
+identifiants à durée de vie courte depuis un gestionnaire de secrets.
+
+## Les backends diffèrent
+
+**SQLite n'est pas un serveur**, et dimensionner le pool n'y veut pas
+dire la même chose. SQLite sérialise les écrivains globalement — un seul
+à la fois, quelle que soit la taille du pool — donc augmenter
+`pool_max_size` ajoute de la concurrence en lecture mais jamais en
+écriture. Avec une base en mémoire, les connexions supplémentaires sont
+pires qu'inutiles : chacune est une *base vide distincte*, sauf si l'URL
+précise `cache=shared`.
+
+**PostgreSQL et MySQL** imposent tous deux une limite de connexions côté
+serveur. Dimensionnez vos pools dans ce budget, toutes répliques
+confondues, et rappelez-vous que les *poolers* comme PgBouncer changent
+le calcul.
+
+## Les options de connexion sont autre chose
+
+Les paramètres ci-dessus concernent le *pool*. Les options d'une
+*connexion* individuelle — TLS, délais de connexion, le nom
+d'application que voit le serveur — voyagent dans l'URL de connexion :
+
+```
+postgres://user:pw@host:5432/db?sslmode=require&connect_timeout=10&application_name=myapp
+mysql://user:pw@host:3306/db?ssl-mode=REQUIRED
+sqlite://./dev.db?mode=rwc
+```
+
+Elles sont transmises telles quelles au driver : tout ce qu'accepte son
+analyseur d'URL fonctionne.
+
+## Pools de tenants
+
+Dans une application multi-tenant, chaque tenant en mode base de données
+a son propre pool, et ceux-ci se configurent séparément via
+`TenantPoolsConfig` — voir [Réglage des pools de tenants](manage.md) dans
+le guide `manage`. Leurs valeurs par défaut diffèrent de celles du pool
+principal ; en particulier le délai d'acquisition des tenants est plus
+généreux, ce qui mérite un examen si vous exploitez de nombreux tenants
+sur des bases pouvant devenir injoignables indépendamment.

--- a/docs/fr/index.toml
+++ b/docs/fr/index.toml
@@ -9,7 +9,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Guides"
 slug = "guides"
-pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "database-tuning.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Authentification"

--- a/docs/index.toml
+++ b/docs/index.toml
@@ -20,7 +20,7 @@ pages = ["getting-started.md", "scaffolding.md", "glossary.md"]
 [[section]]
 title = "Guides"
 slug = "guides"
-pages = ["models.md", "orm.md", "admin.md", "operator-console.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
+pages = ["models.md", "orm.md", "admin.md", "operator-console.md", "serializers.md", "viewsets.md", "html-views.md", "openapi.md", "query-method.md", "mcp.md", "urls.md", "manage.md", "migrations.md", "database-tuning.md", "middleware.md", "jobs.md", "websockets.md", "caching.md", "files.md", "i18n.md", "email.md", "testing.md", "security.md"]
 
 [[section]]
 title = "Authentication"


### PR DESCRIPTION
**Stage 2 of 7** for #1373, stacked on #1374. Stage 1 made every pool build in one place; this is what that place is for.

## The bug

`[database].pool_max_size` and `pool_min_size` were parsed, type-checked and unit-tested — and reached **no pool at all**. Setting them did nothing.

That is worse than not offering them. A pool sized for production silently ran on sqlx's default of 10, with no error and nothing in the logs to explain it. The symptom is latency that grows with traffic while the database itself sits idle, which reads as a capacity problem rather than a configuration one.

## What lands

`PoolTuning` carries the five knobs, `configure_pools` installs it from `Cli::with_settings`, and a `tuned!` macro applies it in the typed constructors — which stage 1 made the only place a pool is built, so one edit reaches every pool in the process including the main `runserver` pool.

Three knobs are new, with matching env overrides:

| setting | env |
|---|---|
| `pool_acquire_timeout_secs` | `RUSTANGO_DB_ACQUIRE_TIMEOUT_SECS` |
| `pool_idle_timeout_secs` | `RUSTANGO_DB_IDLE_TIMEOUT_SECS` |
| `pool_max_lifetime_secs` | `RUSTANGO_DB_MAX_LIFETIME_SECS` |
| (existing) `pool_max_size` | `RUSTANGO_DB_MAX_CONNECTIONS` |
| (existing) `pool_min_size` | `RUSTANGO_DB_MIN_CONNECTIONS` |

**Env wins over TOML** — the precedence `bind` already uses, so a deploy-time override never needs a config push.

**`None` means "leave sqlx's default alone", not "zero".** A knob nobody set behaves exactly as it did before the knob existed.

A value that is not a positive whole number is ignored with a warning rather than obeyed: a typo should neither silently take a bound to zero nor fail a boot.

## The `OnceLock` read no longer seals the cell

The first cut used `get_or_init`, which meant **reading** the tuning froze it. Any pool opened before `with_settings` — an app connecting in `main()`, a second test in the same binary — permanently locked the process to env-only tuning, silently, for every pool after it.

A read now falls back without writing, counts that it happened, and `configure_pools` warns when settings arrive after pools already exist:

```
N database pool(s) were opened before settings were applied and are running on
environment defaults — move `.with_settings(…)` ahead of any pool construction
```

## The assertion nobody wrote the first time

Every previous test asserted the **parsed value**. Parsing was never the problem.

`a_configured_size_reaches_the_pool_itself` asserts on `pool.options().get_max_connections()` — the effect, not the input. That test would have failed for as long as these fields have existed.

## Deliberately untouched

`connect_with_timeout` / `connect_diagnosed` stay un-sized. Their only caller is the tenant preflight probe, which opens a pool, asks whether the database answers, and closes it — giving it `min_connections` would have it eagerly open connections it is about to discard.

## Documentation

`docs/database-tuning.md`, **in all four locales**, registered in every `index.toml` so `docs_links` and `docs_versions` hold the translations to the same standard as the English page.

Organised around failures rather than fields, because "what does `pool_idle_timeout_secs` do" is not the question anyone has. It also covers the two things that bite people hardest: the binding constraint is the **server's** connection limit (ten pods at 50 is 500 against a Postgres allowing 100), and **SQLite is not a server** — it serialises writers globally, so a bigger pool buys read concurrency and never write concurrency.

## A note on two tests I got wrong

Both new tests initially asserted on process-global state, so they passed under `sqlite,tenancy` and failed under `tenancy` purely by test order — `manage.rs`'s `with_settings` tests seal the tuning cell. Fixed by asserting the *property* ("a read does not change whether the cell is set"; "the pool matches the tuning in force") rather than absolute values. Caught by the pre-push hook, not by CI.

## Verification

- **3711** lib tests under `--all-features`, **3599** under `tenancy`, **2445** under `sqlite,tenancy`.
- `docs_links` and `docs_versions` green across all four locales.
- `--all-features` / `sqlite,tenancy` / `mysql` build clean.